### PR TITLE
Bandwidth limit

### DIFF
--- a/workload/rwn-workload.py
+++ b/workload/rwn-workload.py
@@ -345,7 +345,7 @@ def main():
   parser.add_argument(
       "-P", "--packet-loss", type=int, default=0, help="Percentage of packet loss to add to all VLANed interfaces")
   parser.add_argument(
-      "-B", "--max-bandwidth", type=int, default=0, help="Bandwidth limit to apply to all VLANed interfaces (kilobits). 0 for no limit.")
+      "-B", "--bandwidth-limit", type=int, default=0, help="Bandwidth limit to apply to all VLANed interfaces (kilobits). 0 for no limit.")
   parser.add_argument("-F", "--link-flap-down", type=int, default=0, help="Time period to flap link down (Seconds)")
   parser.add_argument("-U", "--link-flap-up", type=int, default=0, help="Time period to flap link up (Seconds)")
   parser.add_argument("-T", "--link-flap-firewall", action="store_true", default=False,

--- a/workload/rwn-workload.py
+++ b/workload/rwn-workload.py
@@ -224,37 +224,30 @@ def command(cmd, dry_run, cmd_directory="", mask_output=False, mask_arg=0, no_lo
     os.chdir(working_directory)
   return return_code, output
 
+def parse_tc_netem_args(cliargs):
+  args = {}
 
-def apply_tc_netem(interface, start_vlan, end_vlan, latency, packet_loss, bandwidth_limit, dry_run=False):
-  tc_latency = []
-  tc_loss = []
-  tc_bandwidth = []
-  impairments = []
-  if latency > 0:
-    impairments.append("latency")
-  if packet_loss > 0:
-    impairments.append("packet loss")
-  if bandwidth_limit > 0:
-    impairments.append("bandwidth limit")
+  if cliargs.latency > 0:
+    args["latency"] = ["delay", "{}ms".format(cliargs.latency)]
+  if cliargs.packet_loss > 0:
+    args["packet loss"] = ["loss", "{}%".format(cliargs.packet_loss)]
+  if cliargs.bandwidth_limit > 0:
+    args["bandwidth limit"] = ["rate", "{}kbit".format(cliargs.bandwidth_limit)]
 
+  return args
+
+def apply_tc_netem(interface, start_vlan, end_vlan, impairments, dry_run=False):
   if len(impairments) > 1:
-    logger.info("Applying {} impairments".format(", ".join(impairments)))
+    logger.info("Applying {} impairments".format(", ".join(impairments.keys())))
   elif len(impairments) == 1:
-    logger.info("Applying only {} impairment".format(impairments[0]))
+    logger.info("Applying only {} impairment".format(list(impairments.keys())[0]))
   else:
     logger.warn("Invalid state. Applying no impairments.")
 
-  if latency > 0:
-    tc_latency = ["delay", "{}ms".format(latency)]
-  if packet_loss > 0:
-    tc_loss = ["loss", "{}%".format(packet_loss)]
-  if bandwidth_limit > 0:
-    tc_bandwidth = ["rate", "{}kbit".format(bandwidth_limit)]
   for vlan in range(start_vlan, end_vlan + 1):
     tc_command = ["tc", "qdisc", "add", "dev", "{}.{}".format(interface, vlan), "root", "netem"]
-    tc_command.extend(tc_loss)
-    tc_command.extend(tc_latency)
-    tc_command.extend(tc_bandwidth)
+    for impairment in impairments.values():
+      tc_command.extend(impairment)
     rc, _ = command(tc_command, dry_run)
     if rc != 0:
       logger.error("RWN workload applying latency and packet loss failed, tc rc: {}".format(rc))
@@ -371,6 +364,8 @@ def main():
   if cliargs.debug:
     logger.setLevel(logging.DEBUG)
 
+  netem_impairments = parse_tc_netem_args(cliargs)
+
   phase_break()
   logger.info("RWN Workload")
   phase_break()
@@ -404,9 +399,9 @@ def main():
         logger.info("Link flapping enabled via iptables")
         flap_links = True
       else:
-        if cliargs.latency > 0 or cliargs.packet_loss > 0 or cliargs.bandwidth_limit > 0:
+        if len(netem_impairments) > 0:
           logger.warning(
-              "Latency/Bandwidth Limit/Packet Loss impairments are mutually exclusive to link flapping impairment via ip link. "
+              "Netem (Latency/Bandwidth Limit/Packet Loss) impairments are mutually exclusive to link flapping impairment via ip link. "
               "Use -T flag to combine impairments by using iptables instead of ip link. Disabling link flapping.")
         else:
           logger.info("Link flapping enabled via ip link")
@@ -479,7 +474,7 @@ def main():
       logger.info("  * RWN tolerations")
   if not cliargs.no_impairment_phase:
     logger.info("* Impairment Phase - {}s Duration".format(cliargs.duration))
-    if cliargs.latency > 0 or cliargs.packet_loss > 0 or cliargs.bandwidth_limit > 0:
+    if len(netem_impairments) > 0:
       logger.info("  * Link Latency: {}ms".format(cliargs.latency))
       logger.info("  * Packet Loss: {}%".format(cliargs.packet_loss))
       logger.info("  * Bandwidth Limit: {}kbits".format(cliargs.bandwidth_limit))
@@ -493,7 +488,7 @@ def main():
           cliargs.interface,
           cliargs.end_vlan))
       logger.info("  * Flap {}s down, {}s up by {}".format(cliargs.link_flap_down, cliargs.link_flap_up, flapping))
-    if cliargs.latency == 0 and cliargs.packet_loss == 0 and cliargs.bandwidth_limit == 0 and not flap_links:
+    if len(netem_impairments) == 0 and not flap_links:
       logger.info("  * No impairments")
   if not cliargs.no_cleanup_phase:
     if index_measurement_data:
@@ -558,14 +553,12 @@ def main():
         round(impairment_expected_end_time, 1),
         cliargs.duration))
 
-    if cliargs.latency > 0 or cliargs.packet_loss > 0 or cliargs.bandwidth_limit > 0:
+    if len(netem_impairments):
       apply_tc_netem(
           cliargs.interface,
           cliargs.start_vlan,
           cliargs.end_vlan,
-          cliargs.latency,
-          cliargs.packet_loss,
-          cliargs.bandwidth_limit,
+          netem_impairments,
           cliargs.dry_run)
 
     if flap_links:
@@ -603,7 +596,7 @@ def main():
       flap_links_up(cliargs.interface, cliargs.start_vlan, cliargs.end_vlan, cliargs.dry_run,
                     cliargs.link_flap_firewall, cliargs.link_flap_network, True)
 
-    if cliargs.latency > 0 or cliargs.packet_loss > 0 or cliargs.bandwidth_limit > 0:
+    if len(netem_impairments):
       remove_tc_netem(
           cliargs.interface,
           cliargs.start_vlan,

--- a/workload/rwn-workload.py
+++ b/workload/rwn-workload.py
@@ -225,7 +225,7 @@ def command(cmd, dry_run, cmd_directory="", mask_output=False, mask_arg=0, no_lo
   return return_code, output
 
 
-def apply_latency_packet_loss(interface, start_vlan, end_vlan, latency, packet_loss, bandwidth_limit, dry_run=False):
+def apply_tc_netem(interface, start_vlan, end_vlan, latency, packet_loss, bandwidth_limit, dry_run=False):
   tc_latency = []
   tc_loss = []
   tc_bandwidth = []
@@ -261,8 +261,8 @@ def apply_latency_packet_loss(interface, start_vlan, end_vlan, latency, packet_l
       sys.exit(1)
 
 
-def remove_latency_packet_loss(
-      interface, start_vlan, end_vlan, latency, packet_loss, bandwidth_limit, dry_run=False, ignore_errors=False):
+def remove_tc_netem(
+      interface, start_vlan, end_vlan, dry_run=False, ignore_errors=False):
   logger.info("Removing bandwidth, latency, and packet loss impairments")
   for vlan in range(start_vlan, end_vlan + 1):
     tc_command = ["tc", "qdisc", "del", "dev", "{}.{}".format(interface, vlan), "root", "netem"]
@@ -380,13 +380,10 @@ def main():
     logger.info("Resetting all network impairments")
     flap_links_up(cliargs.interface, cliargs.start_vlan, cliargs.end_vlan, cliargs.dry_run, cliargs.link_flap_firewall,
                   cliargs.link_flap_network, ignore_errors=True)
-    remove_latency_packet_loss(
+    remove_tc_netem(
         cliargs.interface,
         cliargs.start_vlan,
         cliargs.end_vlan,
-        cliargs.latency,
-        cliargs.packet_loss,
-        cliargs.bandwidth_limit,
         cliargs.dry_run,
         ignore_errors=True)
     sys.exit(0)
@@ -562,7 +559,7 @@ def main():
         cliargs.duration))
 
     if cliargs.latency > 0 or cliargs.packet_loss > 0 or cliargs.bandwidth_limit > 0:
-      apply_latency_packet_loss(
+      apply_tc_netem(
           cliargs.interface,
           cliargs.start_vlan,
           cliargs.end_vlan,
@@ -607,13 +604,10 @@ def main():
                     cliargs.link_flap_firewall, cliargs.link_flap_network, True)
 
     if cliargs.latency > 0 or cliargs.packet_loss > 0 or cliargs.bandwidth_limit > 0:
-      remove_latency_packet_loss(
+      remove_tc_netem(
           cliargs.interface,
           cliargs.start_vlan,
           cliargs.end_vlan,
-          cliargs.latency,
-          cliargs.packet_loss,
-          cliargs.bandwidth_limit,
           cliargs.dry_run)
     impairment_end_time = time.time()
     logger.info("Impairment phase complete")


### PR DESCRIPTION
This commit adds a bandwidth limit impairment. The limit is specified as an integer in kilobits.

I changed the way the "Applying impairments" message works to make it more friendly to adding more impairments.

I don't have the cluster needed to test this, so only parts are tested. I tested the new message, and running the script to make sure the parts before kube-burner are working. I also tested the command applied manually on my computer instead of through this script.
```
>>> apply_latency_packet_loss(None, None, None, 0, 0, 0)
Invalid state. Applying no impairments.
>>> apply_latency_packet_loss(None, None, None, 0, 0, 1)
Applying only bandwidth limit impairment
>>> apply_latency_packet_loss(None, None, None, 0, 1, 0)
Applying only packet loss impairment
>>> apply_latency_packet_loss(None, None, None, 1, 0, 0)
Applying only latency impairment
>>> apply_latency_packet_loss(None, None, None, 1, 1, 0)
Applying latency, packet loss impairments
>>> apply_latency_packet_loss(None, None, None, 1, 1, 1)
Applying latency, packet loss, bandwidth limit impairments
>>> apply_latency_packet_loss(None, None, None, 0, 1, 1)
Applying packet loss, bandwidth limit impairments
>>> apply_latency_packet_loss(None, None, None, 1, 0, 1)
Applying latency, bandwidth limit impairments
```
