### PR TITLE
dns resoln for sno ingress routes

### DIFF
--- a/ansible/roles/bastion-network/templates/jetlag.conf.j2
+++ b/ansible/roles/bastion-network/templates/jetlag.conf.j2
@@ -11,3 +11,7 @@ address=/{{ bastion_dnsmasq_cd_prefix }}{{ '%05d' % (cd_index + 1) }}/{{ bastion
 address=/apps.{{ bastion_dnsmasq_cd_prefix }}{{ '%05d' % (cd_index + 1) }}.{{ base_dns_name }}/{{ bastion_dnsmasq_cd_network | next_nth_usable(cd_index + bastion_dnsmasq_cd_network_offset) }}
 address=/api.{{ bastion_dnsmasq_cd_prefix }}{{ '%05d' % (cd_index + 1) }}.{{ base_dns_name }}/{{ bastion_dnsmasq_cd_network | next_nth_usable(cd_index + bastion_dnsmasq_cd_network_offset) }}
 {% endfor %}
+
+{% for item in groups['sno'] %}
+address=/apps.{{ hostvars[item].inventory_hostname }}.{{ base_dns_name }}/{{ hostvars[item].ip_address }}
+{% endfor %}

--- a/ansible/roles/bastion-network/templates/resolv.conf.j2
+++ b/ansible/roles/bastion-network/templates/resolv.conf.j2
@@ -1,5 +1,8 @@
 # Deployed by Jetlag automation
 search {{ base_dns_name }}
+{% if public_vlan %}
+nameserver {{ ansible_default_ipv4.address }}
+{% endif %}
 nameserver {{ bastion_controlplane_ip }}
 {% for dns in labs[lab]['dns'] %}
 nameserver {{ dns }}


### PR DESCRIPTION
Included dnsmasq configuration to resolve ingress routes for SNO, 
Tested on public routable VLAN env.

