### PR TITLE
Allow syncing of separate ocp releases to the bastion machine for

### DIFF
--- a/ansible/disconnected-sync-ocp-release.yml
+++ b/ansible/disconnected-sync-ocp-release.yml
@@ -1,0 +1,20 @@
+---
+# Sync an OCP release to the disconnected registry. This simplifies adding a new
+# release that could be different from the original release that was synced to
+# the disconnected registry during the initial bastion setup.
+#
+# Example Usage:
+#
+# ansible-playbook -i ansible/inventory/cloud03.local ansible/disconnected-sync-ocp-release.yml
+#
+
+- name: Sync OCP release container images into disconnected registry
+  hosts: bastion
+  gather_facts: false
+  vars_files:
+  - vars/disconnected-sync-ocp-release.yml
+  roles:
+  - role: bastion-ocp-version
+    vars:
+      setup_bastion: false
+  - disconnected-sync-ocp-release

--- a/ansible/roles/bastion-disconnected-registry/tasks/main.yml
+++ b/ansible/roles/bastion-disconnected-registry/tasks/main.yml
@@ -69,15 +69,6 @@
     AUTHSTRING="{\"{{ disconnected_registry_host }}:{{ disconnected_registry_port }}\": {\"auth\": \"$b64auth\",\"email\": \"openshift@redhat.com\" }}"
     jq -c ".auths += $AUTHSTRING" < {{ registry_path }}/pull-secret.txt > {{ registry_path }}/pull-secret-disconnected.txt
 
-- name: Mirror the repository
-  shell: |
-    oc adm release mirror \
-      -a {{ registry_path }}/pull-secret-disconnected.txt \
-      --from={{ ocp_release_image }} \
-      --to-release-image={{ disconnected_registry_host }}:{{ disconnected_registry_port }}/{{ registry_repo }}:{{ ocp_release_image.split(":")[1] }} \
-      --to={{ disconnected_registry_host }}:{{ disconnected_registry_port }}/{{ registry_repo }}
-  register: mirror_output
-
 - name: Mirror ocpmetal images
   shell: |
     oc image mirror -a {{ registry_path }}/pull-secret-disconnected.txt {{ item }} {{ disconnected_registry_host }}:{{ disconnected_registry_port }}/ocpmetal/{{ item.split("/")[-1] }}

--- a/ansible/roles/bastion-ocp-version/tasks/main.yml
+++ b/ansible/roles/bastion-ocp-version/tasks/main.yml
@@ -28,6 +28,7 @@
     dest: /usr/local/bin/oc
   - src: "{{ ocp_version_path }}/kubectl"
     dest: /usr/local/bin/kubectl
+  when: setup_bastion | default(true)
 
 - name: Get display/release name/version
   shell: |
@@ -69,9 +70,11 @@
     content: |
       {"{{ openshift_version }}":{"display_name": "{{ ocp_version_display_name.stdout }}", "release_version": "{{ ocp_version_display_name.stdout }}", "release_image": "{{ ocp_release_image }}", "rhcos_image": "http://{{ http_store_host }}:{{ http_store_port }}/{{ ocp_version_display_name.stdout }}/{{ ocp_version_disk_location.stdout | basename }}", "rhcos_rootfs": "http://{{ http_store_host }}:{{ http_store_port }}/{{ ocp_version_display_name.stdout }}/{{ ocp_version_rootfs_location.stdout | basename }}", "rhcos_version": "{{ ocp_version_rhcos_version.stdout }}", "support_level": "beta"} }
     dest: "{{ ocp_version_path }}/assisted_service_openshift_version.json"
+  when: setup_bastion | default(true)
 
 - name: Dump version json (disconnected)
   copy:
     content: |
       {"{{ openshift_version }}":{"display_name": "{{ ocp_version_display_name.stdout }}", "release_version": "{{ ocp_version_display_name.stdout }}", "release_image": "{{ disconnected_registry_host }}:{{ disconnected_registry_port }}/{{ registry_repo }}:{{ ocp_release_image.split(":")[1] }}", "rhcos_image": "http://{{ http_store_host }}:{{ http_store_port }}/{{ ocp_version_display_name.stdout }}/{{ ocp_version_disk_location.stdout | basename }}", "rhcos_rootfs": "http://{{ http_store_host }}:{{ http_store_port }}/{{ ocp_version_display_name.stdout }}/{{ ocp_version_rootfs_location.stdout | basename }}", "rhcos_version": "{{ ocp_version_rhcos_version.stdout }}", "support_level": "beta"} }
     dest: "{{ ocp_version_path }}/assisted_service_openshift_version-disconnected.json"
+  when: setup_bastion | default(true)

--- a/ansible/roles/disconnected-sync-ocp-release/defaults/main/bastion-disconnected-registry.yml
+++ b/ansible/roles/disconnected-sync-ocp-release/defaults/main/bastion-disconnected-registry.yml
@@ -1,0 +1,1 @@
+../../../bastion-disconnected-registry/defaults/main/main.yml

--- a/ansible/roles/disconnected-sync-ocp-release/defaults/main/main.yml
+++ b/ansible/roles/disconnected-sync-ocp-release/defaults/main/main.yml
@@ -1,0 +1,6 @@
+---
+# disconnected-sync-ocp-release default vars
+
+# This will be your bastion machine (if you run setup-bastion playbook)
+disconnected_registry_host: "{{ groups['bastion'][0] }}"
+disconnected_registry_port: 5000

--- a/ansible/roles/disconnected-sync-ocp-release/tasks/main.yml
+++ b/ansible/roles/disconnected-sync-ocp-release/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# disconnected-sync-ocp-release tasks
+
+- name: Mirror the repository
+  shell: |
+    oc adm release mirror \
+      -a {{ registry_path }}/pull-secret-disconnected.txt \
+      --from={{ ocp_release_image }} \
+      --to-release-image={{ disconnected_registry_host }}:{{ disconnected_registry_port }}/{{ registry_repo }}:{{ ocp_release_image.split(":")[1] }} \
+      --to={{ disconnected_registry_host }}:{{ disconnected_registry_port }}/{{ registry_repo }}

--- a/ansible/setup-bastion.yml
+++ b/ansible/setup-bastion.yml
@@ -19,4 +19,6 @@
   - bastion-ocp-version
   - role: bastion-disconnected-registry
     when: use_disconnected_registry
+  - role: disconnected-sync-ocp-release
+    when: use_disconnected_registry
   - bastion-assisted-installer

--- a/ansible/vars/.gitignore
+++ b/ansible/vars/.gitignore
@@ -1,3 +1,4 @@
 all.yml
 disconnected-sync-acm-d.yml
+disconnected-sync-ocp-release.yml
 network-impairments.yml

--- a/ansible/vars/disconnected-sync-ocp-release.sample.yml
+++ b/ansible/vars/disconnected-sync-ocp-release.sample.yml
@@ -1,0 +1,4 @@
+---
+# Sample disconnected-sync-ocp-release vars file
+
+ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.8.0-rc.3-x86_64


### PR DESCRIPTION
quick SNO testing of different versions