### PR TITLE
Fix deploy issues

### DIFF
--- a/ansible/roles/bastion-ocp-version/tasks/main.yml
+++ b/ansible/roles/bastion-ocp-version/tasks/main.yml
@@ -4,6 +4,14 @@
 # Sets  all of the version string data up and downloads images as needed
 #
 
+- name: Create directory for pull secret
+  file: path=/root/.docker state=directory
+
+- name: Copy pull secret to bastion
+  ansible.builtin.copy:
+    content: "{{ pull_secret }}"
+    dest: "/root/.docker/config.json"
+
 - name: Create directory for bastion ocp-version data
   file:
     path: "{{ ocp_version_path }}"

--- a/ansible/roles/bastion-ocp-version/tasks/main.yml
+++ b/ansible/roles/bastion-ocp-version/tasks/main.yml
@@ -5,7 +5,9 @@
 #
 
 - name: Create directory for pull secret
-  file: path=/root/.docker state=directory
+  file:
+    path: /root/.docker
+    state: directory
 
 - name: Copy pull secret to bastion
   ansible.builtin.copy:

--- a/ansible/roles/boot-iso/tasks/supermicro.yml
+++ b/ansible/roles/boot-iso/tasks/supermicro.yml
@@ -55,6 +55,9 @@
     return_content: yes
 
 - name: SuperMicro - Set Boot
+  # Error ignored as a workaround for old firmware.
+  # If this errors, you will need to manually configure the boot order to put CD boot entries on top,
+  # then unmount the ISO when it is done with it, which will be the first restart after a long delay.
   ignore_errors: yes
   uri:
     url: "https://{{ hostvars[item]['bmc_address'] }}/redfish/v1/Systems/1"

--- a/ansible/roles/boot-iso/tasks/supermicro.yml
+++ b/ansible/roles/boot-iso/tasks/supermicro.yml
@@ -55,6 +55,7 @@
     return_content: yes
 
 - name: SuperMicro - Set Boot
+  ignore_errors: yes
   uri:
     url: "https://{{ hostvars[item]['bmc_address'] }}/redfish/v1/Systems/1"
     user: "{{ hostvars[item]['bmc_user'] }}"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -71,3 +71,28 @@ Run dnf update to upgrade to RHEL 8.4
 ```
 
 Reboot afterwards and start from the `create-inventory.yml` playbook.
+
+## Resolving redfish connection error
+
+```
+Failed GET request to 'https://address.example.com/redfish/v1/Systems/1': 'The read operation timed out'"
+```
+
+In that case, if it normally works, it can be helpful to reset the baseboard management controller with:
+```
+ipmitool -I lanplus -H mgmt-computer.example.com -U user -P password mc reset cold
+```
+
+If that fails, verify that the server supports the redfish API.
+
+## Failure of TASK [boot-iso : SuperMicro - Set Boot] when using Supermicro servers.
+
+```
+The property Boot is not in the list of valid properties for the resource.
+```
+
+This is caused by having an older BIOS version. The older BIOS version simply does not support the command.
+
+When set to ignore the error, JetLag can proceed, but you will need to manually unmount the ISO when the machines reboot the second time (as in not the reboot that happens immediately when Jetlag is run, but the one that happens after a noticeable delay). The unmount must be done as soon as the machines restart, as doing it too early can interrupt the process, and doing it after it boots into the ISO will be too late.
+
+


### PR DESCRIPTION
Changes:
1. Copies the pull secret to the bastion. This is necessary as the current design expects the pull secret to be there, but it isn't automated.
2. Added ignore_errors to the "SuperMicro - Set Boot" command. This is needed to run JetLag on clusters that have machines whose BMC firmware version is too old.
3. Added troubleshooting documentation for the error expected in change 2, and the error that requires resetting the machine.