### PR TITLE
Fix typo in symlink introduced by b1c66d481b20dae9b08966d743864a9e923…

### DIFF
--- a/ansible/roles/sno-generate-discovery-iso/defaults/main/bastion-http.yml
+++ b/ansible/roles/sno-generate-discovery-iso/defaults/main/bastion-http.yml
@@ -1,1 +1,1 @@
-../../../bastion-http/tasks/main.yml
+../../../bastion-http/defaults/main.yml


### PR DESCRIPTION
…ec2e3

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>