### PR TITLE
Introduce `sno_node_count` variable

### DIFF
--- a/ansible/bm-deploy.yml
+++ b/ansible/bm-deploy.yml
@@ -21,6 +21,7 @@
   - role: boot-iso
     vars:
       inventory_group: worker
+      index: "{{ worker_node_count }}"
   - wait-hosts-discovered
   - install-cluster
   - bm-post-cluster-install

--- a/ansible/inventory/inventory-bm.sample
+++ b/ansible/inventory/inventory-bm.sample
@@ -1,4 +1,7 @@
 # Create inventory playbook will generate this for you much easier
+[all:vars]
+allocation_node_count={{ ocpinventory.json.nodes | length }}
+
 [bastion]
 example.com ansible_ssh_user=root
 

--- a/ansible/inventory/inventory-rwn.sample
+++ b/ansible/inventory/inventory-rwn.sample
@@ -1,4 +1,7 @@
 # Create inventory playbook will generate this for you much easier
+[all:vars]
+allocation_node_count={{ ocpinventory.json.nodes | length }}
+
 [bastion]
 example.com ansible_ssh_user=root
 

--- a/ansible/inventory/inventory-sno.sample
+++ b/ansible/inventory/inventory-sno.sample
@@ -1,4 +1,7 @@
 # Create inventory playbook will generate this for you much easier
+[all:vars]
+allocation_node_count={{ ocpinventory.json.nodes | length }}
+
 [bastion]
 example.com ansible_ssh_user=root
 

--- a/ansible/roles/bastion-network/templates/jetlag.conf.j2
+++ b/ansible/roles/bastion-network/templates/jetlag.conf.j2
@@ -12,6 +12,6 @@ address=/apps.{{ bastion_dnsmasq_cd_prefix }}{{ '%05d' % (cd_index + 1) }}.{{ ba
 address=/api.{{ bastion_dnsmasq_cd_prefix }}{{ '%05d' % (cd_index + 1) }}.{{ base_dns_name }}/{{ bastion_dnsmasq_cd_network | next_nth_usable(cd_index + bastion_dnsmasq_cd_network_offset) }}
 {% endfor %}
 
-{% for item in groups['sno'] %}
+{% for item in groups['sno'][:sno_node_count|int] %}
 address=/apps.{{ hostvars[item].inventory_hostname }}.{{ base_dns_name }}/{{ hostvars[item].ip_address }}
 {% endfor %}

--- a/ansible/roles/boot-iso/tasks/main.yml
+++ b/ansible/roles/boot-iso/tasks/main.yml
@@ -4,11 +4,11 @@
 - name: Boot iso on dell hardware
   include_tasks: dell.yml
   with_items:
-    - "{{ groups[inventory_group] }}"
+    - "{{ groups[inventory_group][:index|int] }}"
   when: hostvars[item]['vendor'] == 'Dell'
 
 - name: Boot iso on supermicro hardware
   include_tasks: supermicro.yml
   with_items:
-    - "{{ groups[inventory_group] }}"
+    - "{{ groups[inventory_group][:index|int] }}"
   when: hostvars[item]['vendor'] == 'Supermicro'

--- a/ansible/roles/create-inventory/tasks/main.yml
+++ b/ansible/roles/create-inventory/tasks/main.yml
@@ -129,9 +129,20 @@
 - name: Single Node OpenShift cluster type tasks
   when: cluster_type == "sno"
   block:
+
+  - name: SNO - Set max number of nodes
+    set_fact:
+      max_nodes: "{{ ocpinventory.json.nodes|length }}"
+    when: sno_node_count == None
+
+  - name: SNO - Set max number of SNO nodes (sno_node_count is set)
+    set_fact:
+      max_nodes: "{{ sno_node_count|int + 1 }}"
+    when: sno_node_count != None
+
   - name: SNO - Set ocpinventory sno nodes
     set_fact:
-      ocpinventory_sno_nodes: "{{ ocpinventory.json.nodes[1:] }}"
+      ocpinventory_sno_nodes: "{{ ocpinventory.json.nodes[1:max_nodes|int] }}"
 
   - name: SNO - Get lab data for each sno
     uri:

--- a/ansible/roles/create-inventory/templates/inventory-bm.j2
+++ b/ansible/roles/create-inventory/templates/inventory-bm.j2
@@ -1,3 +1,6 @@
+[all:vars]
+allocation_node_count={{ ocpinventory.json.nodes | length }}
+
 [bastion]
 {{ bastion_machine }} ansible_ssh_user=root
 

--- a/ansible/roles/create-inventory/templates/inventory-rwn.j2
+++ b/ansible/roles/create-inventory/templates/inventory-rwn.j2
@@ -1,3 +1,6 @@
+[all:vars]
+allocation_node_count={{ ocpinventory.json.nodes | length }}
+
 [bastion]
 {{ bastion_machine }} ansible_ssh_user=root
 

--- a/ansible/roles/create-inventory/templates/inventory-sno.j2
+++ b/ansible/roles/create-inventory/templates/inventory-sno.j2
@@ -1,3 +1,6 @@
+[all:vars]
+allocation_node_count={{ ocpinventory.json.nodes | length }}
+
 [bastion]
 {{ bastion_machine }} ansible_ssh_user=root
 

--- a/ansible/roles/sno-create-ai-cluster/tasks/main.yml
+++ b/ansible/roles/sno-create-ai-cluster/tasks/main.yml
@@ -20,7 +20,7 @@
         "ssh_public_key": "{{ lookup('file', ssh_public_key_file) }}",
         "additional_ntp_source": "{{ labs[lab]['ntp_server'] }}"
     }
-  loop: "{{ groups['sno'] }}"
+  loop: "{{ groups['sno'][:sno_node_count|int] }}"
   register: create_cluster_return
 
 - name: Populate cluster ids
@@ -72,7 +72,7 @@
       {%- endif %}
     insertafter: "EOF"
     marker: "# {mark} {{ hostvars[item].inventory_hostname }} OCP CLUSTER MANAGED BLOCK"
-  loop: "{{ groups['sno'] }}"
+  loop: "{{ groups['sno'][:sno_node_count|int] }}"
 
 - name: Include custom manifest
   include_tasks: 01_manifest_task.yml

--- a/ansible/roles/sno-generate-discovery-iso/tasks/10_custom_iso.yml
+++ b/ansible/roles/sno-generate-discovery-iso/tasks/10_custom_iso.yml
@@ -25,4 +25,4 @@
 - name: Download discovery ISO
   get_url:
     url: "http://{{ assisted_installer_host }}:{{ assisted_installer_port }}/api/assisted-install/v1/clusters/{{ ai_cluster_ids[item].cluster_id }}/downloads/image"
-    dest: "{{ http_store_path }}/{{ item }}.iso"
+    dest: "{{ http_store_path }}/data/{{ item }}.iso"

--- a/ansible/roles/sno-generate-discovery-iso/tasks/main.yml
+++ b/ansible/roles/sno-generate-discovery-iso/tasks/main.yml
@@ -25,4 +25,4 @@
   include_tasks: 10_custom_iso.yml
   when:
     - public_vlan | bool
-  loop: "{{ groups['sno'] }}"
+  loop: "{{ groups['sno'][:sno_node_count|int] }}"

--- a/ansible/roles/validate-vars/tasks/main.yml
+++ b/ansible/roles/validate-vars/tasks/main.yml
@@ -22,3 +22,27 @@
   when:
   - ansible_distribution is defined
   - (ansible_distribution != "RedHat" or ansible_distribution_version|float < 8.4)
+
+- name: Set worker_node_count if undefined or empty (bm/rwn)
+  set_fact:
+    worker_node_count: "{{ allocation_node_count - 4 }}"
+  when: (cluster_type == "bm" or cluster_type == "rwn") and
+        (worker_node_count is undefined or not worker_node_count | int)
+
+- name: Set sno_node_count if undefined or empty
+  set_fact:
+    sno_node_count: "{{ (allocation_node_count - 1) | int   }}"
+  when: (cluster_type == "sno")  and
+        (sno_node_count is undefined or not sno_node_count | int)
+
+- name: Check if the required number of nodes exist for bm/rwn
+  fail:
+    msg: "Insufficient number of nodes in your allocation for bm/rwn"
+  when: (allocation_node_count is defined and (cluster_type == "bm" or cluster_type == "rwn")) and (worker_node_count | int  > allocation_node_count - 4)
+
+- name: Check if the required number of nodes exist for sno
+  fail:
+    msg: "Insufficient number of nodes in your allocation for bm/rwn"
+  when: (allocation_node_count is defined and cluster_type == "sno") and (sno_node_count | int   > allocation_node_count | int  - 1)
+
+

--- a/ansible/rwn-deploy.yml
+++ b/ansible/rwn-deploy.yml
@@ -26,4 +26,5 @@
   - role: boot-iso
     vars:
       inventory_group: remoteworker
+      index: "{{ worker_node_count }}"
   - wait-for-rwn-to-join

--- a/ansible/sno-deploy.yml
+++ b/ansible/sno-deploy.yml
@@ -18,6 +18,7 @@
   - role: boot-iso
     vars:
       inventory_group: sno
+      index: "{{ sno_node_count }}"
   - sno-wait-hosts-discovered
   - sno-install-cluster
   - sno-post-cluster-install

--- a/ansible/vars/all.sample.yml
+++ b/ansible/vars/all.sample.yml
@@ -14,6 +14,9 @@ cluster_type:
 # Applies to both bm/rwn clusters
 worker_node_count:
 
+# Applies to sno clusters
+sno_node_count:
+
 # Lab Network type, applies to sno cluster_type only
 # Set this variable if you want to host your SNO cluster on lab public routable
 # VLAN network, set this ONLY if you have public routable VLAN enabled in your


### PR DESCRIPTION
This helps deploy only on subset of hosts in the allocation.
Also introduces additional checks to ensure that requested
worker/sno nodes can be accomodated in the lab allocation.
If `worker_node_count` or `sno_node_count` are empty, we deploy
on all avaialable nodes after accounting for bastion and controlplane.

This also helps enforce the usage of `worker_node_count` in tasks where
it was previously not used.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>