### PR TITLE
Ensure pods are started if rerunning the setup-bastion playbook

### DIFF
--- a/ansible/roles/bastion-assisted-installer/tasks/main.yml
+++ b/ansible/roles/bastion-assisted-installer/tasks/main.yml
@@ -56,6 +56,13 @@
     network: host
     state: started
 
+# On a reboot "started" state does not start an exited pod (why..idk)
+- name: Ensure assisted-service pod is up
+  containers.podman.podman_pod:
+    name: assisted-service
+    network: host
+    state: restarted
+
 - name: Create database container in assisted-service pod
   containers.podman.podman_container:
     pod: assisted-service

--- a/ansible/roles/bastion-disconnected-registry/tasks/main.yml
+++ b/ansible/roles/bastion-disconnected-registry/tasks/main.yml
@@ -38,6 +38,13 @@
     network: host
     state: started
 
+# On a reboot "started" state does not start an exited pod (why..idk)
+- name: Ensure registry pod is up
+  containers.podman.podman_pod:
+    name: ocpdiscon-registry
+    network: host
+    state: restarted
+
 - name: Create registry container
   containers.podman.podman_container:
     pod: ocpdiscon-registry

--- a/ansible/roles/bastion-http/tasks/main.yml
+++ b/ansible/roles/bastion-http/tasks/main.yml
@@ -22,6 +22,13 @@
     network: host
     state: started
 
+# On a reboot "started" state does not start an exited pod (why..idk)
+- name: Ensure http pod is up
+  containers.podman.podman_pod:
+    name: http-store
+    network: host
+    state: restarted
+
 - name: Create http container in http pod
   containers.podman.podman_container:
     pod: http-store


### PR DESCRIPTION
One example would be if you reboot the bastion, you could simply
rerun the setup-bastion playbook and the pods will be restarted
for you.