### PR TITLE
No longer limit localstorage operator to install from 4.7 channel

### DIFF
--- a/ansible/roles/bm-post-cluster-install/templates/localstorage.yml.j2
+++ b/ansible/roles/bm-post-cluster-install/templates/localstorage.yml.j2
@@ -21,11 +21,7 @@ metadata:
   name: local-storage-operator
   namespace: openshift-local-storage
 spec:
-{% if openshift_version == "4.8" %}
-  channel: "4.7"
-{% else %}
   channel: "{{ openshift_version }}"
-{% endif %}
   installPlanApproval: Automatic
   name: local-storage-operator
 {% if use_disconnected_registry %}


### PR DESCRIPTION
It actually seems to work regardless anyhow, but lets be accurate.