### PR TITLE
added and formatted doc for ordering ibmcloud hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Versions:
 * RHEL 8.4 / Centos 8.4 (Bastion)
 * podman 3 (Bastion)
 
+For guidance on how to order hardware on IBMcloud, see [order-hardware-ibmcloud.md](docs/order-hardware-ibmcloud.md) in [docs](docs) directory.
+
 Pre-reqs for the playbooks:
 
 ```console

--- a/docs/deploy-bm-ibmcloud.md
+++ b/docs/deploy-bm-ibmcloud.md
@@ -1,6 +1,8 @@
 # Deploy a Bare Metal cluster on IBMcloud via jetlag quickstart
 
-To deploy a bare metal OpenShift cluster, order 6 machines from the [IBM bare metal server catalog](https://cloud.ibm.com/gen1/infrastructure/provision/bm). The machines used to test this are of Server profile E5-2620 in DAL10 datacenter with automatic port redundancy. One machine will become the bastion, 3 machines will become control-plane nodes, and the remaining 2 nodes will be worker nodes. Ensure that you order either CentOS or RHEL machines with a new enough version (8.4) otherwise podman will not have host networking functionality. The bastion machine should have a public accessible ip and will NAT traffic for the cluster to the public network. The other machines can have a public ip address but it is not currently in use with this deployment method.
+To deploy a bare metal OpenShift cluster, order 6 machines from the [IBM bare metal server catalog](https://cloud.ibm.com/gen1/infrastructure/provision/bm). 
+For guidance on how to order hardware on IBMcloud, see [order-hardware-ibmcloud.md](docs/order-hardware-ibmcloud.md) in [docs](docs) directory.
+The machines used to test this are of Server profile E5-2620 in DAL10 datacenter with automatic port redundancy. One machine will become the bastion, 3 machines will become control-plane nodes, and the remaining 2 nodes will be worker nodes. Ensure that you order either CentOS or RHEL machines with a new enough version (8.4) otherwise podman will not have host networking functionality. The bastion machine should have a public accessible ip and will NAT traffic for the cluster to the public network. The other machines can have a public ip address but it is not currently in use with this deployment method.
 
 Once your machines are delivered, login to the ibmcloud cli using the cut and paste link from the cloud portal. You should be able to list the machines from your local machine, for example:
 

--- a/docs/deploy-sno-ibmcloud.md
+++ b/docs/deploy-sno-ibmcloud.md
@@ -2,6 +2,8 @@
 
 To deploy Single Node OpenShift (SNO) clusters on IBMcloud hardware you can simply follow the bare metal cluster guide with a few differences. The changes in this guide will apply after [Review ibmcloud.yml](deploy-bm-ibmcloud.md#review-ibmcloudyml) section.
 
+For guidance on how to order hardware on IBMcloud, see [order-hardware-ibmcloud.md](docs/order-hardware-ibmcloud.md) in [docs](docs) directory.
+
 ## SNO var changes
 
 Change `cluster_type` to `cluster_type: sno`

--- a/docs/order-hardware-ibmcloud.md
+++ b/docs/order-hardware-ibmcloud.md
@@ -1,0 +1,80 @@
+# Order hardware on IBMcloud guide
+
+## Prerequisites
+
+Ensure you have access to IBMcloud (https://cloud.ibm.com). You will need to contact the lab manager to get an account created.
+
+Currently supported hardware vendors in Jetlag are 'Supermicro' and 'Lenovo'. Unfortunately. you will not get to know which vendor the servers are from until your devices are ready.
+
+
+## Ordering Hardware
+
+Login to your IBMcloud account
+
+Browse to Catalog and filter 'Compute'. Select Bare Metal Servers from the list of filtered products
+
+You can select the location/datacenter and the Server profile based on cost estimates
+
+For baremetal deployment, you will need:
+
+* One server to be provisioned as your bastion machine
+* Three additional servers to serve as control-plane nodes 
+* At least two more servers to serve as worker nodes in your openshift cluster
+
+The following guides can also assist you with procurement of devices:
+
+https://cloud.ibm.com/docs/bare-metal?topic=bare-metal-getting-started
+
+https://cloud.ibm.com/docs/bare-metal?topic=bare-metal-about-bm
+
+Points to keep in mind while ordering hardware:
+
+* Ensure that you order either CentOS or RHEL machines with a new enough version (8.4) otherwise podman will not have host networking functionality
+* Add your SSH keys while ordering. Generate a new key pair for ibmcloud as a best practice.
+* Select an SSD disk
+* 32 GB RAM at minimum
+* Port speed of 10 Gbps at minimum
+* The bastion machine should have a public accessible ip and will NAT traffic for the cluster to the public network. Other machines can have a public ip address but it is not currently in use with this deployment method.
+
+You might not receive an immediate notification on the order you just placed. 
+If there are significant delays, IBMcloud will open up a support ticket on your behalf to notify about the readiness status of your servers.
+
+Once you are notified of the servers being ready, login to IBMcloud and navigate to 'Classic Infrastructure' to view your devices.
+
+
+## Post Hardware acquisition
+
+**IBMcloud VPN access:**
+
+To manage your servers remotely and securely over the IBM Cloud private network, you need to connect to IBMcloud VPN. 
+
+To get started, refer to https://cloud.ibm.com/docs/iaas-vpn?topic=iaas-vpn-getting-started
+
+**IBMcloud Shell:**
+
+To get started with IBMcloud shell, refer to https://cloud.ibm.com/docs/cloud-shell?topic=cloud-shell-getting-started
+
+Once you have successfully logged into the IBMcloud Shell, you should be able to list  your devices using the following command:
+
+```console
+[user@fedora]$ ibmcloud sl hardware list
+```
+
+Sample output:
+
+```console
+$ ibmcloud sl hardware list
+id        hostname     domain                    public_ip        private_ip    datacenter   status
+960237    jetlag-bm0   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE
+1165601   jetlag-bm1   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE
+1112925   jetlag-bm2   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE
+1163781   jetlag-bm3   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE
+1165519   jetlag-bm4   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE
+1117051   jetlag-bm5   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE
+```
+
+**IBMcloud Support Cases:**
+
+To open a support case with IBMcloud, access the link below:
+https://cloud.ibm.com/unifiedsupport/supportcenter
+


### PR DESCRIPTION
1. Added a doc for IBM cloud hardware ordering procedure
2. Formatted the file to make it more comprehensible
3. Added references to this file inside of relevant docs (README.md, docs/deploy-bm-ibmcloud.md and docs/deploy-sno-ibmcloud.md)