### PR TITLE
ibmcloud BM lenovo fix boot order

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ _**Table of Contents**_
 | Hardware                 | BM  | SNO |
 | -------------------------| --- | --- |
 | Supermicro E5-2620       | Yes | Yes |
-| Lenovo ThinkSystem SR630 | No  | Yes |
+| Lenovo ThinkSystem SR630 | Yes | Yes |
 
 
 ## Prerequisites

--- a/ansible/roles/install-cluster/tasks/check-cluster-install.yml
+++ b/ansible/roles/install-cluster/tasks/check-cluster-install.yml
@@ -39,13 +39,21 @@
     register: get_hosts
     when: not cluster.json.status == 'installed'
 
-  - name: Fix hosts with incorrect boot order by unmounting virtual media
+  - name: Supermicro Fix hosts with incorrect boot order by unmounting virtual media
     include_tasks: supermicro-unmount-virtual-media.yml
     loop: "{{ get_hosts.json|selectattr('status', 'eq', 'installing-pending-user-action') }}"
     when:
     - not cluster.json.status == 'installed'
     - item.requested_hostname not in boot_order_fixed_hosts
     - hostvars[item.requested_hostname]['vendor'] == 'Supermicro'
+
+  - name: Lenovo Fix hosts with incorrect boot order by unmounting virtual media
+    include_tasks: lenovo-unmount-virtual-media.yml
+    loop: "{{ get_hosts.json|selectattr('status', 'eq', 'installing-pending-user-action') }}"
+    when:
+    - not cluster.json.status == 'installed'
+    - item.requested_hostname not in boot_order_fixed_hosts
+    - hostvars[item.requested_hostname]['vendor'] == 'Lenovo'
 
   - name: Append host with unmounted virtual media to boot order fixed hosts list
     set_fact:


### PR DESCRIPTION
1. Added Lenovo fix boot order task in check-cluster-install.yml (ansible/roles/install-cluster/tasks/check-cluster-install.yml)
2. README.md updated to include Lenovo BM devices in the list of tested hardware on IBM Cloud