### PR TITLE
add reserved_cpus for workload pinning on SNOs

### DIFF
--- a/ansible/roles/create-ai-cluster/templates/99-master-workload-partitioning.yml
+++ b/ansible/roles/create-ai-cluster/templates/99-master-workload-partitioning.yml
@@ -1,0 +1,26 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-master-workload-partitioning
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,{{ lookup('template', './crio-runtime-workload-management.conf.j2') | b64encode }}
+        mode: 420
+        overwrite: true
+        path: /etc/crio/crio.conf.d/01-workload-partitioning
+        user:
+          name: root
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,{{ lookup('template', './kubernetes-workload-pinning.j2') | b64encode }}
+        mode: 420
+        overwrite: true
+        path: /etc/kubernetes/openshift-workload-pinning
+        user:
+          name: root

--- a/ansible/roles/create-ai-cluster/templates/crio-runtime-workload-management.conf.j2
+++ b/ansible/roles/create-ai-cluster/templates/crio-runtime-workload-management.conf.j2
@@ -1,0 +1,4 @@
+[crio.runtime.workloads.management]
+activation_annotation = "target.workload.openshift.io/management"
+annotation_prefix = "resources.workload.openshift.io"
+resources = { "cpushares" = 0, "cpuset" = "{{ reserved_cpus }}" }

--- a/ansible/roles/create-ai-cluster/templates/kubernetes-workload-pinning.j2
+++ b/ansible/roles/create-ai-cluster/templates/kubernetes-workload-pinning.j2
@@ -1,0 +1,5 @@
+{
+  "management": {
+    "cpuset": "{{ reserved_cpus }}"
+  }
+}

--- a/ansible/roles/ibmcloud-sno-create-ai-cluster/defaults/main/main.yml
+++ b/ansible/roles/ibmcloud-sno-create-ai-cluster/defaults/main/main.yml
@@ -10,3 +10,7 @@ kubelet_config: false
 
 # Manifest for MachineConfig to enable kdump on master nodes
 kdump_master_config: false
+
+# Performance-addon-operator vars
+install_performance_addon_operator: false
+reserved_cpus: 0,48,24,72

--- a/ansible/roles/ibmcloud-sno-create-ai-cluster/tasks/01_manifest_task.yml
+++ b/ansible/roles/ibmcloud-sno-create-ai-cluster/tasks/01_manifest_task.yml
@@ -8,6 +8,9 @@
   - file_name: 99-master-kdump.yml
     template_name: 99-master-kdump.yml
     enabled: "{{ kdump_master_config }}"
+  - file_name: 99-master-workload-partitioning.yml
+    template_name: 99-master-workload-partitioning.yml
+    enabled: "{{ install_performance_addon_operator }}"
   vars:
     ai_cluster_id: "{{ ai_cluster_ids[outer_item].cluster_id }}"
     kubelet_config_max_pods_label: "pools.operator.machineconfiguration.openshift.io/master: ''"

--- a/ansible/roles/sno-create-ai-cluster/defaults/main/main.yml
+++ b/ansible/roles/sno-create-ai-cluster/defaults/main/main.yml
@@ -10,3 +10,7 @@ kubelet_config: false
 
 # Manifest for MachineConfig to enable kdump on master nodes
 kdump_master_config: false
+
+# Performance-addon-operator vars
+install_performance_addon_operator: false
+reserved_cpus: 0-1,32-33

--- a/ansible/roles/sno-create-ai-cluster/tasks/01_manifest_task.yml
+++ b/ansible/roles/sno-create-ai-cluster/tasks/01_manifest_task.yml
@@ -11,6 +11,9 @@
   - file_name: 99-master-kdump.yml
     template_name: 99-master-kdump.yml
     enabled: "{{ kdump_master_config }}"
+  - file_name: 99-master-workload-partitioning.yml
+    template_name: 99-master-workload-partitioning.yml
+    enabled: "{{ install_performance_addon_operator }}"
   vars:
     ai_cluster_id: "{{ ai_cluster_ids[outer_item].cluster_id }}"
     kubelet_config_max_pods_label: "pools.operator.machineconfiguration.openshift.io/master: ''"

--- a/ansible/roles/validate-vars/tasks/main.yml
+++ b/ansible/roles/validate-vars/tasks/main.yml
@@ -66,3 +66,8 @@
     fail:
       msg: "Invalid cluster_type selected - {{ cluster_type }} Select from {{ ibmcloud_cluster_types }}"
     when: cluster_type not in ibmcloud_cluster_types
+
+- name: Check reserved_cpus var is set
+  fail:
+    msg: "reserved_cpus is unset"
+  when: (cluster_type == "sno") and (install_performance_addon_operator | bool) and reserved_cpus is undefined


### PR DESCRIPTION
Added workload-pinning-manifests to be included during SNO installs.
Modified tips-and-vars.md to include explanation for reserved_cpus var settings.