### PR TITLE
Make getting started more user friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,6 @@ Versions:
 
 For guidance on how to order hardware on IBMcloud, see [order-hardware-ibmcloud.md](docs/order-hardware-ibmcloud.md) in [docs](docs) directory.
 
-Pre-reqs for the playbooks:
-
-```console
-ansible-galaxy collection install ansible.netcommon
-ansible-galaxy collection install ansible.posix
-ansible-galaxy collection install community.general
-ansible-galaxy collection install containers.podman
-```
-
-```console
-pip3 install netaddr python-hpilo
-```
 
 Pre-reqs for Supermicro hardware
 

--- a/ansible/create-inventory.yml
+++ b/ansible/create-inventory.yml
@@ -14,4 +14,5 @@
   - vars/lab.yml
   roles:
   - validate-vars
+  - install-early-deps
   - create-inventory

--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -114,31 +114,34 @@
       dest: /root/.ssh/id_rsa.pub
       mode: "644"
 
-- name: Check if SMCIPMITool tar is downloaded
-  stat:
-    path: "{{ playbook_dir }}/smcipmitool.tar.gz"
-  delegate_to: localhost
-  register: stat_smcipmitool
-
-# This is "proxied", assuming your local laptop can reach the smcipmitool URL
-# and that the bastion machine may not (Ex you copy the smcipmitool tar file
-# to a local lab machine)
-- name: Get SMCIPMITool
-  get_url:
-    validate_certs: false
-    force: true
-    url: "{{ smcipmitool_url }}"
-    dest: "{{ playbook_dir }}/smcipmitool.tar.gz"
-  delegate_to: localhost
-  when: not stat_smcipmitool.stat.exists
-
-- name: Untar SMCIPMITool
-  unarchive:
-    src: "{{ playbook_dir }}/smcipmitool.tar.gz"
-    dest: /usr/local/bin
-    mode: 0700
-    extra_opts:
-    - --strip-components=1
+- name: Supermicro tool tasks
+  block: 
+    - name: Check if SMCIPMITool tar is downloaded
+      stat:
+        path: "{{ playbook_dir }}/smcipmitool.tar.gz"
+      delegate_to: localhost
+      register: stat_smcipmitool
+    
+    # This is "proxied", assuming your local laptop can reach the smcipmitool URL
+    # and that the bastion machine may not (Ex you copy the smcipmitool tar file
+    # to a local lab machine)
+    - name: Get SMCIPMITool
+      get_url:
+        validate_certs: false
+        force: true
+        url: "{{ smcipmitool_url }}"
+        dest: "{{ playbook_dir }}/smcipmitool.tar.gz"
+      delegate_to: localhost
+      when: not stat_smcipmitool.stat.exists
+    
+    - name: Untar SMCIPMITool
+      unarchive:
+        src: "{{ playbook_dir }}/smcipmitool.tar.gz"
+        dest: /usr/local/bin
+        mode: 0700
+        extra_opts:
+        - --strip-components=1
+  when: supermicro_nodes
 
 - name: Get OpenShift clients, opm, kube-burner, grpcurl, and yq
   get_url:

--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -32,13 +32,6 @@
     name: python-hpilo
     executable: pip3
 
-- name: Install ansible-galaxy collections
-  shell: |
-    ansible-galaxy collection install ansible.netcommon
-    ansible-galaxy collection install ansible.posix
-    ansible-galaxy collection install community.general
-    ansible-galaxy collection install containers.podman
-
 - name: Scale / Alias lab bastion tasks
   when: lab in rh_labs
   block:

--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -27,7 +27,7 @@
     update_cache: true
     disable_gpg_check: yes
 
-- name: Install python 
+- name: Install python
   pip:
     name: python-hpilo
     executable: pip3
@@ -115,13 +115,13 @@
       mode: "644"
 
 - name: Supermicro tool tasks
-  block: 
+  block:
     - name: Check if SMCIPMITool tar is downloaded
       stat:
         path: "{{ playbook_dir }}/smcipmitool.tar.gz"
       delegate_to: localhost
       register: stat_smcipmitool
-    
+
     # This is "proxied", assuming your local laptop can reach the smcipmitool URL
     # and that the bastion machine may not (Ex you copy the smcipmitool tar file
     # to a local lab machine)
@@ -133,7 +133,7 @@
         dest: "{{ playbook_dir }}/smcipmitool.tar.gz"
       delegate_to: localhost
       when: not stat_smcipmitool.stat.exists
-    
+
     - name: Untar SMCIPMITool
       unarchive:
         src: "{{ playbook_dir }}/smcipmitool.tar.gz"

--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -19,13 +19,25 @@
     - jq
     - net-tools
     - podman
-    - python3
     - skopeo
     - tcpdump
     - tmux
+    - vim
     state: present
     update_cache: true
     disable_gpg_check: yes
+
+- name: Install python 
+  pip:
+    name: python-hpilo
+    executable: pip3
+
+- name: Install ansible-galaxy collections
+  shell: |
+    ansible-galaxy collection install ansible.netcommon
+    ansible-galaxy collection install ansible.posix
+    ansible-galaxy collection install community.general
+    ansible-galaxy collection install containers.podman
 
 - name: Scale / Alias lab bastion tasks
   when: lab in rh_labs

--- a/ansible/roles/create-inventory/tasks/find_supermicro.yml
+++ b/ansible/roles/create-inventory/tasks/find_supermicro.yml
@@ -1,10 +1,5 @@
 ---
-- name: Print vendor for each node
-  debug:
-    msg: "{{ hw_vendor[(item.pm_addr.split('.')[0]).split('-')[-1]] }}"
-  register: vendor
-
 - name: Found Supermicro node
   set_fact:
     has_supermicro: true
-  when: vendor == "Supermicro"
+  when: hw_vendor[(item.pm_addr.split('.')[0]).split('-')[-1]] == 'Supermicro'

--- a/ansible/roles/create-inventory/tasks/find_supermicro.yml
+++ b/ansible/roles/create-inventory/tasks/find_supermicro.yml
@@ -1,0 +1,10 @@
+---
+- name: Print vendor for each node
+  debug:
+    msg: "{{ hw_vendor[(item.pm_addr.split('.')[0]).split('-')[-1]] }}"
+  register: vendor
+
+- name: Found Supermicro node
+  set_fact:
+    has_supermicro: true
+  when: vendor == "Supermicro"

--- a/ansible/roles/create-inventory/tasks/main.yml
+++ b/ansible/roles/create-inventory/tasks/main.yml
@@ -172,6 +172,11 @@
   include_tasks: find_supermicro.yml
   loop: "{{ ocpinventory.json.nodes }}"
 
+- name: If no Supermicros found set fact
+  set_fact:
+    has_supermicro: false
+  when: has_supermicro is not defined
+
 - name: Place inventory file named {{ lab_cloud }}.local into inventory directory
   template:
     src: "inventory-{{ cluster_type }}.j2"

--- a/ansible/roles/create-inventory/tasks/main.yml
+++ b/ansible/roles/create-inventory/tasks/main.yml
@@ -173,3 +173,7 @@
     src: "inventory-{{ cluster_type }}.j2"
     dest: "{{ playbook_dir }}/inventory/{{ lab_cloud }}.local"
     backup: true
+
+- name: Loop over all OCP nodes to find Supermicro hardware
+  include_tasks: find_supermicro.yml
+  loop: "{{ ocpinventory.json.nodes }}"

--- a/ansible/roles/create-inventory/tasks/main.yml
+++ b/ansible/roles/create-inventory/tasks/main.yml
@@ -16,6 +16,14 @@
 # * Remaining machines are SNO clusters (depending upon sno_node_count)
 #
 
+- name: Install python netaddr prereq
+  yum:
+    name:
+    - python3-netaddr
+    state: present
+    update_cache: true
+    disable_gpg_check: yes
+
 - name: Set ocp inventory download url from lab wiki
   set_fact:
     ocp_inventory_url: "http://{{ labs[lab]['quads'] }}/cloud/{{ lab_cloud }}_ocpinventory.json"

--- a/ansible/roles/create-inventory/tasks/main.yml
+++ b/ansible/roles/create-inventory/tasks/main.yml
@@ -16,14 +16,6 @@
 # * Remaining machines are SNO clusters (depending upon sno_node_count)
 #
 
-- name: Install python netaddr prereq
-  yum:
-    name:
-    - python3-netaddr
-    state: present
-    update_cache: true
-    disable_gpg_check: yes
-
 - name: Set ocp inventory download url from lab wiki
   set_fact:
     ocp_inventory_url: "http://{{ labs[lab]['quads'] }}/cloud/{{ lab_cloud }}_ocpinventory.json"

--- a/ansible/roles/create-inventory/tasks/main.yml
+++ b/ansible/roles/create-inventory/tasks/main.yml
@@ -182,4 +182,3 @@
     src: "inventory-{{ cluster_type }}.j2"
     dest: "{{ playbook_dir }}/inventory/{{ lab_cloud }}.local"
     backup: true
-

--- a/ansible/roles/create-inventory/tasks/main.yml
+++ b/ansible/roles/create-inventory/tasks/main.yml
@@ -168,12 +168,13 @@
     set_fact:
       mac_query: "json.interfaces[?type=='interface'].mac"
 
+- name: Loop over all OCP nodes to find Supermicro hardware
+  include_tasks: find_supermicro.yml
+  loop: "{{ ocpinventory.json.nodes }}"
+
 - name: Place inventory file named {{ lab_cloud }}.local into inventory directory
   template:
     src: "inventory-{{ cluster_type }}.j2"
     dest: "{{ playbook_dir }}/inventory/{{ lab_cloud }}.local"
     backup: true
 
-- name: Loop over all OCP nodes to find Supermicro hardware
-  include_tasks: find_supermicro.yml
-  loop: "{{ ocpinventory.json.nodes }}"

--- a/ansible/roles/create-inventory/templates/inventory-bm.j2
+++ b/ansible/roles/create-inventory/templates/inventory-bm.j2
@@ -1,5 +1,6 @@
 [all:vars]
 allocation_node_count={{ ocpinventory.json.nodes | length }}
+supermicro_nodes={{ has_supermicro | bool }}
 
 [bastion]
 {{ bastion_machine }} ansible_ssh_user=root bmc_address=mgmt-{{ bastion_machine }}

--- a/ansible/roles/install-early-deps/tasks/main.yml
+++ b/ansible/roles/install-early-deps/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+# install-early-deps tasks
+#
+# Install what we need to run the playbooks
+#
+
+- name: Install python netaddr prereq
+  yum:
+    name:
+    - python3-netaddr
+    state: present
+    update_cache: true
+    disable_gpg_check: yes
+
+- name: Install ansible-galaxy collections
+  command: ansible-galaxy collection install ansible.netcommon ansible.posix community.general containers.podman
+

--- a/ansible/setup-bastion.yml
+++ b/ansible/setup-bastion.yml
@@ -7,6 +7,8 @@
 #
 - name: ensure bastion is powered on
   hosts: localhost
+  vars:
+    ssh_known_hosts_file: "{{ lookup('env','HOME') + '/.ssh/known_hosts' }}"
   vars_files:
   - vars/all.yml
   - vars/lab.yml
@@ -29,6 +31,19 @@
       delay: 60
       timeout: 420
     when: bastion_power.changed
+
+  - name: For each host, scan for its ssh public key
+    shell: "ssh-keyscan {{ item }},`dig +short {{ item }}`"
+    with_items: "{{ bastion_machine }}"
+    register: ssh_known_host_results
+    ignore_errors: yes
+
+  - name: Add/update the public key in the '{{ ssh_known_hosts_file }}'
+    known_hosts:
+      name: "{{ item.item }}"
+      key: "{{ item.stdout }}"
+      path: "{{ ssh_known_hosts_file }}"
+    with_items: "{{ ssh_known_host_results.results }}"
 
 - name: Setup bastion machine
   hosts: bastion

--- a/ansible/setup-bastion.yml
+++ b/ansible/setup-bastion.yml
@@ -9,6 +9,7 @@
   hosts: localhost
   vars:
     ssh_known_hosts_file: "{{ lookup('env','HOME') + '/.ssh/known_hosts' }}"
+    ssh_pub_key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
   vars_files:
   - vars/all.yml
   - vars/lab.yml
@@ -44,6 +45,12 @@
       key: "{{ item.stdout }}"
       path: "{{ ssh_known_hosts_file }}"
     with_items: "{{ ssh_known_host_results.results }}"
+
+  - name: Set authorized key took from file
+    authorized_key:
+      user: root
+      state: present
+      key: "{{ ssh_pub_key }}"
 
 - name: Setup bastion machine
   hosts: bastion

--- a/ansible/setup-bastion.yml
+++ b/ansible/setup-bastion.yml
@@ -7,9 +7,6 @@
 #
 - name: ensure bastion is powered on
   hosts: localhost
-  vars:
-    ssh_known_hosts_file: "{{ lookup('env','HOME') + '/.ssh/known_hosts' }}"
-    ssh_pub_key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
   vars_files:
   - vars/all.yml
   - vars/lab.yml
@@ -32,25 +29,6 @@
       delay: 60
       timeout: 420
     when: bastion_power.changed
-
-  - name: For each host, scan for its ssh public key
-    shell: "ssh-keyscan {{ item }},`dig +short {{ item }}`"
-    with_items: "{{ bastion_machine }}"
-    register: ssh_known_host_results
-    ignore_errors: yes
-
-  - name: Add/update the public key in the '{{ ssh_known_hosts_file }}'
-    known_hosts:
-      name: "{{ item.item }}"
-      key: "{{ item.stdout }}"
-      path: "{{ ssh_known_hosts_file }}"
-    with_items: "{{ ssh_known_host_results.results }}"
-
-  - name: Set authorized key took from file
-    authorized_key:
-      user: root
-      state: present
-      key: "{{ ssh_pub_key }}"
 
 - name: Setup bastion machine
   hosts: bastion


### PR DESCRIPTION
After installing ansible on the machine that will run jetlag playbooks, the user doesn't need to install anything else manually.
The system packages, pip packages and ansible galaxy packages are all handled by the playbooks as necessary.
Additionally we check to see if we need to deal with the Supermicro tools based on presence of the nodes.

I've only changed the baremetal inventory template at this point.