### PR TITLE
pao install tasks on standard bm cluster and changes in tips doc

### DIFF
--- a/ansible/roles/bm-post-cluster-install/defaults/main/main.yml
+++ b/ansible/roles/bm-post-cluster-install/defaults/main/main.yml
@@ -39,3 +39,6 @@ net_attach_def_namespace: default
 net_attach_def_name: net1
 net_attach_def_interface: bond0
 net_attach_def_range: 192.168.0.0/16
+
+# Performance-addon-operator vars_files
+install_performance_addon_operator: false

--- a/ansible/roles/bm-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/bm-post-cluster-install/tasks/main.yml
@@ -12,6 +12,7 @@
     - "{{ bastion_cluster_config_dir }}/localstorage"
     - "{{ bastion_cluster_config_dir }}/net-attach-def"
     - "{{ bastion_cluster_config_dir }}/openshift-monitoring"
+    - "{{ bastion_cluster_config_dir }}/performance-addon-operator"
 
 - name: Get credentials (kubeconfig and kubeadmin password) from installed cluster
   get_url:
@@ -24,6 +25,17 @@
 - name: Apply a label to the worker node(s)
   shell: |
     KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc label no --overwrite -l node-role.kubernetes.io/worker jetlag=true
+
+- name: Install Performance-Addon-Operator - find channel
+  shell: |
+    KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc get packagemanifest performance-addon-operator -n openshift-marketplace -o jsonpath='{.status.defaultChannel}'
+  register: channel
+  when: install_performance_addon_operator
+
+- name: Install Performance-Addon-Operator - Store channel in var
+  set_fact:
+    ocp_channel: "{{ channel.stdout }}"
+  when: install_performance_addon_operator
 
 - name: Place templated configuration items
   template:
@@ -42,6 +54,8 @@
       dest: "{{ bastion_cluster_config_dir }}/net-attach-def/network-attachment-definition.yml"
     - src: cluster-monitoring-config.yml.j2
       dest: "{{ bastion_cluster_config_dir }}/openshift-monitoring/cluster-monitoring-config.yml"
+    - src: performance-addon-operator.yml.j2
+      dest: "{{ bastion_cluster_config_dir }}/performance-addon-operator/performance-addon-operator.yml"
 
 - name: Clone performance-dashboards
   git:
@@ -191,3 +205,8 @@
   when: setup_network_attachment_definition
   shell:
     KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc apply -f {{ bastion_cluster_config_dir }}/net-attach-def/network-attachment-definition.yml
+
+- name: Install Performance-Addon-Operator - create PAO namespace, OperatorGroup and subscription
+  shell: |
+    KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc create -f {{ bastion_cluster_config_dir }}/performance-addon-operator/performance-addon-operator.yml
+  when: install_performance_addon_operator

--- a/ansible/roles/bm-post-cluster-install/templates/performance-addon-operator.yml.j2
+++ b/ansible/roles/bm-post-cluster-install/templates/performance-addon-operator.yml.j2
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-performance-addon-operator
+  annotations:
+    workload.openshift.io/allowed: management
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-performance-addon-operator
+  namespace: openshift-performance-addon-operator
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-performance-addon-operator-subscription
+  namespace: openshift-performance-addon-operator
+spec:
+  channel: "{{ ocp_channel }}"
+  name: performance-addon-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/ansible/vars/lab.yml
+++ b/ansible/vars/lab.yml
@@ -16,7 +16,7 @@ labs:
     - 10.19.96.1
     foreman: foreman.alias.bos.scalelab.redhat.com
     ntp_server: clock2.bos.redhat.com
-    quads: quads11.alias.bos.scalelab.redhat.com
+    quads: quads.alias.bos.scalelab.redhat.com
   scalelab:
     dns:
     - 10.1.36.1

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -51,16 +51,12 @@ install_performance_addon_operator: true
 
 **Please Note**
 * This feature is available for GA releases of OCP only
-* Currently available only for Single Node Openshift clusters
 * You must define `reserved_cpus` in the vars file when installing Performance Addon Operator on Single Node Openshift clusters
 * The workload partitioning CPUs (`reserved_cpus`) should match the reserved cpu specs within your performance-profile
 
 Setting `reserved_cpus` would allow us to isolate the control plane services to run on a restricted set of CPUs.
 
-Choosing the CPUs to isolate requires careful consideration of the CPU topology of the system. If you plan to enable rt-kernel also in your performance-profile, different use cases may require different configuration:
-
-If you have a multi-threaded application where threads need to communicate with one another by sharing cache, they may need to be kept on the same NUMA node or physical socket.
-If you run multiple unrelated real-time applications, separating the CPUs by NUMA node or socket may be suitable.
+You can reserve cores, or threads, for operating system housekeeping tasks from a single NUMA node and put your workloads on another NUMA node. The reason for this is that the housekeeping processes might be using the CPUs in a way that would impact latency sensitive processes running on those same CPUs. Keeping your workloads on a separate NUMA node prevents the processes from interfering with each other. Additionally, each NUMA node has its own memory bus that is not shared.
 
 If you are unsure about which cpus to reserve for housekeeping-pods, the general rule is to identify any two processors and their siblings on separate NUMA nodes:
 


### PR DESCRIPTION
1. Added pao install tasks for standard BM cluster 
2. Made changes to cpu reserve tips in the tips-and-vars doc
3. Corrected the quads url for the ALIAS lab in lab.yml
Haven't been able to test due to cluster install issues in the ALIAS lab but these are basically the same tasks that were previously tested on SNOs