### PR TITLE
adding promdump to bastion server

### DIFF
--- a/ansible/roles/bastion-install/defaults/main.yml
+++ b/ansible/roles/bastion-install/defaults/main.yml
@@ -9,3 +9,7 @@ yq_url: https://github.com/mikefarah/yq/releases/download/v4.17.2/yq_linux_amd64
 # Since the use of tc on the bastion machine is rare and only for remote worker node testing in scale/alias labs, we
 # disable rebooting the bastion machine by default.
 bastion_install_tc_reboot: false
+
+# promdump
+promdump_url: https://github.com/ihcsim/promdump/releases/download/v0.2.3/kubectl-promdump-linux-amd64-v0.2.3.tar.gz
+promdump_tarball: /tmp/kubectl-promdump-linux-amd64.tar.gz

--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -224,3 +224,19 @@
     dest: /usr/local/bin/yq
     remote_src: true
     mode: 0700
+
+- name: Download promdump
+  get_url:
+    url: "{{ promdump_url }}"
+    dest: "{{ promdump_tarball }}"
+
+- name: Untar promdump
+  unarchive:
+    src: "{{ promdump_tarball }}"
+    dest: /usr/local/bin
+    remote_src: yes
+
+- name: Remove promdump tarball
+  file:
+    path: "{{ promdump_tarball }}"
+    state: absent


### PR DESCRIPTION
This installs promdump so that a prometheus data store archive can be created after tests are run.