### PR TITLE
doc: prefer RHEL8.6 as a base, swap Rocky for CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ The listed hardware has been used for cluster deployments successfully. Potentia
 
 Versions:
 
-* Ansible 4.10 (core 2.11.10) (on machine running jetlag playbooks)
+* Ansible 4.10+ (core >= 2.11.10) (on machine running jetlag playbooks)
 * ibmcloud cli => 2.0.1 (IBMcloud environments)
-* RHEL 8.4 / Centos 8.4 (Bastion)
+* RHEL 8.6 / Rocky 8.6 (Bastion)
 * podman 3 (Bastion)
 
 For guidance on how to order hardware on IBMcloud, see [order-hardware-ibmcloud.md](docs/order-hardware-ibmcloud.md) in [docs](docs) directory.

--- a/ansible/roles/validate-vars/tasks/main.yml
+++ b/ansible/roles/validate-vars/tasks/main.yml
@@ -13,12 +13,12 @@
     msg: "Pull secret appears unset"
   when: pull_secret is not defined
 
-- name: Check for RHEL 8.4 (Bastion Validation)
+- name: Check for RHEL 8.6 (Bastion Validation)
   fail:
-    msg: "Upgrade to RHEL 8.4 for podman host network support"
+    msg: "Upgrade to RHEL 8.6 for podman host network support"
   when:
   - ansible_distribution is defined
-  - (ansible_distribution|lower != "redhat" and ansible_distribution|lower != "centos") or ansible_distribution_version|float < 8.4
+  - (ansible_distribution|lower != "redhat" and ansible_distribution|lower != "centos") or ansible_distribution_version|float < 8.6
 
 - name: Set worker_node_count if undefined or empty (bm/rwn)
   set_fact:

--- a/docs/deploy-bm-ibmcloud.md
+++ b/docs/deploy-bm-ibmcloud.md
@@ -2,7 +2,7 @@
 
 To deploy a bare metal OpenShift cluster, order 6 machines from the [IBM bare metal server catalog](https://cloud.ibm.com/gen1/infrastructure/provision/bm).
 For guidance on how to order hardware on IBMcloud, see [order-hardware-ibmcloud.md](../docs/order-hardware-ibmcloud.md) in [docs](../docs) directory.
-The machines used to test this are of Server profile E5-2620 in DAL10 datacenter with automatic port redundancy. One machine will become the bastion, 3 machines will become control-plane nodes, and the remaining 2 nodes will be worker nodes. Ensure that you order either CentOS or RHEL machines with a new enough version (8.4) otherwise podman will not have host networking functionality. The bastion machine should have a public accessible ip and will NAT traffic for the cluster to the public network. The other machines can have a public ip address but it is not currently in use with this deployment method.
+The machines used to test this are of Server profile E5-2620 in DAL10 datacenter with automatic port redundancy. One machine will become the bastion, 3 machines will become control-plane nodes, and the remaining 2 nodes will be worker nodes. Ensure that you order either CentOS or RHEL machines with a new enough version (8.6) otherwise podman will not have host networking functionality. The bastion machine should have a public accessible ip and will NAT traffic for the cluster to the public network. The other machines can have a public ip address but it is not currently in use with this deployment method.
 
 Once your machines are delivered, login to the ibmcloud cli using the cut and paste link from the cloud portal. You should be able to list the machines from your local machine, for example:
 

--- a/docs/deploy-bm-quickstart.md
+++ b/docs/deploy-bm-quickstart.md
@@ -354,7 +354,7 @@ bmc_user=quads
 bmc_password=XXXXXXX
 ```
 
-** If your bastion machine is not running RHEL 8.4, you will have to upgrade following [this short procedure](troubleshooting.md#upgrade-rhel-to-84-in-scalelab).
+** If your bastion machine is not running RHEL 8.6, you will have to upgrade following [this short procedure](troubleshooting.md#upgrade-rhel-to-86-in-scalelab).
 
 Next run the `setup-bastion.yml` playbook ...
 

--- a/docs/order-hardware-ibmcloud.md
+++ b/docs/order-hardware-ibmcloud.md
@@ -29,7 +29,7 @@ https://cloud.ibm.com/docs/bare-metal?topic=bare-metal-about-bm
 
 Points to keep in mind while ordering hardware:
 
-* Ensure that you order either CentOS or RHEL machines with a new enough version (8.4) otherwise podman will not have host networking functionality
+* Ensure that you order either CentOS or RHEL machines with a new enough version (8.6) otherwise podman will not have host networking functionality
 * Add your SSH keys while ordering. Generate a new key pair for ibmcloud as a best practice.
 * Select an SSD disk
 * 32 GB RAM at minimum

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,7 +36,7 @@ HTTP Server - http://f99-h11-000-1029p.rdu2.scalelab.redhat.com:8081/
 
 Example accessing the disconnected registry and listing repositories:
 ```console
-[root@f99-h11-000-1029p akrzos]# curl -u registry:registry -k https://f99-h11-000-1029p.rdu2.scalelab.redhat.com:5000/v2/_catalog?n=100 | jq                                                 
+[root@f99-h11-000-1029p akrzos]# curl -u registry:registry -k https://f99-h11-000-1029p.rdu2.scalelab.redhat.com:5000/v2/_catalog?n=100 | jq
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100   532  100   532    0     0    104      0  0:00:05  0:00:05 --:--:--   120
@@ -130,17 +130,17 @@ If a machine needs to be rebuilt in the Scale Lab and refuses to correctly rebui
 
 Substitute the user/password/hostname to allow the boot order to be fixed on the host machine. Note it will take a few minutes before the machine should reboot. If you previously triggered a rebuild, the machine will likely go straight into rebuild mode afterwards. You can learn more about [badfish here](https://github.com/redhat-performance/badfish).
 
-## Scalelab - Upgrade RHEL to 8.4
+## Scalelab - Upgrade RHEL to 8.6
 
 On the bastion machine:
 
 ```console
-[root@f16-h11-000-1029p ~]# ./update-latest-rhel-release.sh 8.4
-Changing repository from 8.2 to 8.4
+[root@f16-h11-000-1029p ~]# ./update-latest-rhel-release.sh 8.6
+Changing repository from 8.2 to 8.6
 Cleaning dnf repo cache..
 
 -------------------------
-Run dnf update to upgrade to RHEL 8.4
+Run dnf update to upgrade to RHEL 8.6
 
 [root@f16-h21-000-1029p ~]# dnf update -y
 ...

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,7 +8,7 @@ _**Table of Contents**_
 - [Bastion - Clean all container images from disconnected registry](#bastion---clean-all-container-images-from-disconnected-registry)
 - [Dell - Reset BMC / iDrac](#dell---reset-bmc--idrac)
 - [Scalelab - Fix boot order of machines](#scalelab---fix-boot-order-of-machines)
-- [Scalelab - Upgrade RHEL to 8.4](#scalelab---upgrade-rhel-to-84)
+- [Scalelab - Upgrade RHEL to 8.6](#scalelab---upgrade-rhel-to-86)
 - [SuperMicro - Reset BMC / Resolving redfish connection error](#supermicro---reset-bmc--resolving-redfish-connection-error)
 - [Supermicro - The node product key needs to be activated for this device](#supermicro---the-node-product-key-needs-to-be-activated-for-this-device)
 - [Supermicro - Failure of TASK SuperMicro Set Boot](#supermicro---failure-of-task-supermicro-set-boot)


### PR DESCRIPTION
TLDR;

* Change reference from RHEL8.4 to RHEL8.6 for internal/lab/repo reasons
* Change reference from CentOS to Rocky

This is a doc patch to remove references to RHEL8.4 and instead
encourage usage of RHEL8.6.

Internally our globalsync repos do not have ansible-core* packages
present for 8.4, however these are present for 8.6 in the AppStream
repositories.

(If someone uses an RHN subscription this is a non-issue)

This means that people using a Scale Lab (or ALIAS) provided internal
repository will have dependency issues with Ansible provided via RPM.

(This issue was raised by @yobshans).

```
TASK [bastion-install : Install ansible] ************************************************************************************************************************************
Wednesday 08 June 2022  13:13:48 +0000 (0:00:00.026)       0:00:40.431 ********
fatal: [f04-h14-000-1029u.rdu2.scalelab.example.com]: FAILED! => {"changed": false, "failures": [], "msg": "Depsolve Error occured: \n Problem: conflicting requests\n  - nothing provides (ansible-core >= 2.12.2 with ansible-core < 2.13) needed by ansible-5.4.0-2.el8.noarch", "rc": 1, "results": []}
```

```
Problem: conflicting requests
  - nothing provides (ansible-core >= 2.12.2 with ansible-core < 2.13) needed by ansible-5.4.0-2.el8.noarch
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

As there should be no changes in binary/ABI compatibility between 8.4
and 8.6 there should be no problem here.

Lastly, there is no CentOS anymore even the mirrors are gone and CentOS
stream is not a good replacement for this.

I am including Rocky Linux 8.6 instead, it's available as an option via
Scale Lab Foreman and is 100% identical to RHEL8.6 with branding
removed.  (Rocky is one of two RHEL clones to emerge since CentOS has
been retired)

https://rockylinux.org/about/

We can see here it has the same Ansible libs/deps as RHEL8.6 so it's a
drop-in replacement for people who don't want to use an RHN subscription
for extra repository needs.

```
[root@chipmunts ~]# dnf install ansible
Last metadata expiration check: 1:08:00 ago on Thu 09 Jun 2022 06:09:49 PM CEST.
Dependencies resolved.
================================================================================
 Package            Arch   Version                              Repo       Size
================================================================================
Installing:
 ansible            noarch 5.4.0-2.el8                          epel       40 M
Installing dependencies:
 ansible-core       x86_64 2.12.2-3.1.el8                       appstream 2.4 M
 python38           x86_64 3.8.12-1.module+el8.6.0+794+eba84017 appstream  78 k
 python38-asn1crypto
                    noarch 1.2.0-3.module+el8.4.0+570+c2eaf144  appstream 183 k
 python38-babel     noarch 2.7.0-11.module+el8.5.0+672+ab6eb015 appstream 5.9 M
 python38-cffi      x86_64 1.13.2-3.module+el8.4.0+570+c2eaf144 appstream 247 k
 python38-cryptography
                    x86_64 2.8-3.module+el8.5.0+672+ab6eb015    appstream 552 k
 python38-idna      noarch 2.8-6.module+el8.4.0+570+c2eaf144    appstream  86 k
 python38-jinja2    noarch 2.10.3-5.module+el8.5.0+672+ab6eb015 appstream 262 k
 python38-libs      x86_64 3.8.12-1.module+el8.6.0+794+eba84017 appstream 8.3 M
 python38-markupsafe
                    x86_64 1.1.1-6.module+el8.4.0+570+c2eaf144  appstream  35 k
 python38-pip-wheel noarch 19.3.1-5.module+el8.6.0+794+eba84017 appstream 1.0 M
 python38-ply       noarch 3.11-10.module+el8.4.0+570+c2eaf144  appstream 111 k
 python38-pycparser noarch 2.19-3.module+el8.4.0+570+c2eaf144   appstream 127 k
 python38-pytz      noarch 2019.3-3.module+el8.4.0+570+c2eaf144 appstream  54 k
 python38-pyyaml    x86_64 5.4.1-1.module+el8.5.0+672+ab6eb015  appstream 211 k
 python38-resolvelib
                    noarch 0.5.4-5.el8                          appstream  29 k
 python38-setuptools
                    noarch 41.6.0-5.module+el8.5.0+672+ab6eb015 appstream 667 k
 python38-setuptools-wheel
                    noarch 41.6.0-5.module+el8.5.0+672+ab6eb015 appstream 303 k
 python38-six       noarch 1.12.0-10.module+el8.4.0+570+c2eaf144
                                                                appstream  38 k
 sshpass            x86_64 1.09-4.el8                           appstream  29 k
Installing weak dependencies:
 python3-jmespath   noarch 0.9.0-11.el8                         appstream  44 k
 python38-pip       noarch 19.3.1-5.module+el8.6.0+794+eba84017 appstream 1.8 M
Enabling module streams:
 python38                  3.8
```