### PR TITLE
Fix issue when creating inventory with hypervisors on undefined var.

### DIFF
--- a/ansible/roles/create-inventory/defaults/main/dns.yml
+++ b/ansible/roles/create-inventory/defaults/main/dns.yml
@@ -1,0 +1,1 @@
+../../../bastion-network/defaults/main/dns.yml


### PR DESCRIPTION
`bastion_dnsmasq_cd_network_offset` will end up undefined if we do not link dns.yml into the create-inventory role.