### PR TITLE
Fix AnsibleUndefinedVariable for `supermicro_nodes` for rh lab with RWN

### DIFF
--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -147,7 +147,7 @@
         mode: 0700
         extra_opts:
         - --strip-components=1
-  when: supermicro_nodes
+  when: supermicro_nodes | default(true)
 
 - name: Get OpenShift clients, opm, kube-burner, grpcurl, and yq
   get_url:

--- a/ansible/roles/create-inventory/templates/inventory-rwn.j2
+++ b/ansible/roles/create-inventory/templates/inventory-rwn.j2
@@ -1,5 +1,6 @@
 [all:vars]
 allocation_node_count={{ ocpinventory.json.nodes | length }}
+supermicro_nodes={{ has_supermicro | bool }}
 
 [bastion]
 {{ bastion_machine }} ansible_ssh_user=root bmc_address=mgmt-{{ bastion_machine }}

--- a/ansible/roles/create-inventory/templates/inventory-sno.j2
+++ b/ansible/roles/create-inventory/templates/inventory-sno.j2
@@ -1,5 +1,6 @@
 [all:vars]
 allocation_node_count={{ ocpinventory.json.nodes | length }}
+supermicro_nodes={{ has_supermicro | bool }}
 
 [bastion]
 {{ bastion_machine }} ansible_ssh_user=root bmc_address=mgmt-{{ bastion_machine }}


### PR DESCRIPTION
and SNOs.  Also conservatively set `supermicro_nodes` to default to true
for ibmcloud environments.