### PR TITLE
Removed PAO install for SNO DU-profile on OCP 4.11 and higher

### DIFF
--- a/ansible/roles/bastion-install/defaults/main.yml
+++ b/ansible/roles/bastion-install/defaults/main.yml
@@ -2,7 +2,7 @@
 # bastion-install default vars
 
 openshift_client_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp
-kubeburner_url: https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.16/kube-burner-0.16-Linux-x86_64.tar.gz
+kubeburner_url: https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.16.3/kube-burner-0.16.3-Linux-x86_64.tar.gz
 grpcurl_url: https://github.com/fullstorydev/grpcurl/releases/download/v1.8.1/grpcurl_1.8.1_linux_x86_64.tar.gz
 yq_url: https://github.com/mikefarah/yq/releases/download/v4.17.2/yq_linux_amd64.tar.gz
 

--- a/ansible/roles/sno-create-ai-cluster/tasks/01_manifest_task.yml
+++ b/ansible/roles/sno-create-ai-cluster/tasks/01_manifest_task.yml
@@ -8,13 +8,13 @@
   - file_name: kubeletconfig-max-pods.yml
     template_name: kubeletconfig-max-pods.yml
     enabled: "{{ kubelet_config }}"
-    enabled_pao: "{{ install_performance_addon_operator }}"
+    enabled_pao: "{{ du_profile }}"
   - file_name: 99-master-kdump.yml
     template_name: 99-master-kdump.yml
     enabled: "{{ kdump_master_config }}"
   - file_name: 99-master-workload-partitioning.yml
     template_name: 99-master-workload-partitioning.yml
-    enabled: "{{ install_performance_addon_operator }}"
+    enabled: "{{ du_profile }}"
   - file_name: 01-container-mount-ns-and-kubelet-conf-master.yaml
     template_name: 01-container-mount-ns-and-kubelet-conf-master.yaml
     enabled: "{{ du_profile }}"

--- a/ansible/roles/sno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/sno-post-cluster-install/tasks/main.yml
@@ -19,12 +19,12 @@
   loop: "{{ ai_cluster_ids | dict2items }}"
   when: setup_network_attachment_definition
 
-- name: Create performance-addon-operator directory per sno cluster
+- name: Create performance-profile directory per sno cluster
   file:
-    path: "{{ bastion_cluster_config_dir }}/{{ item.key }}/performance-addon-operator"
+    path: "{{ bastion_cluster_config_dir }}/{{ item.key }}/performance-profile"
     state: directory
   loop: "{{ ai_cluster_ids | dict2items }}"
-  when: install_performance_addon_operator
+  when: install_performance_addon_operator or du_profile
 
 - name: Place templated net-attachment-definition
   template:
@@ -96,13 +96,13 @@
 - name: Install Performance-Addon-Operator - Place templated PAO namespace, OperatorGroup and subscription
   template:
     src: performance-addon-operator.yml.j2
-    dest: "{{ bastion_cluster_config_dir }}/{{ item.key }}/performance-addon-operator/performance-addon-operator.yml"
+    dest: "{{ bastion_cluster_config_dir }}/{{ item.key }}/performance-profile/performance-addon-operator.yml"
   loop: "{{ ai_cluster_ids | dict2items }}"
   when: install_performance_addon_operator
 
 - name: Install Performance-Addon-Operator - create PAO namespace, OperatorGroup and subscription
   shell: |
-    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ item.key }}/kubeconfig oc create -f {{ bastion_cluster_config_dir }}/{{ item.key }}/performance-addon-operator/performance-addon-operator.yml
+    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ item.key }}/kubeconfig oc create -f {{ bastion_cluster_config_dir }}/{{ item.key }}/performance-profile/performance-addon-operator.yml
   loop: "{{ ai_cluster_ids | dict2items }}"
   when: install_performance_addon_operator
 
@@ -111,17 +111,17 @@
     src: performance-profile.yml.j2
     dest: "{{ bastion_cluster_config_dir }}/{{ item.key }}/performance-addon-operator/performance-profile.yml"
   loop: "{{ ai_cluster_ids | dict2items }}"
-  when: install_performance_addon_operator
+  when: du_profile
 
 - name: Apply the PerformanceProfile
   shell: |
-    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ item.key }}/kubeconfig oc create -f {{ bastion_cluster_config_dir }}/{{ item.key }}/performance-addon-operator/performance-profile.yml
+    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ item.key }}/kubeconfig oc create -f {{ bastion_cluster_config_dir }}/{{ item.key }}/performance-profile/performance-profile.yml
   register: perf_result
   retries: 120
   delay: 2
   until: not perf_result.failed
   loop: "{{ ai_cluster_ids | dict2items }}"
-  when: install_performance_addon_operator
+  when: du_profile
 
 - name: Wait until MachineConfigPools are updating
   shell: |
@@ -131,7 +131,7 @@
   retries: 120
   until: result.stdout == "True"
   loop: "{{ ai_cluster_ids | dict2items }}"
-  when: install_performance_addon_operator
+  when: du_profile
 
 - name: Wait until MachineConfigPools are updated
   shell: |
@@ -141,4 +141,4 @@
   retries: 180
   until: result.stdout == "True"
   loop: "{{ ai_cluster_ids | dict2items }}"
-  when: install_performance_addon_operator
+  when: du_profile

--- a/ansible/roles/sno-post-cluster-install/templates/performance-profile.yml.j2
+++ b/ansible/roles/sno-post-cluster-install/templates/performance-profile.yml.j2
@@ -14,6 +14,7 @@ spec:
   additionalKernelArgs:
   - idle=poll
   - rcupdate.rcu_normal_after_boot=0
+  - efi=runtime
 {% endif %}
   cpu:
     # Temp. workaround for RT kernel bugs that consume too much

--- a/ansible/roles/validate-vars/tasks/main.yml
+++ b/ansible/roles/validate-vars/tasks/main.yml
@@ -67,12 +67,17 @@
       msg: "Invalid cluster_type selected - {{ cluster_type }} Select from {{ ibmcloud_cluster_types }}"
     when: cluster_type not in ibmcloud_cluster_types
 
+- name: Check if PAO install is enabled when du_profile is enabled and OCP version is 4.9 or 4.10
+  fail:
+    msg: "set install_performance_addon_operator to true"
+  when: (cluster_type == "sno") and (openshift_version == "4.9" or openshift_version == "4.10") and (not install_performance_addon_operator | default(false) | bool) and (du_profile | default(false) | bool)
+
 - name: Check reserved_cpus var is set
   fail:
     msg: "reserved_cpus is unset"
-  when: (cluster_type == "sno") and (install_performance_addon_operator | default(false) | bool) and reserved_cpus is undefined
+  when: (cluster_type == "sno") and (du_profile | default(false) | bool) and reserved_cpus is undefined
 
 - name: Check isolated_cpus var is set
   fail:
     msg: "isolated_cpus is unset"
-  when: (cluster_type == "sno") and (install_performance_addon_operator | default(false) | bool) and isolated_cpus is undefined
+  when: (cluster_type == "sno") and (du_profile | default(false) | bool) and isolated_cpus is undefined


### PR DESCRIPTION
1. Removed dependencies on "install_performance_addon_operator" for DU profile setup on OCP 4.11 or higher
2. Updated Kube-burner url to latest version
3. Updated performance-profile based on cnf-feature-deploy repo
4. Updated the "tips and vars" doc to reflect the changes