### PR TITLE
Allow setting worker node disks separately from control-plane node disks

### DIFF
--- a/ansible/roles/wait-hosts-discovered/defaults/main/main.yml
+++ b/ansible/roles/wait-hosts-discovered/defaults/main/main.yml
@@ -6,3 +6,4 @@ assisted_installer_host: "{{ groups['bastion'][0] }}"
 assisted_installer_port: 8090
 
 bm_control_plane_install_disk: /dev/sda
+bm_worker_install_disk: /dev/sda

--- a/ansible/roles/wait-hosts-discovered/tasks/main.yml
+++ b/ansible/roles/wait-hosts-discovered/tasks/main.yml
@@ -100,7 +100,17 @@
 
 - name: Set install disk for control-plane nodes
   include_tasks: set_node_install_disk.yml
+  vars:
+    set_to_disk: "{{ bm_control_plane_install_disk }}"
   loop: "{{ cluster.json.hosts | selectattr('role', 'eq', 'master') | list }}"
+  loop_control:
+    loop_var: bm_node
+
+- name: Set install disk for worker nodes
+  include_tasks: set_node_install_disk.yml
+  vars:
+    set_to_disk: "{{ bm_worker_install_disk }}"
+  loop: "{{ cluster.json.hosts | selectattr('role', 'eq', 'worker') | list }}"
   loop_control:
     loop_var: bm_node
 

--- a/ansible/roles/wait-hosts-discovered/tasks/set_node_install_disk.yml
+++ b/ansible/roles/wait-hosts-discovered/tasks/set_node_install_disk.yml
@@ -21,7 +21,7 @@
             "id": "{{ bm_node.id }}",
             "disks_config": [
               {
-                "id": "{{ bm_control_plane_install_disk }}",
+                "id": "{{ set_to_disk }}",
                 "role": "install"
               },
               {
@@ -32,4 +32,4 @@
           }
         ]
     }
-  when: bm_node.installation_disk_path != bm_control_plane_install_disk
+  when: bm_node.installation_disk_path != set_to_disk


### PR DESCRIPTION
for bm clusters