### PR TITLE
folder correction for perf-profile placement

### DIFF
--- a/ansible/roles/sno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/sno-post-cluster-install/tasks/main.yml
@@ -109,7 +109,7 @@
 - name: Place templated PerformanceProfile
   template:
     src: performance-profile.yml.j2
-    dest: "{{ bastion_cluster_config_dir }}/{{ item.key }}/performance-addon-operator/performance-profile.yml"
+    dest: "{{ bastion_cluster_config_dir }}/{{ item.key }}/performance-profile/performance-profile.yml"
   loop: "{{ ai_cluster_ids | dict2items }}"
   when: du_profile
 


### PR DESCRIPTION
This was an oversight in the last du-profile related commit. 