### PR TITLE
Update the default timeout

### DIFF
--- a/ansible/roles/generate-discovery-iso/tasks/main.yml
+++ b/ansible/roles/generate-discovery-iso/tasks/main.yml
@@ -44,12 +44,14 @@
     status_code: [201]
     return_content: true
     body: { "ssh_public_key": "{{ lookup('file', ssh_public_key_file) }}", "static_network_config" : "{{ static_network_config }}", "image_type": "full-iso" }
+    timeout: 60
   register: http_reply
 
 - name: Download discovery ISO
   get_url:
     url: "http://{{ assisted_installer_host }}:{{ assisted_installer_port }}/api/assisted-install/v1/clusters/{{ ai_cluster_id }}/downloads/image"
     dest: "{{ http_store_path }}/data/discovery.iso"
+    timeout: 60
 
 - name: Symlink for /iso/discovery.iso
   ansible.builtin.file:


### PR DESCRIPTION
- Ansible uri moduel has a default timeout of 30 seconds 
- Ansible get_url module has a default timeout of 10 seconds

On a medium sized cluster, the `get_url` module was bumping into the default timeout. From the error message, it made it seem like a networking issue, however the client was terminating the connection.

Instead of having two different timeouts I am recommending we default to a single 60 second timeout for these tasks.

Signed-off-by: Joe Talerico <jtaleric@redhat.com>