### PR TITLE
FIX to correct DNS server for ipv4 and ipv6 clusters

### DIFF
--- a/ansible/roles/create-inventory/templates/inventory-sno.j2
+++ b/ansible/roles/create-inventory/templates/inventory-sno.j2
@@ -53,7 +53,7 @@ network_prefix={{ controlplane_pub_network_cidr | ipaddr('prefix') }}
 {% elif use_disconnected_registry %}
 network_prefix={{ controlplane_network | ipaddr('prefix') }}
 {% endif %}
-{% if controlplane_bastion_as_dns %}
+{% if use_disconnected_registry %}
 dns1={{ bastion_controlplane_ip }}
 {% else %}
 dns1={{ labs[lab]['dns'][0] }}


### PR DESCRIPTION
jetlag generates the local inventory file for the installation and, based on the address family, it selects the correct DNS server. However, I was seeing without this change a wrong DNS in my inventory. This change corrects that.