### PR TITLE
set proper hostname for disconnected ipv6 sno

### DIFF
--- a/ansible/roles/sno-wait-hosts-discovered/tasks/main.yml
+++ b/ansible/roles/sno-wait-hosts-discovered/tasks/main.yml
@@ -36,7 +36,7 @@
     }
   with_items: "{{ cluster.results }}"
   no_log: true
-  when: (public_vlan | default(false) | bool) or (lab in cloud_labs)
+  when: (public_vlan | default(false) | bool) or (lab in cloud_labs) or (use_disconnected_registry | default(false))
 
 - name: Patch cluster network settings
   uri:


### PR DESCRIPTION
Correctly sets hostname for disconnected ipv6 sno clusters (probably missed in [#288](https://github.com/redhat-performance/jetlag/pull/288))