### PR TITLE
disconnected sno post install operator sync

### DIFF
--- a/ansible/roles/sno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/sno-post-cluster-install/tasks/main.yml
@@ -62,6 +62,24 @@
   loop: "{{ ai_cluster_ids | dict2items }}"
   when: setup_kube_burner_sa | default(true) | bool
 
+- name: Disable default OperatorHub sources on disconnected clusters
+  shell: |
+    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ item.key }}/kubeconfig oc patch OperatorHub cluster --type json -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
+  loop: "{{ ai_cluster_ids | dict2items }}"
+  when: use_disconnected_registry | default(false)
+
+- name: Apply olm-mirror imageContentSourcePolicy on disconnected clusters
+  shell: |
+    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ item.key }}/kubeconfig oc apply -f {{ bastion_cluster_config_dir }}/olm-mirror-{{ operator_index_tag }}/imageContentSourcePolicy.yaml
+  loop: "{{ ai_cluster_ids | dict2items }}"
+  when: use_disconnected_registry | default(false)
+
+- name: Apply olm-mirror catalogSource on disconnected clusters
+  shell: |
+    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ item.key }}/kubeconfig oc apply -f {{ bastion_cluster_config_dir }}/olm-mirror-{{ operator_index_tag }}/catalogSource.yaml
+  loop: "{{ ai_cluster_ids | dict2items }}"
+  when: use_disconnected_registry | default(false)
+
 - name: Setup NetworkAttachmentDefinition for 2nd pod network (macvlan type only)
   when: setup_network_attachment_definition
   shell:

--- a/ansible/roles/sno-post-cluster-install/templates/performance-addon-operator.yml.j2
+++ b/ansible/roles/sno-post-cluster-install/templates/performance-addon-operator.yml.j2
@@ -20,5 +20,9 @@ metadata:
 spec:
   channel: "{{ ocp_channel }}"
   name: performance-addon-operator
+{% if use_disconnected_registry | default(false) %}
+  source: {{ operator_index_name }}
+{% else %}
   source: redhat-operators
+{% endif %}
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Disable default OperatorHub sources and apply olm-mirror ICSP and CatalogSource on disconnected SNO clusters 