### PR TITLE
Since the last time I have synced a v4.11 operator index, something must

### DIFF
--- a/ansible/roles/disconnected-sync-operator-index/templates/operator-index.Dockerfile.j2
+++ b/ansible/roles/disconnected-sync-operator-index/templates/operator-index.Dockerfile.j2
@@ -1,20 +1,3 @@
-{% if operator_index_tag == "v4.11" %}
-# The base image is expected to contain
-# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.redhat.io/openshift4/ose-operator-registry:{{ operator_index_tag }}
-
-# Configure the entrypoint and command
-ENTRYPOINT ["/bin/opm"]
-CMD ["serve", "/configs"]
-
-# Copy declarative config root into image at /configs
-ADD {{ operator_index_name }} /configs
-
-# Set DC-specific label for the location of the DC root directory
-# in the image
-LABEL operators.operatorframework.io.index.configs.v1=/configs
-
-{% elif operator_index_tag == "v4.12" %}
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
 FROM registry.redhat.io/openshift4/ose-operator-registry:{{ operator_index_tag }}
@@ -30,5 +13,3 @@ RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
 # Set DC-specific label for the location of the DC root directory
 # in the image
 LABEL operators.operatorframework.io.index.configs.v1=/configs
-
-{% endif %}


### PR DESCRIPTION
have changed in the base ose-operator-registry image to make v4.11 behave like v4.12