### PR TITLE
Add composable openshift feature to du_profile for OCP 4.13

### DIFF
--- a/ansible/roles/sno-install-cluster/templates/install-config-overrides.yml.j2
+++ b/ansible/roles/sno-install-cluster/templates/install-config-overrides.yml.j2
@@ -1,3 +1,10 @@
+{% if openshift_version == "4.13" and du_profile %}
+capabilities:
+  baselineCapabilitySet: None
+  additionalEnabledCapabilities:
+  - marketplace
+  - NodeTuning
+{% endif %}
 {% if use_disconnected_registry | default(false) %}
 imageContentSources:
 - mirrors:

--- a/ansible/roles/sno-post-cluster-install/defaults/main.yml
+++ b/ansible/roles/sno-post-cluster-install/defaults/main.yml
@@ -13,13 +13,11 @@ net_attach_def_name: net1
 net_attach_def_interface: bond0
 net_attach_def_range: 192.168.0.0/16
 
-# Performance-addon-operator vars_files
+# Performance-addon-operator and du profile vars
 install_performance_addon_operator: false
-kernel_rt: false
 hugepages_count: 16
 node: 0
 isolated_cpus: 2-47,50-95
-topology_manager_policy: restricted
 
 du_profile: false
 

--- a/ansible/roles/sno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/sno-post-cluster-install/tasks/main.yml
@@ -55,6 +55,10 @@
 - name: Apply a label to the worker node(s)
   shell: |
     KUBECONFIG={{ bastion_cluster_config_dir }}/{{ item.key }}/kubeconfig oc label no --all --overwrite jetlag=true
+  register: jetlag_label
+  retries: 120
+  delay: 2
+  until: not jetlag_label.failed
   loop: "{{ ai_cluster_ids | dict2items }}"
 
 - name: Add kube-burner sa
@@ -103,6 +107,19 @@
 - name: Disable Network Diagnostics - Apply CR
   shell: |
     KUBECONFIG={{ bastion_cluster_config_dir }}/{{ item.key }}/kubeconfig oc apply -f {{ bastion_cluster_config_dir }}/{{ item.key }}/DisableSnoNetworkDiag.yaml
+  loop: "{{ ai_cluster_ids | dict2items }}"
+  when: du_profile
+
+- name: Reduce Monitoring Footprint - Place ReduceMonitoringFootprint CR
+  template:
+    src: ReduceMonitoringFootprint.yaml
+    dest: "{{ bastion_cluster_config_dir }}/{{ item.key }}/ReduceMonitoringFootprint.yaml"
+  loop: "{{ ai_cluster_ids | dict2items }}"
+  when: du_profile
+
+- name: Reduce Monitoring Footprint - Apply CR
+  shell: |
+    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ item.key }}/kubeconfig oc apply -f {{ bastion_cluster_config_dir }}/{{ item.key }}/ReduceMonitoringFootprint.yaml
   loop: "{{ ai_cluster_ids | dict2items }}"
   when: du_profile
 
@@ -155,6 +172,19 @@
   loop: "{{ ai_cluster_ids | dict2items }}"
   when: du_profile
 
+- name: Register the CONFIG name reported in "oc get mcp"
+  shell: |
+    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ item.key }}/kubeconfig oc get mcp master -o json | jq -r '.status.configuration.name'
+  register: config_name
+  loop: "{{ ai_cluster_ids | dict2items }}"
+  when: du_profile and openshift_version == "4.13"
+
+- name: Print the CONFIG name, null if empty
+  debug:
+    msg: "{{ item.stdout }}"
+  loop: "{{ config_name.results }}"
+  when: du_profile and openshift_version == "4.13"
+
 - name: Wait until MachineConfigPools are updating
   shell: |
     KUBECONFIG={{ bastion_cluster_config_dir }}/{{ item.key }}/kubeconfig oc get mcp --no-headers master | awk '{print $4}'
@@ -164,16 +194,33 @@
   until: result.stdout == "True"
   loop: "{{ ai_cluster_ids | dict2items }}"
   when: du_profile
+  ignore_errors: yes
 
-- name: Wait until MachineConfigPools are updated
+- name: Wait until MachineConfigPools are updating/updated
   shell: |
     KUBECONFIG={{ bastion_cluster_config_dir }}/{{ item.key }}/kubeconfig oc get mcp --no-headers master | awk '{print $3}'
   register: result
   delay: 10
-  retries: 180
+  retries: 360
   until: result.stdout == "True"
   loop: "{{ ai_cluster_ids | dict2items }}"
   when: du_profile
+
+- name: Wait until MachineConfigPools get a CONFIG
+  shell: |
+    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ item.key }}/kubeconfig oc get mcp master -o custom-columns=CONFIG:.status.configuration.name --no-headers
+  register: config_name
+  delay: 10
+  retries: 360
+  until: ("rendered" in config_name.stdout)
+  loop: "{{ ai_cluster_ids | dict2items }}"
+  when: du_profile and openshift_version == "4.13"
+
+- name: Print the latest CONFIG name
+  debug:
+    msg: "{{ item.stdout }}"
+  loop: "{{ config_name.results }}"
+  when: du_profile and openshift_version == "4.13"
 
 - name: Apply the TunedPerformancePatch
   shell: |
@@ -193,14 +240,14 @@
   retries: 120
   until: result.stdout == "True"
   loop: "{{ ai_cluster_ids | dict2items }}"
-  when: du_profile
+  when: du_profile and openshift_version != "4.13"
 
 - name: Wait until MachineConfigPools are updated
   shell: |
     KUBECONFIG={{ bastion_cluster_config_dir }}/{{ item.key }}/kubeconfig oc get mcp --no-headers master | awk '{print $3}'
   register: result
   delay: 10
-  retries: 180
+  retries: 360
   until: result.stdout == "True"
   loop: "{{ ai_cluster_ids | dict2items }}"
   when: du_profile

--- a/ansible/roles/sno-post-cluster-install/templates/ReduceMonitoringFootprint.yaml
+++ b/ansible/roles/sno-post-cluster-install/templates/ReduceMonitoringFootprint.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    grafana:
+      enabled: false
+    alertmanagerMain:
+      enabled: false
+    prometheusK8s:
+       retention: 24h

--- a/ansible/roles/sno-post-cluster-install/templates/performance-profile.yml.j2
+++ b/ansible/roles/sno-post-cluster-install/templates/performance-profile.yml.j2
@@ -10,13 +10,16 @@ metadata:
       {"maxPods": {{ kubelet_config_max_pods }}}
 {% endif %}
 spec:
-{% if kernel_rt %}
   additionalKernelArgs:
+{% if openshift_version == "4.9" %}
+  - idle=poll
+{% endif %}
   - rcupdate.rcu_normal_after_boot=0
+{% if not openshift_version in ["4.9","4.10"] %}
   - efi=runtime
+{% endif %}
 {% if openshift_version == "4.12" or openshift_version == "4.13" %}
   - module_blacklist=irdma
-{% endif %}
 {% endif %}
   cpu:
     # Temp. workaround for RT kernel bugs that consume too much
@@ -31,8 +34,10 @@ spec:
      count: {{ hugepages_count }}
      node: {{ node }}
 {% endif %}
+{% if openshift_version == "4.9" %}
   net:
     userLevelNetworking: true
+{% endif %}
   # for 3 node converged master/worker and SNO clusters we use the masters as a selector
   nodeSelector:
     node-role.kubernetes.io/master: ""
@@ -42,15 +47,16 @@ spec:
   # nodeSelector:
     # Pay attention to the node label, create MCP accordingly
     #node-role.kubernetes.io/worker-cnf: ""
-{% if topology_manager_policy is defined %}
   numa:
-   topologyPolicy: "{{ topology_manager_policy }}"
-{% endif %}
-{% if kernel_rt %}
-    # For CU should be false
+   topologyPolicy: "restricted"
+  # To use the standard (non-realtime) kernel, set enabled to false
   realTimeKernel:
     enabled: true
-{% else %}
-  realTimeKernel:
-    enabled: false
-{% endif %}
+  # workloadHints:
+    # WorkloadHints defines the set of upper level flags for different type of workloads.
+    # See https://github.com/openshift/cluster-node-tuning-operator/blob/master/docs/performanceprofile/performance_profile.md#workloadhints
+    # for detailed descriptions of each item.
+    # The configuration below is set for a low latency, performance mode.
+    # realTime: true
+    # highPowerConsumption: false
+    # perPodPowerManagement: false

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -34,9 +34,14 @@ As a result, the following machine configuration files will be added to the clus
 * 01-container-mount-ns-and-kubelet-conf-master.yaml 
 * 03-sctp-machine-config-master.yaml
 * 04-accelerated-container-startup-master.yaml
+* 05-kdump-config-master (when kdump is enabled)
+* 99-crio-disable-wipe-master
 * 99-master-workload-partitioning.yml
+* enable-crun-master.yaml
 
-In addition to this, Network Diagnostics will be disabled, performance-profile and tunedPerformancePatch will be applied post SNO install (based on input vars defined - See **SNO DU Profile** section under [Post Deployment Tasks](#post-deployment-tasks)).
+When deploying DU profile on OCP 4.13 or higher, composable openshift feature will automatically be deployed and as a result, all unnecessary optional Cluster Operators will not be deployed.
+
+In addition to this, Network Diagnostics will be disabled, monitoring footprint will be reduced, performance-profile and tunedPerformancePatch will be applied post SNO install (based on input vars defined - See **SNO DU Profile** section under [Post Deployment Tasks](#post-deployment-tasks)).
 
 Refer to https://github.com/openshift-kni/cnf-features-deploy/tree/master/ztp/source-crs for config details.
 
@@ -99,15 +104,9 @@ isolated_cpus: 2-47,50-95
 
 #Optional vars
 
-# If you want to install real-time kernel:
-kernel_rt: true
-
 # Number of hugepages of size 1G to be allocated on the SNO
 hugepages_count: 16
 
-# Kubelet Topology Manager Policy of the performance profile to be created. [Valid values: single-numa-node, best-effort, restricted] (default "restricted")
-topology_manager_policy: best-effort
-```
 #### Tuned Performance Patch
 
 After performance-profile is applied, the standard TunedPerformancePatch used for SNO DUs will also be applied post SNO install if DU profile is enabled.


### PR DESCRIPTION
1. Added install config overrides for composable openshift when du_profile is enabled on ocp 4.13
2. Add ReduceMonitoringFootprint.yaml CR to sno_post_cluster_install tasks for du_profile
3. Modified machine config pool watch tasks post applying performance profile and tuned patch to accommodate config update behaviors observed with composable openshift in du_profile in ocp 4.13
4. Updated doc