### PR TITLE
Fix issue with bm-deploy failing

### DIFF
--- a/ansible/vars/all.sample.yml
+++ b/ansible/vars/all.sample.yml
@@ -78,6 +78,8 @@ controlplane_pub_network_gateway:
 jumbo_mtu: false
 
 # Network only for remote worker nodes
+# Note: these cannot be commented out or bm-deploy will fail
+#       You will need to knowledge of actual interface names.
 rwn_lab_interface: eno1np0
 rwn_network_interface: ens1f1
 


### PR DESCRIPTION
if rwn_lab_interface and rwn_network_interface are commented, then bm-deploy will fail.  Add comments in all.sample.yml to document that the variables should not be commented.

Fixes: https://github.com/redhat-performance/jetlag/issues/331