### PR TITLE
Incorporate ssh keys instead of overwriting

### DIFF
--- a/ansible/roles/hv-install/tasks/main.yml
+++ b/ansible/roles/hv-install/tasks/main.yml
@@ -50,11 +50,19 @@
     enabled: true
     name: chronyd
 
+- name: Check ssh_public_key_file content
+  command: cat "{{ ssh_public_key_file }}"
+  register: tmp_ssh_pubkey
+  changed_when: false
+
 - name: Copying the public key to the root user's authorized_keys
-  copy:
-    src: "{{ ssh_public_key_file }}"
-    dest: /root/.ssh/authorized_keys
-    mode: 0600
+  lineinfile:
+    path: /root/.ssh/authorized_keys
+    line: "{{ item }}"
+    insertafter: "{{ (item.0 == '@')|ternary('EOF', omit) }}"
+    insertbefore: "{{ (item.0 != '@')|ternary('^@.*$', omit)}}"
+    firstmatch: true
+  loop: "{{ tmp_ssh_pubkey.stdout_lines }}"
 
 - name: Start and enable KSM
   systemd:


### PR DESCRIPTION
Instead of overwriting the ssh keys, make sure the requisite pubkey is included into the /root/.ssh/authorized keys file. This is unapologetically pulled from an answer found here:

https://stackoverflow.com/questions/73311329/insert-lines-in-a-file-from-an-other-file-lines-in-ansible

Fixes: https://github.com/redhat-performance/jetlag/issues/323