### PR TITLE
Fails to pull image quay.io/repository/centos7/httpd-24-centos7 - wrong url?

### DIFF
--- a/ansible/roles/bastion-http/tasks/main.yml
+++ b/ansible/roles/bastion-http/tasks/main.yml
@@ -38,5 +38,5 @@
     - "{{ http_store_path }}/data:/var/www/html"
     - "{{ http_store_path }}/conf:/etc/httpd/conf"
     name: httpd
-    image: quay.io/repository/centos7/httpd-24-centos7
+    image: quay.io/centos7/httpd-24-centos7
     state: started


### PR DESCRIPTION
Fails to pull image quay.io/repository/centos7/httpd-24-centos7  - seems `repository` in URL is not necessary. 



``` 
TASK [bastion-http : Create http container in http pod] *****************************************************************************************************************************************************************************
fatal: [e39-h05-000-r650.rdu2.scalelab.redhat.com]: FAILED! => {"changed": false, "msg": "Can't pull image quay.io/repository/centos7/httpd-24-centos7", "stderr": 
"Trying to pull quay.io/repository/centos7/httpd-24-centos7:latest...\nError: initializing source docker://quay.io/repository/centos7/httpd-24-centos7:latest: 
reading manifest latest in quay.io/repository/centos7/httpd-24-centos7: unauthorized: access to the requested resource is not authorized\n", 
"stderr_lines": ["Trying to pull quay.io/repository/centos7/httpd-24-centos7:latest...", "
Error: initializing source docker://quay.io/repository/centos7/httpd-24-centos7:latest: reading manifest latest in quay.io/repository/centos7/httpd-24-centos7: unauthorized: 
access to the requested resource is not authorized"], "stdout": "", "stdout_lines": []}

PLAY RECAP **************************************************************************************************************************************************************************************************************************
e39-h05-000-r650.rdu2.scalelab.redhat.com : ok=35   changed=14   unreachable=0    failed=1    skipped=33   rescued=0    ignored=0   

[root@e39-h05-000-r650 inventory]# podman pull quay.io/repository/centos7/httpd-24-centos7
Trying to pull quay.io/repository/centos7/httpd-24-centos7:latest...
Error: initializing source docker://quay.io/repository/centos7/httpd-24-centos7:latest: reading manifest latest in quay.io/repository/centos7/httpd-24-centos7: unauthorized: access to the requested resource is not authorized
[root@e39-h05-000-r650 inventory]# podman pull quay.io/centos7/httpd-24-centos7
Trying to pull quay.io/centos7/httpd-24-centos7:latest...
Getting image source signatures
Copying blob 8f001c8d7e00 skipped: already exists  
Copying blob c61d16cfe03e skipped: already exists  
Copying blob 06c7e4737942 skipped: already exists  
Copying config d7af31210b done  
Writing manifest to image destination
Storing signatures
d7af31210b288164c319bae740ca1281528390a3c5cee657e95f243670b49e6a
```