### PR TITLE
sanitize hostnames

### DIFF
--- a/docs/bastion-deploy-bm.md
+++ b/docs/bastion-deploy-bm.md
@@ -15,19 +15,19 @@ _**Table of Contents**_
 
 ## Bastion setup
 
-1. Obtain your first machine from the allocation from the [scale lab wiki](http://wiki.rdu2.scalelab.redhat.com/)
+1. Obtain your first machine from the allocation from the [scale lab wiki](http://wiki.subdomain.example.com/). You should have the URL if you were given an allocation in your environment.
 2. Copy your ssh keys to the designated bastion machine
 
 ```console
-[user@fedora ~]$ ssh-copy-id root@xxx-h01-000-r650.example.redhat.com
+[user@fedora ~]$ ssh-copy-id root@xxx-h01-000-r650.subdomain.example.com
 /usr/bin/ssh-copy-id: INFO: attempting to log in with the new key(s), to filter out any that are already installed
 /usr/bin/ssh-copy-id: INFO: 2 key(s) remain to be installed -- if you are prompted now it is to install the new keys
-Warning: Permanently added 'xxx-h01-000-r650.example.redhat.com,x.x.x.x' (ECDSA) to the list of known hosts.
-root@xxx-h01-000-r650.example.redhat.com's password:
+Warning: Permanently added 'xxx-h01-000-r650.subdomain.example.com,x.x.x.x' (ECDSA) to the list of known hosts.
+root@xxx-h01-000-r650.subdomain.example.com's password:
 
 Number of key(s) added: 2
 
-Now try logging into the machine, with:   "ssh 'root@xxx-h01-000-r650.example.redhat.com'"
+Now try logging into the machine, with:   "ssh 'root@xxx-h01-000-r650.subdomain.example.com'"
 and check to make sure that only the key(s) you wanted were added.
 [user@fedora ~]$
 ```
@@ -35,7 +35,7 @@ and check to make sure that only the key(s) you wanted were added.
 3. Update the version of RHEL that came on the bastion machine and reboot
 
 ```console
-[user@fedora ~]$ ssh root@xxx-h01-000-r650.example.redhat.com
+[user@fedora ~]$ ssh root@xxx-h01-000-r650.subdomain.example.com
 ...
 [root@xxx-h01-000-r650 ~]# cat /etc/redhat-release
 Red Hat Enterprise Linux release 8.2 (Ootpa)
@@ -59,10 +59,10 @@ Dependencies resolved.
 ...
 Complete!
 [root@xxx-h01-000-r650 ~]# reboot
-Connection to xxx-h01-000-r650.rdu2.scalelab.redhat.com closed by remote host.
-Connection to xxx-h01-000-r650.rdu2.scalelab.redhat.com closed.
+Connection to xxx-h01-000-r650.subdomain.example.com closed by remote host.
+Connection to xxx-h01-000-r650.subdomain.example.com closed.
 ...
-[user@fedora ~]$ ssh root@xxx-h01-000-r650.example.redhat.com
+[user@fedora ~]$ ssh root@xxx-h01-000-r650.subdomain.example.com
 ...
 [root@xxx-h01-000-r650 ~]# cat /etc/redhat-release
 Red Hat Enterprise Linux release 8.7 (Ootpa)
@@ -88,7 +88,7 @@ Enter same passphrase again:
 Your identification has been saved in /root/.ssh/id_rsa.
 Your public key has been saved in /root/.ssh/id_rsa.pub.
 The key fingerprint is:
-SHA256:uA61+n0w3Dht4/oIy1IKXrSgt9tfC/8zjICd7LJ550s root@xxx-h01-000-r650.rdu2.scalelab.redhat.com
+SHA256:uA61+n0w3Dht4/oIy1IKXrSgt9tfC/8zjICd7LJ550s root@xxx-h01-000-r650.subdomain.example.com
 The key's randomart image is:
 +---[RSA 3072]----+
 ...
@@ -342,16 +342,16 @@ allocation_node_count=16
 supermicro_nodes=False
 
 [bastion]
-xxx-h01-000-r650.rdu2.scalelab.redhat.com ansible_ssh_user=root bmc_address=mgmt-xxx-h01-000-r650.rdu2.scalelab.redhat.com
+xxx-h01-000-r650.subdomain.example.com ansible_ssh_user=root bmc_address=mgmt-xxx-h01-000-r650.subdomain.example.com
 
 [bastion:vars]
 bmc_user=quads
 bmc_password=XXXXXXX
 
 [controlplane]
-xxx-h02-000-r650 bmc_address=mgmt-xxx-h02-000-r650.rdu2.scalelab.redhat.com network_mac=b4:96:91:cb:ec:02 lab_mac=5c:6f:69:75:c0:70 ip=198.18.10.5 vendor=Dell install_disk=/dev/sda
-xxx-h03-000-r650 bmc_address=mgmt-xxx-h03-000-r650.rdu2.scalelab.redhat.com network_mac=b4:96:91:cc:e5:80 lab_mac=5c:6f:69:56:dd:c0 ip=198.18.10.6 vendor=Dell install_disk=/dev/sda
-xxx-h05-000-r650 bmc_address=mgmt-xxx-h05-000-r650.rdu2.scalelab.redhat.com network_mac=b4:96:91:cc:e6:40 lab_mac=5c:6f:69:56:b0:50 ip=198.18.10.7 vendor=Dell install_disk=/dev/sda
+xxx-h02-000-r650 bmc_address=mgmt-xxx-h02-000-r650.subdomain.example.com network_mac=b4:96:91:cb:ec:02 lab_mac=5c:6f:69:75:c0:70 ip=198.18.10.5 vendor=Dell install_disk=/dev/sda
+xxx-h03-000-r650 bmc_address=mgmt-xxx-h03-000-r650.subdomain.example.com network_mac=b4:96:91:cc:e5:80 lab_mac=5c:6f:69:56:dd:c0 ip=198.18.10.6 vendor=Dell install_disk=/dev/sda
+xxx-h05-000-r650 bmc_address=mgmt-xxx-h05-000-r650.subdomain.example.com network_mac=b4:96:91:cc:e6:40 lab_mac=5c:6f:69:56:b0:50 ip=198.18.10.7 vendor=Dell install_disk=/dev/sda
 
 [controlplane:vars]
 role=master
@@ -418,7 +418,7 @@ Finally run the `bm-deploy.yml` playbook ...
 
 ## Monitor install and interact with cluster
 
-It is suggested to monitor your first deployment to see if anything hangs on boot or if the virtual media is incorrect according to the bmc. You can monitor your deployment by opening the bastion's GUI to assisted-installer (port 8080, ex `xxx-h01-000-r650.rdu2.scalelab.redhat.com:8080`), opening the consoles via the bmc of each system, and once the machines are booted, you can directly ssh to them and tail log files.
+It is suggested to monitor your first deployment to see if anything hangs on boot or if the virtual media is incorrect according to the bmc. You can monitor your deployment by opening the bastion's GUI to assisted-installer (port 8080, ex `xxx-h01-000-r650.subdomain.example.com:8080`), opening the consoles via the bmc of each system, and once the machines are booted, you can directly ssh to them and tail log files.
 
 If everything goes well you should have a cluster in about 60-70 minutes. You can interact with the cluster from the bastion.
 

--- a/docs/deploy-sno-quickstart.md
+++ b/docs/deploy-sno-quickstart.md
@@ -86,7 +86,7 @@ Set `smcipmitool_url` to the location of the Supermicro SMCIPMITool binary. Sinc
 
 The system type determines the values of `bastion_lab_interface` and `bastion_controlplane_interface`.
 
-Using the chart provided by the [scale lab here](http://docs.scalelab.redhat.com/trac/scalelab/wiki/ScaleLabTipsAndTricks#RDU2ScaleLabPrivateNetworksandInterfaces), determine the names of the nic per network for EL8.
+Using the chart provided by the [scale lab here](http://docs.subdomain.example.com/trac/scalelab/wiki/ScaleLabTipsAndTricks#RDU2ScaleLabPrivateNetworksandInterfaces), determine the names of the nic per network for EL8.
 
 * `bastion_lab_interface` will always be set to the nic name under "Public Network"
 * `bastion_controlplane_interface` should be set to the nic name under "Network 1" for this guide
@@ -316,7 +316,7 @@ allocation_node_count=6
 supermicro_nodes=True
 
 [bastion]
-f12-h05-000-1029u.rdu2.scalelab.redhat.com ansible_ssh_user=root bmc_address=mgmt-f12-h05-000-1029u.rdu2.scalelab.redhat.com
+xxx-h05-000-1029u.subdomain.example.com ansible_ssh_user=root bmc_address=mgmt-xxx-h05-000-1029u.subdomain.example.com
 
 [bastion:vars]
 bmc_user=quads
@@ -342,7 +342,7 @@ bmc_password=xxxx
 
 [sno]
 # Single Node OpenShift Clusters
-f12-h06-000-1029u bmc_address=mgmt-f12-h06-000-1029u.rdu2.scalelab.redhat.com boot_iso=f12-h06-000-1029u.iso ip_address=10.1.38.222 vendor=Supermicro lab_mac=ac:1f:6b:56:57:0e network_mac=00:25:90:5f:5f:5b
+xxx-h06-000-1029u bmc_address=mgmt-xxx-h06-000-1029u.subdomain.example.com boot_iso=xxx-h06-000-1029u.iso ip_address=192.168.1.1 vendor=Supermicro lab_mac=ac:1f:6b:56:57:0e network_mac=00:25:90:5f:5f:5b
 
 [sno:vars]
 bmc_user=quads
@@ -375,8 +375,8 @@ Next run the `setup-bastion.yml` playbook ...
 We can now set the ssh vars in the `ansible/vars/all.yml` file since `setup-bastion.yml` has completed. For bare metal clusters only `ssh_public_key_file` is required to be filled out. The recommendation is to copy the public ssh key file from your bastion local to your laptop and set `ssh_public_key_file` to the location of that file. This file determines which ssh key will be automatically permitted to ssh into the cluster's nodes.
 
 ```console
-[user@fedora jetlag]$ scp root@f12-h05-000-1029u.rdu2.scalelab.redhat.com:/root/.ssh/id_rsa.pub .
-Warning: Permanently added 'f12-h05-000-1029u.rdu2.scalelab.redhat.com,10.1.43.101' (ECDSA) to the list of known hosts.
+[user@fedora jetlag]$ scp root@xxx-h05-000-1029u.subdomain.example.com:/root/.ssh/id_rsa.pub .
+Warning: Permanently added 'xxx-h05-000-1029u.subdomain.example.com,10.1.43.101' (ECDSA) to the list of known hosts.
 id_rsa.pub                                                                                100%  554    22.6KB/s   00:00
 ```
 
@@ -389,7 +389,7 @@ Finally run the `sno-deploy.yml` playbook ...
 ...
 ```
 
-A typical deployment will require around 60-70 minutes to complete mostly depending upon how fast your systems reboot. It is suggested to monitor your first deployment to see if anything hangs on boot or if the virtual media is incorrect according to the bmc. You can monitor your deployment by opening the bastion's GUI to assisted-installer (port 8080, ex `f12-h05-000-1029u.rdu2.scalelab.redhat.com:8080`), opening the consoles via the bmc of each system, and once the machines are booted, you can directly ssh to them and tail log files.
+A typical deployment will require around 60-70 minutes to complete mostly depending upon how fast your systems reboot. It is suggested to monitor your first deployment to see if anything hangs on boot or if the virtual media is incorrect according to the bmc. You can monitor your deployment by opening the bastion's GUI to assisted-installer (port 8080, ex `xxx-h05-000-1029u.subdomain.example.com:8080`), opening the consoles via the bmc of each system, and once the machines are booted, you can directly ssh to them and tail log files.
 
 If everything goes well you should have a cluster in about 60-70 minutes. You can interact with the cluster from the bastion. Look for the kubeconfig file under `/root/sno/...`
 

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -16,7 +16,7 @@ _**Table of Contents**_
 Current jetlag lab use selects machines for roles bastion, control-plane, and worker in that order from the ocpinventory.json file. You may have to create a new json file with the desired order to match desired roles if the auto selection is incorrect. After creating a new json file, host this where your machine running the playbooks can reach and set the following var such that the modified ocpinventory json file is used:
 
 ```yaml
-ocp_inventory_override: http://example.redhat.com/cloud12-inventories/cloud12-cp_r640-w_5039ms.json
+ocp_inventory_override: http://wiki.subdomain.example.com/cloud12-inventories/cloud12-cp_r640-w_5039ms.json
 ```
 ## DU Profile for SNOs
 
@@ -196,7 +196,7 @@ function rm_XXX_tag {
 If you want to use a NIC other than the default, you need to override the `controlplane_network_interface_idx` variable in the `Extra vars` section of `ansible/vars/all.yml`.
 In this example using nic `ens2f0` in a cluster of r650 nodes is shown.
 1. Select which NIC you want to use instead of the default, in this example, `ens2f0`.
-2. Look for your server model number in [your labs wiki page](http://docs.scalelab.redhat.com/trac/scalelab/wiki/ScaleLabTipsAndTricks#RDU2ScaleLabPrivateNetworksandInterfaces) then select the network you want configured as your primary network using the following mapping
+2. Look for your server model number in [your labs wiki page](http://docs.subdomain.example.com/trac/scalelab/wiki/ScaleLabTipsAndTricks#RDU2ScaleLabPrivateNetworksandInterfaces) then select the network you want configured as your primary network using the following mapping
 ```
 * Network 1 = `controlplane_network_interface_idx: 0`
 * Network 2 = `controlplane_network_interface_idx: 1`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -38,14 +38,14 @@ Several services are run on the bastion in order to automate the tasks that jetl
 
 Examples, change the FQDN to your bastion machine and open in your browser
 ```
-AI Gui - http://f99-h11-000-1029p.rdu2.scalelab.redhat.com:8080/
-AI API - http://f99-h11-000-1029p.rdu2.scalelab.redhat.com:8090/
-HTTP Server - http://f99-h11-000-1029p.rdu2.scalelab.redhat.com:8081/
+AI Gui - http://xxx-h11-000-1029p.subdomain.example.com:8080/
+AI API - http://xxx-h11-000-1029p.subdomain.example.com:8090/
+HTTP Server - http://xxx-h11-000-1029p.subdomain.example.com:8081/
 ```
 
 Example accessing the bastion registry and listing repositories:
 ```console
-[root@f99-h11-000-1029p akrzos]# curl -u registry:registry -k https://f99-h11-000-1029p.rdu2.scalelab.redhat.com:5000/v2/_catalog?n=100 | jq
+[root@f99-h11-000-1029p akrzos]# curl -u registry:registry -k https://xxx-h11-000-1029p.subdomain.example.com:5000/v2/_catalog?n=100 | jq
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100   532  100   532    0     0    104      0  0:00:05  0:00:05 --:--:--   120


### PR DESCRIPTION
Use example.com instead of hostnames which are meaningless outside VPN connected hosts.  The docs should be generic and actual hostnames and wiki URLs are well known as they are commicated via email when allocations are given out.