### PR TITLE
update ibmcloud sl plugin 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ kubeconfig
 id_rsa
 id_rsa.pub
 *.csv
+.idea/

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Versions:
 
 * Ansible 4.10+ (core >= 2.11.12) (on machine running jetlag playbooks)
 * ibmcloud cli => 2.0.1 (IBMcloud environments)
+* ibmcloud plugin install sl (IBMcloud environments)
 * RHEL 8.6 / Rocky 8.6 (Bastion)
 * podman 3 / 4 (Bastion)
 


### PR DESCRIPTION
Documentation fix:

- Adding ibmcloud sl plugin installation prerequisites to readme doc.
required when running: 
`$ ansible-playbook ansible/ibmcloud-create-inventory.yml`
- Adding .idea/ to gitingnore when using JetBrains PyCharm