### PR TITLE
fix for 2960e64 opm/openshift-client

### DIFF
--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -159,8 +159,8 @@
   with_items:
   - url: "{{ coredns_url }}"
     dest: "{{ bastion_cluster_config_dir }}/coredns_linux_amd64.tgz"
-  - url: "{{ openshift_client_url }}/latest/openshift-client-linux.tar.gz"
-    dest: "{{ bastion_cluster_config_dir }}/openshift-client-linux.tar.gz"
+  - url: "{{ openshift_client_url }}/latest/opm-linux.tar.gz"
+    dest: "{{ bastion_cluster_config_dir }}/opm-linux.tar.gz"
   - url: "{{ openshift_client_url }}/latest/oc-mirror.tar.gz"
     dest: "{{ bastion_cluster_config_dir }}/oc-mirror.tar.gz"
   - url: "{{ openshift_client_url }}/latest/openshift-client-linux.tar.gz"


### PR DESCRIPTION
- removing duplicate openshift-client download
- replacing removed opm-linux download