### PR TITLE
Fix SNO installer for 4.14.  The hostname needs to be set unconditionally

### DIFF
--- a/ansible/roles/sno-wait-hosts-discovered/tasks/main.yml
+++ b/ansible/roles/sno-wait-hosts-discovered/tasks/main.yml
@@ -31,7 +31,6 @@
     }
   with_items: "{{ cluster.results }}"
   no_log: true
-  when: (public_vlan | default(false) | bool) or (lab in cloud_labs) or (use_bastion_registry | default(false))
 
 - name: Patch cluster network settings
   uri:


### PR DESCRIPTION
This change is required to set the hostname correctly.  Otherwise it's set to master-0, which is not the actual hostname of the cluster to be installed, and this error results:

```
TASK [sno-wait-hosts-discovered : Adjust non-by-path selected install disk] ***********************************************************************************************************************
task path: /home/rkrawitz/sandbox/JetLag/ansible/roles/sno-wait-hosts-discovered/tasks/set_install_disk.yml:22
Monday 20 November 2023  12:02:57 -0500 (0:00:00.103)       0:21:00.436 ******* 
fatal: [installhost.example.com]: FAILED! => {"msg": "The conditional check 'current_install_disk != hostvars[sno_hostname].install_disk' failed. The error was: error while evaluating conditional (current_install_disk != hostvars[sno_hostname].install_disk): \"hostvars['master-0']\" is undefined. \"hostvars['master-0']\" is undefined\n\nThe error appears to be in '/home/rkrawitz/sandbox/JetLag/ansible/roles/sno-wait-hosts-discovered/tasks/set_install_disk.yml': line 22, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Adjust non-by-path selected install disk\n  ^ here\n"}
```