### PR TITLE
Disable Bandwidth Impairments by default

### DIFF
--- a/ansible/vars/network-impairments.sample.yml
+++ b/ansible/vars/network-impairments.sample.yml
@@ -14,5 +14,8 @@ egress_packet_loss: 0.02
 ingress_packet_loss: 0.02
 # bandwidth in kilobits
 # Ex: 100000kbps = 100Mbps
-egress_bandwidth: 100000
-ingress_bandwidth: 100000
+# This is disabled by default. Bandwidth impairments are
+# generally implemented in the libvirt xml per host.
+# This bandwidth impairment is global to a hypervisor.
+egress_bandwidth: 0
+ingress_bandwidth: 0


### PR DESCRIPTION
Bandwidth impariments per vm are set in the inventory file. This is a global hypervisor impairment that is not generally used.