### PR TITLE
Have coredns restart automatically. Sometimes coredns starts so fast it

### DIFF
--- a/ansible/roles/hv-coredns/tasks/main.yml
+++ b/ansible/roles/hv-coredns/tasks/main.yml
@@ -34,6 +34,8 @@
 
       [Service]
       ExecStart=/usr/local/bin/coredns -conf=/etc/coredns/Corefile
+      Restart=on-failure
+      RestartSec=5s
 
       [Install]
       WantedBy=multi-user.target


### PR DESCRIPTION
mistakenly detects port 53 in use from the previous running coredns.