### PR TITLE
Fix issue 444

### DIFF
--- a/ansible/roles/bastion-ocp-version/tasks/main.yml
+++ b/ansible/roles/bastion-ocp-version/tasks/main.yml
@@ -14,6 +14,16 @@
     content: "{{ pull_secret }}"
     dest: "/root/.docker/config.json"
 
+- name: RHEL version rhel9 check
+  set_fact:
+    rhel_version: "rhel9"
+  when: ansible_facts['distribution_version'] is version('9.0', '>=')
+
+- name: RHEL version rhel8 check
+  set_fact:
+    rhel_version: "rhel8"
+  when: ansible_facts['distribution_version'] is version('8.9', '<=')
+
 - name: Create directory for bastion ocp-version data
   file:
     path: "{{ ocp_version_path }}"
@@ -25,7 +35,11 @@
     rm -rf openshift-install-linux-*.tar.gz openshift-client-linux-*.tar.gz
     REGISTRY_AUTH_FILE="/root/.docker/config.json" oc.latest adm release extract --tools {{ ocp_release_image }}
     tar -xvf openshift-install-linux-*.tar.gz openshift-install
+    {% if openshift_version is version('4.15', ">=") %}
+    tar -xvf openshift-client-linux-amd64-{{ rhel_version }}*.tar.gz oc kubectl
+    {% else %}
     tar -xvf openshift-client-linux-*.tar.gz oc kubectl
+    {% endif %}
 
 - name: Copy correctly versioned oc/kubectl clients into a pathed directory
   copy:


### PR DESCRIPTION
Check for `rhel_version` and add it to the oc client tarball extract.

The check looks to see if the kernel version starts with a 4 vs 5.

I have not tested against < 4.15 -- not sure if the entire build process has changed.

Fixes #444