### PR TITLE
Turns out validate vars is not the best place to determine the bastion

### DIFF
--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -182,7 +182,7 @@
   with_items:
   -  url: "{{ openshift_client_url }}/latest-4.14/opm-linux.tar.gz"
      dest: "{{ bastion_cluster_config_dir }}/opm-linux.tar.gz"
-  when: rhel_version == "rhel8"
+  when: ansible_facts['distribution_major_version'] is version('8', '==')
 
 - name: Get rhel9 opm
   get_url:
@@ -193,7 +193,7 @@
   with_items:
   -  url: "{{ openshift_client_url }}/latest/opm-linux.tar.gz"
      dest: "{{ bastion_cluster_config_dir }}/opm-linux.tar.gz"
-  when: rhel_version == "rhel9"
+  when: ansible_facts['distribution_major_version'] is version('9', '==')
 
 # We rename oc/kubectl clients as oc.latest and kubectl.latest since they are
 # likely not the actual version of the intended cluster, those specific clients

--- a/ansible/roles/bastion-ocp-version/tasks/main.yml
+++ b/ansible/roles/bastion-ocp-version/tasks/main.yml
@@ -19,6 +19,17 @@
     path: "{{ ocp_version_path }}"
     state: directory
 
+# Set bastion rhel version for ocp 4.15 and newer
+- name: RHEL version rhel9 check
+  set_fact:
+    bastion_rhel_version: "rhel9"
+  when: ansible_facts['distribution_major_version'] is version('9', '==')
+
+- name: RHEL version rhel8 check
+  set_fact:
+    bastion_rhel_version: "rhel8"
+  when: ansible_facts['distribution_major_version'] is version('8', '==')
+
 - name: Extract/Download the openshift-install binary for the specific release
   shell: |
     cd {{ ocp_version_path }}
@@ -26,7 +37,7 @@
     REGISTRY_AUTH_FILE="/root/.docker/config.json" oc.latest adm release extract --tools {{ ocp_release_image }}
     tar -xvf openshift-install-linux-*.tar.gz openshift-install
     {% if openshift_version is version('4.15', ">=") %}
-    tar -xvf openshift-client-linux-amd64-{{ rhel_version }}*.tar.gz oc kubectl
+    tar -xvf openshift-client-linux-amd64-{{ bastion_rhel_version }}*.tar.gz oc kubectl
     {% else %}
     tar -xvf openshift-client-linux-*.tar.gz oc kubectl
     {% endif %}

--- a/ansible/roles/validate-vars/tasks/main.yml
+++ b/ansible/roles/validate-vars/tasks/main.yml
@@ -17,25 +17,15 @@
   fail:
     msg: "Expecting RHEL or Centos for a Bastion OS"
   when:
-  - ansible_distribution is defined
-  - (ansible_distribution|lower != "redhat" and ansible_distribution|lower != "centos")
+  - ansible_facts['distribution'] is defined
+  - (ansible_facts['distribution']|lower != "redhat" and ansible_facts['distribution']|lower != "centos")
 
 - name: Check for RHEL 8.6 (Bastion Validation)
   fail:
     msg: "Upgrade to RHEL 8.6 for podman host network support"
   when:
-  - ansible_distribution is defined
-  - (ansible_distribution|lower == "redhat" and ansible_distribution_version|float < 8.6)
-
-- name: RHEL version rhel9 check
-  set_fact:
-    rhel_version: "rhel9"
-  when: ansible_facts['distribution_version'] is version('9.0', '>=')
-
-- name: RHEL version rhel8 check
-  set_fact:
-    rhel_version: "rhel8"
-  when: ansible_facts['distribution_version'] is version('9.0', '<')
+  - ansible_facts['distribution'] is defined
+  - (ansible_facts['distribution']|lower == "redhat" and ansible_facts['distribution_version'] is version('8.6', '<'))
 
 - name: Set worker_node_count if undefined or empty (bm/rwn)
   set_fact:


### PR DESCRIPTION
rhel version since the create-inventory playbook which runs before a bastion machine is selected includes the validate vars role