### PR TITLE
Fix no distribution version in dict

### DIFF
--- a/ansible/roles/validate-vars/tasks/main.yml
+++ b/ansible/roles/validate-vars/tasks/main.yml
@@ -30,12 +30,16 @@
 - name: RHEL version rhel9 check
   set_fact:
     rhel_version: "rhel9"
-  when: ansible_facts['distribution_version'] is version('9.0', '>=')
+  when:
+  - ansible_distribution is defined
+  - (ansible_distribution|lower == "redhat" and ansible_distribution_version|float >= 9.0)
 
 - name: RHEL version rhel8 check
   set_fact:
     rhel_version: "rhel8"
-  when: ansible_facts['distribution_version'] is version('9.0', '<')
+  when:
+  - ansible_distribution is defined
+  - (ansible_distribution|lower == "redhat" and ansible_distribution_version|float < 9.0)
 
 - name: Set worker_node_count if undefined or empty (bm/rwn)
   set_fact:


### PR DESCRIPTION
Hi all,

I was just attempting to do a scale lab install using jetlag following [BM guide](https://github.com/redhat-performance/jetlag/blob/main/docs/bastion-deploy-bm.md#bastion-setup). I was running into an error where the "distribution_version" key was not found in `ansible_facts`.

Apologies for the brief explanation here. This was the fix I needed to get the Ansible scripts running so I thought I would raise it here in case it was helpful.