### PR TITLE
The role bastion-ocp-version now requires ansible facts and

### DIFF
--- a/ansible/sync-ocp-release.yml
+++ b/ansible/sync-ocp-release.yml
@@ -10,7 +10,7 @@
 
 - name: Sync OCP release container images into bastion registry
   hosts: bastion
-  gather_facts: false
+  gather_facts: true
   vars_files:
   - vars/sync-ocp-release.yml
   roles:

--- a/ansible/vars/sync-ocp-release.sample.yml
+++ b/ansible/vars/sync-ocp-release.sample.yml
@@ -3,4 +3,7 @@
 
 ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.15.2-x86_64
 
+# This should just match the above release image version (Ex: 4.15)
+openshift_version: "4.15"
+
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"


### PR DESCRIPTION
openshift_version to be defined