### PR TITLE
setup r750 configs to match the r650s

### DIFF
--- a/ansible/roles/create-inventory/tasks/main.yml
+++ b/ansible/roles/create-inventory/tasks/main.yml
@@ -219,16 +219,15 @@
     loop_control:
       index_var: idx
 
-  - name: Enable disk2_enable for r650, r730xd, and r930 with nvme0n1
+  - name: Enable disk2_enable for r650, r750, r730xd, and r930 with nvme0n1
     set_fact:
       ocpinventory_hv_nodes: "{{ ocpinventory_hv_nodes[:idx] + [ocpinventory_hv_nodes[idx] | combine({'disk2_enable': true, 'disk2_device': 'nvme0n1'})] + ocpinventory_hv_nodes[idx + 1:] }}"
     when:
-    - (item.pm_addr.split('.')[0]).split('-')[-1] in ['r650', 'r730xd', 'r930']
+    - (item.pm_addr.split('.')[0]).split('-')[-1] in ['r650', 'r750', 'r730xd', 'r930']
     loop: "{{ ocpinventory_hv_nodes }}"
     loop_control:
       index_var: idx
 
-  # Skip r750 type since it has no extra disk
   # Skip fc640 type since it has no extra disk
   # Skip 6018r type since it has only 2 80G disks
 

--- a/ansible/vars/lab.yml
+++ b/ansible/vars/lab.yml
@@ -161,7 +161,8 @@ hw_vm_counts:
       default: 3
       nvme0n1: 3
     r750:
-      default: 2
+      default: 4
+      nvme0n1: 23
     r930:
       default: 5
       nvme0n1: 14


### PR DESCRIPTION
- While r750 are more of a storage class machine they can be used as a substitute for an r650
- Proc and Memory specs on these two machine types are the same
- r750s have 4 1.5T nvme so they can do 2nd disk like the r650s
- Only caveat is if doing ACM precaching for upgrades, you'll need to pair two of the r750s nvme drives together to present 3T of space to match the r650s