### PR TITLE
Update JetLag's assisted-installer version

### DIFF
--- a/ansible/roles/bastion-assisted-installer/defaults/main/main.yml
+++ b/ansible/roles/bastion-assisted-installer/defaults/main/main.yml
@@ -1,12 +1,15 @@
 ---
 # bastion-assisted-installer default vars
 
-assisted_image_service_image: quay.io/edge-infrastructure/assisted-image-service:v2.20.1
-assisted_installer_image: quay.io/edge-infrastructure/assisted-installer:v2.20.1
-assisted_installer_agent_image: quay.io/edge-infrastructure/assisted-installer-agent:v2.20.1
-assisted_installer_controller_image: quay.io/edge-infrastructure/assisted-installer-controller:v2.20.1
-assisted_installer_ui_image: quay.io/edge-infrastructure/assisted-installer-ui:v2.20.3
-assisted_service_image: quay.io/edge-infrastructure/assisted-service:v2.20.1
+assisted_installer_tag: v2.31.0
+assisted_installer_ui_tag: v2.31.0
+
+assisted_image_service_image: quay.io/edge-infrastructure/assisted-image-service:{{ assisted_installer_tag }}
+assisted_installer_image: quay.io/edge-infrastructure/assisted-installer:{{ assisted_installer_tag }}
+assisted_installer_agent_image: quay.io/edge-infrastructure/assisted-installer-agent:{{ assisted_installer_tag }}
+assisted_installer_controller_image: quay.io/edge-infrastructure/assisted-installer-controller:{{ assisted_installer_tag }}
+assisted_installer_ui_image: quay.io/edge-infrastructure/assisted-installer-ui:{{ assisted_installer_ui_tag }}
+assisted_service_image: quay.io/edge-infrastructure/assisted-service:{{ assisted_installer_tag }}
 assisted_postgres_image: quay.io/edge-infrastructure/postgresql-12-centos7
 
 # This will be your bastion machine (if you run setup-bastion playbook)

--- a/ansible/roles/create-ai-cluster/tasks/main.yml
+++ b/ansible/roles/create-ai-cluster/tasks/main.yml
@@ -49,8 +49,6 @@
         "cluster_network_cidr": "{{ cluster_network_cidr }}",
         "cluster_network_host_prefix": "{{ cluster_network_host_prefix }}",
         "service_network_cidr": "{{ service_network_cidr }}",
-        "api_vip": "{{ controlplane_network_api }}",
-        "ingress_vip": "{{ controlplane_network_ingress }}",
         "pull_secret": "{{ pull_secret | to_json }}",
         "ssh_public_key": "{{ lookup('file', ssh_public_key_file) }}",
         "vip_dhcp_allocation": "{{ vip_dhcp_allocation }}",

--- a/ansible/roles/wait-hosts-discovered/tasks/main.yml
+++ b/ansible/roles/wait-hosts-discovered/tasks/main.yml
@@ -82,8 +82,8 @@
     body: {
         "cluster_network_host_prefix": "{{ cluster_network_host_prefix }}",
         "vip_dhcp_allocation": "{{ vip_dhcp_allocation }}",
-        "ingress_vip": "{{ controlplane_network_ingress }}",
-        "api_vip": "{{ controlplane_network_api }}",
+        "ingress_vips": [{"ip": "{{ controlplane_network_ingress }}"}],
+        "api_vips": [{"ip": "{{ controlplane_network_api }}"}],
         "network_type": "{{ networktype }}"
     }
 


### PR DESCRIPTION
I'm open to suggestions about the assisted-installer version(s). I was unable to locate any definitive release/support version information, which is a bit frustrating. Previously the UI container was versioned differently: although I'm using the same version currently for both, I created two separate vars to allow each to be set separately if desired.

Updating beyond v2.29 required a change in the cluster JSON payload from `api_vip` as a string to `api_vips` as a list of objects containing an `"id"` field. While the current workflow passes a network interface name to create the cluster, we don't have an IP as this point and the field is not required: I simply dropped `api_vip` and `ingress_vip` from the "Create cluster" step and constructed the proper object list for the "Patch cluster ingress/api vip address" step.

I've used this to create both bare metal and SNO clusters for the latest patch of each OpenShift release from 4.12.53 through 4.15.3 *and* the 4.16.0-ec.4 developer preview. I didn't do a lot with the constructed clusters, but the assisted installer GUI shows a healthy cluster and I did a few simple `oc` commands from the bastion which seem to suggest all is fine.

Resolves #458