### PR TITLE
Annotate openshift-marketplace ns and catalogSource for DUs

### DIFF
--- a/ansible/roles/sno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/sno-post-cluster-install/tasks/main.yml
@@ -94,15 +94,25 @@
     - openshift_version is version('4.14', "<=") 
     - du_profile
 
-- name: Create openshift-marketplace namespace for ocp 4.15 and higher releases
+- name: Place openshift-marketplace-ns.yaml CR for ocp 4.15 and higher releases DUs
+  template:
+    src: openshift-marketplace-ns.yaml
+    dest: "{{ bastion_cluster_config_dir }}/{{ item.key }}/openshift-marketplace-ns.yaml"
+  loop: "{{ ai_cluster_ids | dict2items }}"
+  when:
+    - use_bastion_registry | default(false)
+    - openshift_version is version('4.15', ">=")
+    - du_profile
+
+- name: Create openshift-marketplace namespace for ocp 4.15 and higher releases DUs
   shell: |
-    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ item.key }}/kubeconfig oc create ns openshift-marketplace
+    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ item.key }}/kubeconfig oc apply -f {{ bastion_cluster_config_dir }}/{{ item.key }}/openshift-marketplace-ns.yaml
   register: marketplace_ns
   retries: 120
   delay: 2
   until: not marketplace_ns.failed
   loop: "{{ ai_cluster_ids | dict2items }}"
-  when: 
+  when:
     - use_bastion_registry | default(false)
     - openshift_version is version('4.15', ">=")
     - du_profile
@@ -116,6 +126,16 @@
   until: not icsp_apply.failed
   loop: "{{ ai_cluster_ids | dict2items }}"
   when: use_bastion_registry | default(false)
+
+- name: Annotate catalogSource.yaml to pin opm to reserved cores for DUs
+  shell: |
+    yq -i '.metadata.annotations."target.workload.openshift.io/management" = "{\"effect\": \"PreferredDuringScheduling\"}"' {{ bastion_cluster_config_dir }}/olm-mirror-{{ operator_index_name }}-{{ operator_index_tag }}/catalogSource.yaml
+  register: catsource_annotate
+  retries: 120
+  delay: 2
+  until: not catsource_annotate.failed
+  loop: "{{ ai_cluster_ids | dict2items }}"
+  when: use_bastion_registry | default(false) and du_profile
 
 - name: Apply olm-mirror catalogSource on bastion registry clusters
   shell: |

--- a/ansible/roles/sno-post-cluster-install/templates/openshift-marketplace-ns.yaml
+++ b/ansible/roles/sno-post-cluster-install/templates/openshift-marketplace-ns.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: v1.25
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit-version: v1.25
+    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/warn-version: v1.25
+  name: "openshift-marketplace"


### PR DESCRIPTION
1. Added a template for openshift-marketplace ns with correct annotations for vDUs corresponding to https://github.com/openshift-kni/cnf-features-deploy/blob/master/ztp/source-crs/extra-manifest/09-openshift-marketplace-ns.yaml
2. Updated post install tasks to create openshift-markeplace ns and annotate CatalogSource accordingly for DUs