### PR TITLE
Adding Crucible install on the bastion

### DIFF
--- a/ansible/roles/bastion-install/defaults/main.yml
+++ b/ansible/roles/bastion-install/defaults/main.yml
@@ -8,6 +8,11 @@ minio_client_url: https://dl.min.io/client/mc/release/linux-amd64/mc
 openshift_client_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp
 yq_url: https://github.com/mikefarah/yq/releases/download/v4.40.3/yq_linux_amd64.tar.gz
 
+# Crucible specific vars
+install_rh_crucible: false
+rh_crucible_url: https://github.com/perftool-incubator/crucible
+
+
 # Since the use of tc on the bastion machine is rare and only for remote worker node testing in scale/alias labs, we
 # disable rebooting the bastion machine by default.
 bastion_install_tc_reboot: false

--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -265,3 +265,15 @@
   file:
     path: "{{ promdump_tarball }}"
     state: absent
+
+- name: Download Red Hat Crucible
+  ansible.builtin.git:
+    repo: "{{ rh_crucible_url }}"
+    dest: /tmp/crucible
+  environment:
+    GIT_SSL_NO_VERIFY: "False"
+  when: install_rh_crucible
+
+- name: Install Red Hat Crucible
+  command: chdir=/tmp/crucible bash rh-install-crucible.sh
+  when: install_rh_crucible


### PR DESCRIPTION
`rh_crucible_url` is using a boiler plate URL.

This work depends on the `rh_crucible_url` pointing to AndrewT's crucible gitlab repo.

Closes #465