### PR TITLE
Adjust all guides for usage from bastion

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,25 +66,25 @@ Versions:
 Update to RHEL 8.9
 
 ```console
-[root@xxx-xxx-xxx-r640 ~]# cat /etc/redhat-release
+[root@<bastion> ~]# cat /etc/redhat-release
 Red Hat Enterprise Linux release 8.2 (Ootpa)
 
-[root@xxx-xxx-xxx-r640 ~]# ./update-latest-rhel-release.sh 8.9
+[root@<bastion> ~]# ./update-latest-rhel-release.sh 8.9
 ...
-[root@xxx-xxx-xxx-r640 ~]# dnf update -y
+[root@<bastion> ~]# dnf update -y
 ...
-[root@xxx-xxx-xxx-r640 ~]# reboot
+[root@<bastion> ~]# reboot
 ...
-[root@xxx-xxx-xxx-r640 ~]# cat /etc/redhat-release
+[root@<bastion> ~]# cat /etc/redhat-release
 Red Hat Enterprise Linux release 8.9 (Ootpa)
 ```
 
 Installing Ansible via bootstrap (requires python3-pip)
 
 ```console
-[root@xxx-xxx-xxx-r640 jetlag]# source bootstrap.sh
+[root@<bastion> jetlag]# source bootstrap.sh
 ...
-(.ansible) [root@xxx-xxx-xxx-r640 jetlag]#
+(.ansible) [root@<bastion> jetlag]#
 ```
 
 Pre-reqs for Supermicro hardware:
@@ -111,8 +111,8 @@ but might have to be edited for specific scenario/hardware usage. You can also [
 Start by editing the vars
 
 ```console
-(.ansible) [root@xxx-xxx-xxx-r640 jetlag]# cp ansible/vars/all.sample.yml ansible/vars/all.yml
-(.ansible) [root@xxx-xxx-xxx-r640 jetlag]# vi ansible/vars/all.yml
+(.ansible) [root@<bastion> jetlag]# cp ansible/vars/all.sample.yml ansible/vars/all.yml
+(.ansible) [root@<bastion> jetlag]# vi ansible/vars/all.yml
 ```
 
 Make sure to set/review the following vars:
@@ -130,7 +130,7 @@ Make sure to set/review the following vars:
 Set your pull-secret in `pull_secret.txt` in repo base directory. Example:
 
 ```console
-(.ansible) [root@xxx-xxx-xxx-r640 jetlag]# cat pull_secret.txt
+(.ansible) [root@<bastion> jetlag]# cat pull_secret.txt
 {
   "auths": {
 ...
@@ -139,13 +139,13 @@ Set your pull-secret in `pull_secret.txt` in repo base directory. Example:
 Run create-inventory playbook
 
 ```console
-(.ansible) [root@xxx-xxx-xxx-r640 jetlag]# ansible-playbook ansible/create-inventory.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook ansible/create-inventory.yml
 ```
 
 Run setup-bastion playbook
 
 ```console
-(.ansible) [root@xxx-xxx-xxx-r640 jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/setup-bastion.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/setup-bastion.yml
 ```
 
 Run deploy for either bm/rwn/sno playbook with inventory created by create-inventory playbook
@@ -153,43 +153,43 @@ Run deploy for either bm/rwn/sno playbook with inventory created by create-inven
 Bare Metal Cluster:
 
 ```console
-(.ansible) [root@xxx-xxx-xxx-r640 jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/bm-deploy.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/bm-deploy.yml
 ```
 See [troubleshooting.md](https://github.com/redhat-performance/jetlag/blob/main/docs/troubleshooting.md) in [docs](https://github.com/redhat-performance/jetlag/tree/main/docs) directory for BM install related issues
 
 Remote Worker Node Cluster:
 
 ```console
-(.ansible) [root@xxx-xxx-xxx-r640 jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/rwn-deploy.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/rwn-deploy.yml
 ```
 
 Single Node OpenShift:
 
 ```console
-(.ansible) [root@xxx-xxx-xxx-r640 jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/sno-deploy.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/sno-deploy.yml
 ```
 
 Interact with your cluster from your bastion machine:
 
 ```console
-(.ansible) [root@xxx-xxx-xxx-r640 jetlag]# export KUBECONFIG=/root/bm/kubeconfig
-(.ansible) [root@xxx-xxx-xxx-r640 jetlag]# oc get no
+(.ansible) [root@<bastion> jetlag]# export KUBECONFIG=/root/bm/kubeconfig
+(.ansible) [root@<bastion> jetlag]# oc get no
 NAME               STATUS   ROLES                         AGE    VERSION
 xxx-h02-000-r650   Ready    control-plane,master,worker   73m    v1.25.7+eab9cc9
 xxx-h03-000-r650   Ready    control-plane,master,worker   103m   v1.25.7+eab9cc9
 xxx-h05-000-r650   Ready    control-plane,master,worker   105m   v1.25.7+eab9cc9
-(.ansible) [root@xxx-xxx-xxx-r640 jetlag]# cat /root/bm/kubeadmin-password
+(.ansible) [root@<bastion> jetlag]# cat /root/bm/kubeadmin-password
 xxxxx-xxxxx-xxxxx-xxxxx
 ```
 
 And for SNO
 
 ```console
-(.ansible) [root@xxx-xxx-xxx-r640 jetlag]# export KUBECONFIG=/root/sno/xxx-h02-000-r650/kubeconfig
-(.ansible) [root@xxx-xxx-xxx-r640 jetlag]# oc get no
+(.ansible) [root@<bastion> jetlag]# export KUBECONFIG=/root/sno/xxx-h02-000-r650/kubeconfig
+(.ansible) [root@<bastion> jetlag]# oc get no
 NAME      STATUS   ROLES                         AGE   VERSION
 xxx-h02-000-r650   Ready    control-plane,master,worker   30h   v1.28.6+0fb4726
-(.ansible) [root@xxx-xxx-xxx-r640 jetlag]# cat /root/sno/xxx-h02-000-r650/kubeadmin-password
+(.ansible) [root@<bastion> jetlag]# cat /root/sno/xxx-h02-000-r650/kubeadmin-password
 xxxxx-xxxxx-xxxxx-xxxxx
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,6 @@ Three separate layouts of clusters can be deployed:
 
 Each cluster layout requires a bastion machine which is the first machine out of your lab "cloud" allocation. The bastion machine will host the assisted-installer service and serve as a router for clusters with a private machine network. BM and RWN layouts produce a single cluster consisting of 3 control-plane nodes and X number of worker or remote worker nodes. The worker node count can also be 0 such that your bare metal cluster is a compact 3 node cluster with schedulable control-plane nodes. SNO layout creates an SNO cluster per available machine after fulfilling the bastion machine requirement. Lastly, BM/RWN cluster types will allocate any unused machines under the `hv` ansible group which stands for hypervisor nodes. The `hv` nodes can host vms for additional clusters that can be deployed from the hub cluster. (For ACM/MCE testing)
 
-We recommend that you set up Jetlag on the bastion machine and run playbooks
-from there. This will give faster access to the machines being configured, and
-it also provides an environment that can easily be shared for debugging if
-necessary. However you can run Jetlag playbooks from a remote host (for example,
-your laptop) as long as you can connect to the bastion machine in your cloud
-allocation.
-
-
 _**Table of Contents**_
 
 <!-- TOC -->
@@ -101,7 +93,16 @@ Pre-reqs for Supermicro hardware:
 
 ## Cluster Deployment Usage
 
-There are three main files to configure. The inventory file is generated but might have to be edited for specific scenario/hardware usage:
+We recommend that you set up Jetlag on the bastion machine and run playbooks
+from there. This will give faster access to the machines being configured, and
+it also provides an environment that can easily be shared for debugging if
+necessary. However you can run Jetlag playbooks from a remote host (for example,
+your laptop) as long as you can connect to the bastion machine in your cloud
+allocation.
+
+There are three main files to configure. The inventory file is generated (for SCALE lab and IBM Cloud),
+but might have to be edited for specific scenario/hardware usage. You can also [manually create a
+"Bring Your Own Lab"](docs/bastion-deploy-bm-byol) inventory file.
 
 * `ansible/vars/all.yml` - An ansible vars file (Sample provided `ansible/vars/all.sample.yml`)
 * `pull_secret.txt` - Your OCP pull secret, download from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads)

--- a/README.md
+++ b/README.md
@@ -117,23 +117,39 @@ Start by editing the vars
 
 Make sure to set/review the following vars:
 
-* `lab` - either `alias` or `scalelab`
-* `lab_cloud` - the cloud within the lab environment (Example: `cloud42`)
-* `cluster_type` - either `bm`, `rwn`, or `sno` for the respective cluster layout
-* `worker_node_count` - applies to bm and rwn cluster types for the desired worker count, ideal for leaving left over inventory hosts for other purposes
-* `sno_node_count` - applies to sno cluster type for the desired sno count, ideal for leaving left over inventory hosts for other purposes
-* `bastion_lab_interface` - set to the bastion machine's lab accessible interface
-* `bastion_controlplane_interface` - set to the interface in which the bastion will be networked to the deployed ocp cluster
-* `controlplane_lab_interface` - applies to bm and rwn cluster types and should map to the nodes interface in which the lab provides dhcp to and also required for public routable vlan based sno deployment(to disable this interface)
-* More customization such as cluster_network and service_network can be supported as extra vars, check each ansible roles default vars file for variable names and options
+| Variable | Meaning |
+| - | - |
+| `lab` | either `alias` or `scalelab`
+| `lab_cloud` | the cloud within the lab environment (Example: `cloud42`)
+| `cluster_type` | either `bm`, `rwn`, or `sno` for the respective cluster layout
+| `worker_node_count` | applies to bm and rwn cluster types for the desired worker count, ideal for leaving left over inventory hosts for other purposes
+| `sno_node_count` | applies to sno cluster type for the desired sno count, ideal for leaving left over inventory hosts for other purposes
+| `bastion_lab_interface` | set to the bastion machine's lab accessible interface
+| `bastion_controlplane_interface` | set to the interface in which the bastion will be networked to the deployed ocp cluster
+| `controlplane_lab_interface` | applies to bm and rwn cluster types and should map to the nodes interface in which the lab provides dhcp to and also required for public routable vlan based sno deployment(to disable this interface)
 
-Set your pull-secret in `pull_secret.txt` in repo base directory. Example:
+More customization such as `cluster_network` and `service_network` can be supported as extra vars, check each ansible role default vars file for variable names and options.
+
+Save your pull-secret from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) in `pull_secret.txt` in the Jetlag repo base directory, for example by using the "Copy" button on the web page, and then pasting the clipboard text into a `cat > pull_secret.txt` command like this:
 
 ```console
-(.ansible) [root@<bastion> jetlag]# cat pull_secret.txt
+(.ansible) [root@<bastion> jetlag]# cat >pull_secret.txt
 {
   "auths": {
-...
+    "quay.io": {
+      "auth": "XXXXXXX",
+      "email": "XXXXXXX"
+    },
+    "registry.connect.redhat.com": {
+      "auth": "XXXXXXX",
+      "email": "XXXXXXX"
+    },
+    "registry.redhat.io": {
+      "auth": "XXXXXXX",
+      "email": "XXXXXXX"
+    }
+  }
+}
 ```
 
 Run create-inventory playbook

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Tooling to install clusters for testing via an on-prem [Assisted Installer](http
 
 Three separate layouts of clusters can be deployed:
 
-* BM - Bare Metal - 3 control-plane nodes, X number of worker nodes
-* RWN - Remote Worker Node - 3 control-plane/worker nodes, X number of remote worker nodes
-* SNO - Single Node OpenShift - 1 OpenShift Master/Worker Node "cluster" per available hardware resource
+| Layout | Meaning | Description |
+| - | - | - |
+| BM | Bare Metal | 3 control-plane nodes, X number of worker nodes
+| RWN | Remote Worker Node | 3 control-plane/worker nodes, X number of remote worker nodes
+| SNO | Single Node OpenShift | 1 OpenShift Master/Worker Node "cluster" per available hardware resource
 
 Each cluster layout requires a bastion machine which is the first machine out of your lab "cloud" allocation. The bastion machine will host the assisted-installer service and serve as a router for clusters with a private machine network. BM and RWN layouts produce a single cluster consisting of 3 control-plane nodes and X number of worker or remote worker nodes. The worker node count can also be 0 such that your bare metal cluster is a compact 3 node cluster with schedulable control-plane nodes. SNO layout creates an SNO cluster per available machine after fulfilling the bastion machine requirement. Lastly, BM/RWN cluster types will allocate any unused machines under the `hv` ansible group which stands for hypervisor nodes. The `hv` nodes can host vms for additional clusters that can be deployed from the hub cluster. (For ACM/MCE testing)
 
@@ -104,9 +106,11 @@ There are three main files to configure. The inventory file is generated (for SC
 but might have to be edited for specific scenario/hardware usage. You can also [manually create a
 "Bring Your Own Lab"](docs/bastion-deploy-bm-byol) inventory file.
 
-* `ansible/vars/all.yml` - An ansible vars file (Sample provided `ansible/vars/all.sample.yml`)
-* `pull_secret.txt` - Your OCP pull secret, download from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads)
-* `ansible/inventory/$CLOUDNAME.local` - The generated inventory file (Samples provided in `ansible/inventory`)
+| File | Description |
+| - | - |
+| `ansible/vars/all.yml` | An ansible vars file (Sample provided `ansible/vars/all.sample.yml`)
+| `pull_secret.txt` | Your OCP pull secret, download from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads)
+| `ansible/inventory/$CLOUDNAME.local` | The generated inventory file (Samples provided in `ansible/inventory`)
 
 Start by editing the vars
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jetlag
+# Jetlag
 
 Tooling to install clusters for testing via an on-prem [Assisted Installer](https://github.com/openshift/assisted-installer) in the Red Hat Scale/Alias Lab and bare metal servers in IBMcloud.
 
@@ -9,6 +9,14 @@ Three separate layouts of clusters can be deployed:
 * SNO - Single Node OpenShift - 1 OpenShift Master/Worker Node "cluster" per available hardware resource
 
 Each cluster layout requires a bastion machine which is the first machine out of your lab "cloud" allocation. The bastion machine will host the assisted-installer service and serve as a router for clusters with a private machine network. BM and RWN layouts produce a single cluster consisting of 3 control-plane nodes and X number of worker or remote worker nodes. The worker node count can also be 0 such that your bare metal cluster is a compact 3 node cluster with schedulable control-plane nodes. SNO layout creates an SNO cluster per available machine after fulfilling the bastion machine requirement. Lastly, BM/RWN cluster types will allocate any unused machines under the `hv` ansible group which stands for hypervisor nodes. The `hv` nodes can host vms for additional clusters that can be deployed from the hub cluster. (For ACM/MCE testing)
+
+We recommend that you set up Jetlag on the bastion machine and run playbooks
+from there. This will give faster access to the machines being configured, and
+it also provides an environment that can easily be shared for debugging if
+necessary. However you can run Jetlag playbooks from a remote host (for example,
+your laptop) as long as you can connect to the bastion machine in your cloud
+allocation.
+
 
 _**Table of Contents**_
 

--- a/ansible/vars/all.sample.yml
+++ b/ansible/vars/all.sample.yml
@@ -41,7 +41,7 @@ enable_fips: false
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
 # Place your pull_secret.txt in the base directory of the cloned jetlag repo, Example:
-# [root@<bastion> jetlag]$ ls pull_secret.txt
+# [root@<bastion> jetlag]# ls pull_secret.txt
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
 
 ################################################################################

--- a/ansible/vars/all.sample.yml
+++ b/ansible/vars/all.sample.yml
@@ -41,7 +41,7 @@ enable_fips: false
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
 # Place your pull_secret.txt in the base directory of the cloned jetlag repo, Example:
-# [user@fedora jetlag]$ ls pull_secret.txt
+# [root@<bastion> jetlag]$ ls pull_secret.txt
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
 
 ################################################################################

--- a/ansible/vars/ibmcloud.sample.yml
+++ b/ansible/vars/ibmcloud.sample.yml
@@ -29,7 +29,7 @@ networktype: OVNKubernetes
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
 # Place your pull_secret.txt in the base directory of the cloned jetlag repo, Example:
-# [root@<bastion> jetlag]$ ls pull_secret.txt
+# [root@<bastion> jetlag]# ls pull_secret.txt
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
 
 ################################################################################

--- a/ansible/vars/ibmcloud.sample.yml
+++ b/ansible/vars/ibmcloud.sample.yml
@@ -29,7 +29,7 @@ networktype: OVNKubernetes
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
 # Place your pull_secret.txt in the base directory of the cloned jetlag repo, Example:
-# [user@fedora jetlag]$ ls pull_secret.txt
+# [root@<bastion> jetlag]$ ls pull_secret.txt
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
 
 ################################################################################

--- a/docs/bastion-deploy-bm-byol.md
+++ b/docs/bastion-deploy-bm-byol.md
@@ -59,6 +59,10 @@ Number of key(s) added: 2
 [root@<bastion> ~]
 ```
 
+Now log in to the bastion (with `ssh root@<bastion>` if you copied your public key above,
+or using the bastion root account password if not), because the remaining commands
+should be executed from the bastion.
+
 3. Install some additional tools to help after reboot
 
 ```console
@@ -127,10 +131,11 @@ for subsequent steps:
 [root@<bastion> jetlag]
 ```
 
-6. Download your pull_secret.txt from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) and place it in the root directory of the local `jetlag` repo. You'll find the Pull Secret near the end of the long downloads
-page, in the section labeled "Tokens". You can either click the "Download" button and then copy `~/Downloads/pull-secret.txt` to `./pull_secret.txt` (notice that Jetlag expects an underscore (`_`) while the file will download with a hyphen (`-`)),
-*or* click on the "Copy" button, and then paste into the terminal after typing `cat >pull_secret.txt` to create the expected
-filename:
+6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
+the long downloads page, in the section labeled "Tokens". You can either click the "Download" button and then copy the
+downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
+file will download with a hyphen (`-`)), *or* click on the "Copy" button, and then paste into the terminal after typing
+`cat >pull_secret.txt` on the bastion to create the expected filename:
 
 ```console
 [root@<bastion> jetlag]# cat >pull_secret.txt
@@ -285,7 +290,7 @@ enable_fips: false
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
 # Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
-# [user@fedora jetlag]$ ls pull_secret.txt
+# [root@<bastion> jetlag]$ ls pull_secret.txt
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
 
 ################################################################################
@@ -425,7 +430,7 @@ If everything goes well, you should have a cluster in about 60-70 minutes. You c
 ```console
 (.ansible) [root@<bastion> jetlag]# export KUBECONFIG=/root/bm/kubeconfig
 (.ansible) [root@<bastion> jetlag]# oc get no
-NAME              TATUS   ROLES                  AGE   VERSION
+NAME              STATUS   ROLES                  AGE   VERSION
 control-plane-0   Ready    control-plane,master   36m   v1.27.6+f67aeb3
 control-plane-1   Ready    control-plane,master   61m   v1.27.6+f67aeb3
 control-plane-2   Ready    control-plane,master   63m   v1.27.6+f67aeb3

--- a/docs/bastion-deploy-bm-byol.md
+++ b/docs/bastion-deploy-bm-byol.md
@@ -132,10 +132,10 @@ for subsequent steps:
 ```
 
 6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
-the long downloads page, in the section labeled "Tokens". You can either click the "Download" button and then copy the
+the long downloads page, in the section labeled "Tokens". You can either click the "Download" button, and then copy the
 downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
-file will download with a hyphen (`-`)), *or* click on the "Copy" button, and then paste into the terminal after typing
-`cat >pull_secret.txt` on the bastion to create the expected filename:
+file will download with a hyphen (`-`)); *or* click on the "Copy" button, and then paste the clipboard into the terminal
+after typing `cat >pull_secret.txt` on the bastion to create the expected filename:
 
 ```console
 [root@<bastion> jetlag]# cat >pull_secret.txt

--- a/docs/bastion-deploy-bm-byol.md
+++ b/docs/bastion-deploy-bm-byol.md
@@ -1,6 +1,6 @@
-# Deploy a Bare Metal cluster via jetlag from a non-standard lab, BYOL (Bring Your Own Lab), quickstart
+# Deploy a Bare Metal cluster via Jetlag from a non-standard lab, BYOL (Bring Your Own Lab), quickstart
 
-Assuming that you receive a set of machines to install OCP, this guide walks you through getting a bare-metal cluster installed on this allocation. For the purposes of the guide, the machines used are Dell r660s and r760s running RHEL 9.2. In a BYOL (or with any non-homogeneous allocation containing machines of different models) due to the non-standard interface names and NIC PCI slots, you must craft jetlag's inventory file by hand.
+Assuming that you receive a set of machines to install OCP, this guide walks you through getting a bare-metal cluster installed on this allocation. For the purposes of the guide, the machines used are Dell r660s and r760s running RHEL 9.2. In a BYOL (or with any non-homogeneous allocation containing machines of different models) due to the non-standard interface names and NIC PCI slots, you must craft Jetlag's inventory file by hand.
 
 In other words, the `create-inventory` playbook is not used with BYOL. You must instead create your own inventory file manually, which means gathering information regarding the machines such as NIC names and MAC addresses. Therefore, thinking about simplifying this step, it is recommended to group machines of same/similar models wisely to be the cluster's control-plane and worker nodes.
 
@@ -28,7 +28,6 @@ _**Table of Contents**_
 - [Appendix - Troubleshooting, etc.](#appendix---troubleshooting-etc)
 <!-- /TOC -->
 
-
 <!-- Bastion setup is duplicated in multiple files and should be kept in sync!
      - bastion-deploy-bm-byol.md
      - bastion-bm-ibmcloud.md
@@ -46,24 +45,24 @@ listed in your cloud platform's standard inventory display.
 repeatedly log in from your laptop:
 
 ```console
-[user@fedora ~]$ ssh-copy-id root@xxx-h01-000-r650.example.redhat.com
+[user@<local> ~]$ ssh-copy-id root@<bastion>
 /usr/bin/ssh-copy-id: INFO: attempting to log in with the new key(s), to filter out any that are already installed
 /usr/bin/ssh-copy-id: INFO: 2 key(s) remain to be installed -- if you are prompted now it is to install the new keys
-Warning: Permanently added 'xxx-h01-000-r650.example.redhat.com,x.x.x.x' (ECDSA) to the list of known hosts.
-root@xxx-h01-000-r650.example.redhat.com's password:
+Warning: Permanently added '<bastion>,x.x.x.x' (ECDSA) to the list of known hosts.
+root@<bastion>'s password:
 
 Number of key(s) added: 2
 
 # Now try logging into the machine, and confirm that only the expected key(s)
 # were added to ~/.ssh/known_hosts
-[user@fedora ~] ssh root@xxx-h01-000-r650.example.redhat.com
-[user@fedora ~]
+[user@<local> ~] ssh root@<bastion>
+[root@<bastion> ~]
 ```
 
 3. Install some additional tools to help after reboot
 
 ```console
-[root@xxx-r660 ~]# dnf install tmux git python3-pip sshpass -y
+[root@<bastion> ~]# dnf install tmux git python3-pip sshpass -y
 Updating Subscription Management repositories.
 ...
 Complete!
@@ -73,7 +72,7 @@ Complete!
 local ansible interactions:
 
 ```console
-[root@xxx-r660 ~]# ssh-keygen
+[root@<bastion> ~]# ssh-keygen
 Generating public/private rsa key pair.
 Enter file in which to save the key (/root/.ssh/id_rsa):
 Enter passphrase (empty for no passphrase):
@@ -81,12 +80,12 @@ Enter same passphrase again:
 Your identification has been saved in /root/.ssh/id_rsa.
 Your public key has been saved in /root/.ssh/id_rsa.pub.
 The key fingerprint is:
-SHA256:uA61+n0w3Dht4/oIy1IKXrSgt9tfC/8zjICd7LJ550s root@xxx-r660.machine.com
+SHA256:uA61+n0w3Dht4/oIy1IKXrSgt9tfC/8zjICd7LJ550s root@<bastion>
 The key's randomart image is:
 +---[RSA 3072]----+
 ...
 +----[SHA256]-----+
-[root@xxx-r660 ~]# ssh-copy-id root@localhost
+[root@<bastion> ~]# ssh-copy-id root@localhost
 /usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/root/.ssh/id_rsa.pub"
 The authenticity of host 'localhost (127.0.0.1)' can't be established.
 ECDSA key fingerprint is SHA256:fvvO3NLxT9FPcoOKQ9ldVdd4aQnwuGVPwa+V1+/c4T8.
@@ -97,15 +96,16 @@ root@localhost's password:
 
 Number of key(s) added: 1
 
-Now try logging into the machine, with:   "ssh 'root@localhost'"
-and check to make sure that only the key(s) you wanted were added.
-[root@xxx-r660 ~]#
+Now try logging into the machine and check to make sure that only the key(s) you wanted were added:
+```console
+[root@<bastion> ~] ssh root@localhost
+[root@<bastion> ~]#
 ```
 
-5. Clone `jetlag`
+5. Clone the `jetlag` GitHub repo
 
 ```console
-[root@xxx-r660 ~]# git clone https://github.com/redhat-performance/jetlag.git
+[root@<bastion> ~]# git clone https://github.com/redhat-performance/jetlag.git
 Cloning into 'jetlag'...
 remote: Enumerating objects: 4510, done.
 remote: Counting objects: 100% (4510/4510), done.
@@ -119,10 +119,21 @@ The `git clone` command will normally set the local head to the Jetlag repo's
 `main` branch. To set your local head to a different branch or tag (for example,
 a development branch), you can add `-b <name>` to the command.
 
-6. Download your pull_secret.txt from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) and place it in the root directory of `jetlag`
+Change your working directory to the repo's `jetlag` directory, which we'll assume
+for subsequent steps:
 
 ```console
-[root@xxx-r660 jetlag]# cat pull_secret.txt
+[root@<bastion> ~] cd jetlag
+[root@<bastion> jetlag]
+```
+
+6. Download your pull_secret.txt from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) and place it in the root directory of the local `jetlag` repo. You'll find the Pull Secret near the end of the long downloads
+page, in the section labeled "Tokens". You can either click the "Download" button and then copy `~/Downloads/pull-secret.txt` to `./pull_secret.txt` (notice that Jetlag expects an underscore (`_`) while the file will download with a hyphen (`-`)),
+*or* click on the "Copy" button, and then paste into the terminal after typing `cat >pull_secret.txt` to create the expected
+filename:
+
+```console
+[root@<bastion> jetlag]# cat >pull_secret.txt
 {
   "auths": {
     "quay.io": {
@@ -141,35 +152,34 @@ a development branch), you can add `-b <name>` to the command.
 }
 ```
 
-7. Change to `jetlag` directory, and then run `source bootstrap.sh`. This will
-activate a local virtual Python environment configured with the Jetlag and
+7. Execute the bootstrap script in the current shell, with `source bootstrap.sh`.
+This will activate a local virtual Python environment configured with the Jetlag and
 Ansible dependencies.
 
 ```console
-[root@xxx-r660 ~]# cd jetlag/
-[root@xxx-r660 jetlag]# source bootstrap.sh
+[root@<bastion> jetlag]# source bootstrap.sh
 Collecting pip
 ...
-(.ansible) [root@xxx-r660 jetlag]#
+(.ansible) [root@<bastion> jetlag]#
 ```
 
 You can re-enter that virtual environment when you log in to the bastion again
 with:
 
 ```console
-[root@xxx-r660 ~]# cd jetlag
-[root@xxx-r660 ~]# source .ansible/bin/activate
+[root@<bastion> ~]# cd jetlag
+[root@<bastion> jetlag]# source .ansible/bin/activate
 ```
 
 <!-- End of duplicated setup text -->
 
-## Create your custom vars all.yml
+## Configure Ansible vars in `all.yml`
 
 Copy the vars file and edit it to create the inventory with your BYOL lab info:
 
 ```console
-(.ansible) [root@xxx-r660 jetlag]# cp ansible/vars/all.sample.yml ansible/vars/all.yml
-(.ansible) [root@xxx-r660 jetlag]# vi ansible/vars/all.yml
+(.ansible) [root@<bastion> jetlag]# cp ansible/vars/all.sample.yml ansible/vars/all.yml
+(.ansible) [root@<bastion> jetlag]# vi ansible/vars/all.yml
 ```
 
 ### Lab & cluster infrastructure vars
@@ -191,7 +201,7 @@ Only change `networktype` if you need to test something other than `OVNKubernete
 
 ### Bastion node vars
 
-Set `smcipmitool_url` to the location of the Supermicro SMCIPMITool binary. Since you must accept a EULA in order to download, it is suggested to download the file and place it onto a local http server, that is accessible to your laptop or deployment machine. You can then always reference that URL. Alternatively, you can download it to the `ansible/` directory of your jetlag repo clone and rename the file to `smcipmitool.tar.gz`. You can find the file [here](https://www.supermicro.com/SwDownload/SwSelect_Free.aspx?cat=IPMI).
+Set `smcipmitool_url` to the location of the Supermicro SMCIPMITool binary. Since you must accept a EULA in order to download, it is suggested to download the file and place it onto a local http server, that is accessible to your laptop or deployment machine. You can then always reference that URL. Alternatively, you can download it to the `ansible/` directory of your Jetlag repo clone and rename the file to `smcipmitool.tar.gz`. You can find the file [here](https://www.supermicro.com/SwDownload/SwSelect_Free.aspx?cat=IPMI).
 
 In case of BYOL, the lab itself determines the values of `bastion_lab_interface` and `bastion_controlplane_interface`.
 
@@ -223,7 +233,7 @@ No extra vars are needed for an ipv4 bare metal cluster.
 
 Note that the `all.yml` and the `byol.local` inventory file following this section, only reflect that of an ipv4 connected install.
 
-## Review vars all.yml
+## Review vars `all.yml`
 
 The `ansible/vars/all.yml` now resembles ...
 
@@ -270,7 +280,7 @@ enable_fips: false
 
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
-# Place your pull_secret.txt in the base directory of the cloned jetlag repo, Example:
+# Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
 # [user@fedora jetlag]$ ls pull_secret.txt
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
 
@@ -326,7 +336,7 @@ Choose wisely which server for which role: bastion, masters and workers. Make su
 - Record the names and MACs of their L3 network NIC to be used for the inventory.
 - Choose the control-plane NICs, the L2 NIC interface.
 - Record the interface names and MACs of the chosen control-plane interfaces.
-- The correct DNS needs to be changed in `ansible/vars/lab.yml`. Otherwise some tasks, e.g., pulling images from quay.io when `jetlag` has already touched `/etc/resolv.conf`, will fail.
+- The correct DNS needs to be changed in `ansible/vars/lab.yml`. Otherwise some tasks, e.g., pulling images from quay.io when Jetlag has already touched `/etc/resolv.conf`, will fail.
 - Make sure you have root access to the bmc, i.e., iDRAC for Dell. In the example below, the *bmc_user* and *bmc_password* are set to root and password.
 
 Now, create the `/ansible/inventory/byol.local` inventory file and edit it with the info from above manually from your BYOL lab:
@@ -391,27 +401,27 @@ You can see the real example file for the above inventory [here](https://github.
 Next run the `setup-bastion.yml` playbook ...
 
 ```console
-(.ansible) [rootxxx-r660 jetlag]# ansible-playbook -i ansible/inventory/byol.local ansible/setup-bastion.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/byol.local ansible/setup-bastion.yml
 ...
 ```
 
 Finally run the `bm-deploy.yml` playbook ...
 
 ```console
-(.ansible) [root@xxx-r660 jetlag]# ansible-playbook -i ansible/inventory/byol.local ansible/bm-deploy.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/byol.local ansible/bm-deploy.yml
 ...
 ```
 
 ## Monitor install and interact with cluster
 
-It is suggested to monitor the first deployment to see if anything hangs on boot, or if the virtual media is incorrect according to the bmc. You can monitor the deployment by opening the bastion's GUI to assisted-installer (port 8080, ex `xxx-r660.machine.com:8080/clusters`), opening the consoles via the bmc, i.e., idrac for Dell, of each machine, and once the machines are booted, you can directly connect to them and tail log files.
+It is suggested to monitor the first deployment to see if anything hangs on boot, or if the virtual media is incorrect according to the b. You can monitor the deployment by opening the bastion's GUI to assisted-installer (port 8080, ex `xxx-r660.machine.com:8080/clusters`), opening the consoles via the bmc, i.e., idrac for Dell, of each machine, and once the machines are booted, you can directly connect to them and tail log files.
 
 If everything goes well, you should have a cluster in about 60-70 minutes. You can interact with the cluster from the bastion.
 
 ```console
-(.ansible) [root@xxx-r660]# export KUBECONFIG=/root/bm/kubeconfig
-(.ansible) [root@xxx-r660]# oc get no
-NAME              STATUS   ROLES                  AGE   VERSION
+(.ansible) [root@<bastion> jetlag]# export KUBECONFIG=/root/bm/kubeconfig
+(.ansible) [root@<bastion> jetlag]# oc get no
+NAME              TATUS   ROLES                  AGE   VERSION
 control-plane-0   Ready    control-plane,master   36m   v1.27.6+f67aeb3
 control-plane-1   Ready    control-plane,master   61m   v1.27.6+f67aeb3
 control-plane-2   Ready    control-plane,master   63m   v1.27.6+f67aeb3
@@ -423,14 +433,14 @@ worker-1          Ready    worker                 39m   v1.27.6+f67aeb3
 
 There are a few peculiarities that need to be mentioned for a non-standard lab allocation and/or different versions of software, e.g., RHEL:
 
-In `jetlag`, the cluster installation process is divided into two phases: (1) Setup the bastion machine and (2) the actual OCP installation.
+In Jetlag, the cluster installation process is divided into two phases: (1) Setup the bastion machine and (2) the actual OCP installation.
 
 ### (1) Setup bastion:
-- Make sure that the base operating system (in the case of this guide it was RHEL 9.2) in the bastion machine has repositories added and an active subscription, since `jetlag` requires some packages, such as: `dnsmasq`, `frr`, `golang-bin`, `httpd` and `httpd-tools`, `ipmitool`, `python3-pip`, `podman`, and `skopeo`.
+- Make sure that the base operating system (in the case of this guide it was RHEL 9.2) in the bastion machine has repositories added and an active subscription, since Jetlag requires some packages, such as: `dnsmasq`, `frr`, `golang-bin`, `httpd` and `httpd-tools`, `ipmitool`, `python3-pip`, `podman`, and `skopeo`.
 
 - Sometimes the setup bastion process may fail, because it is not able to have connectivity between the assisted-service API and the target cluster machines. Check for `firewalld` or `iptables` with rules in place that prevent traffic between these machines. A quick test that fixes the problem is to silence and/or disable `firewalld` and clean `iptables` rules.
 
-- For `jetlag` to be able to copy, change the boot order, and boot the machines from the RHCOS image, the user needs to have writing access to the bmc, i.e., idrac in the case of Dell machines.
+- For Jetlag to be able to copy, change the boot order, and boot the machines from the RHCOS image, the user needs to have writing access to the bmc, i.e., idrac in the case of Dell machines.
 
 - The installation disks on the machines could vary from SATA/SAS to NVME, and therefore the `/dev/disk/by-path` IDs will vary.
 
@@ -444,7 +454,7 @@ In `jetlag`, the cluster installation process is divided into two phases: (1) Se
 - The task "Wait up to 40 min for nodes to be discovered" is the last most important step. Make sure that the *boot order* (via the *boot type*) is correct:
   - Check the virtual console in the bmc, i.e., idrac for Dell, if the machines are booting correctly from the .iso image.
 
-  - Make sure to inspect the 'BIOS Settings' in the machine for both, the *boot order* and *boot type*. `jetlag` will mount the .iso and instruct the machines for a one-time boot, where, later, they should be able to boot from the disk. Check if the string in the boot order field contains the hard disk. Once booted, in the virtual console, you will see the L3 NIC interface with an 198.10.18.x address and RHCOS, which is correct according to the `byol.local` above.
+  - Make sure to inspect the 'BIOS Settings' in the machine for both, the *boot order* and *boot type*. Jetlag will mount the .iso and instruct the machines for a one-time boot, where, later, they should be able to boot from the disk. Check if the string in the boot order field contains the hard disk. Once booted, in the virtual console, you will see the L3 NIC interface with an 198.10.18.x address and RHCOS, which is correct according to the `byol.local` above.
   - If the machines boot from the .iso image, but they cannot reach the bastion, it is most likely a networking issue, i.e. double check L2 and L3 NIC interfaces again.
      - [badfish](https://github.com/redhat-performance/badfish) could be used for this purpose, however, it is limited to use only FQDN, and, by the time of writing, the configuration for Del R660 and R760 in the interface config file was missing.
 

--- a/docs/bastion-deploy-bm-byol.md
+++ b/docs/bastion-deploy-bm-byol.md
@@ -21,7 +21,7 @@ _**Table of Contents**_
 
 <!-- TOC -->
 - [Bastion setup](#bastion-setup)
-- [Create your custom vars all.yml](#create-your-custom-vars-allyml)
+- [Configure Ansible vars in `all.yml`](#configure-ansible-vars-in-allyml)
 - [Review vars all.yml](#review-vars-allyml)
 - [Create your custom inventory byol.yml](#create-your-custom-inventory-byolyml)
 - [Monitor install and interact with cluster](#monitor-install-and-interact-with-cluster)
@@ -151,6 +151,10 @@ filename:
   }
 }
 ```
+
+If you are deploying nightly builds then you will need to add a ci token and an entry for
+`registry.ci.openshift.org`. If you plan on deploying an ACM downstream build be sure to
+include an entry for `quay.io:443`.
 
 7. Execute the bootstrap script in the current shell, with `source bootstrap.sh`.
 This will activate a local virtual Python environment configured with the Jetlag and

--- a/docs/bastion-deploy-bm.md
+++ b/docs/bastion-deploy-bm.md
@@ -45,7 +45,7 @@ _**Table of Contents**_
 
 <!-- TOC -->
 - [Bastion setup](#bastion-setup)
-- [Configure vars all.yml](#configure-vars-allyml)
+- [Configure Ansible vars in `all.yml`](#configure-ansible-vars-in-allyml)
 - [Review vars all.yml](#review-vars-allyml)
 - [Run playbooks](#run-playbooks)
 - [Monitor install and interact with cluster](#monitor-install-and-interact-with-cluster)
@@ -173,6 +173,10 @@ filename:
   }
 }
 ```
+
+If you are deploying nightly builds then you will need to add a ci token and an entry for
+`registry.ci.openshift.org`. If you plan on deploying an ACM downstream build be sure to
+include an entry for `quay.io:443`.
 
 7. Execute the bootstrap script in the current shell, with `source bootstrap.sh`.
 This will activate a local virtual Python environment configured with the Jetlag and

--- a/docs/bastion-deploy-bm.md
+++ b/docs/bastion-deploy-bm.md
@@ -1,25 +1,26 @@
-# Deploy a Bare Metal cluster via jetlag from a Scale Lab Bastion Machine quickstart
+# Deploy a Bare Metal cluster via Jetlag from a Scale Lab Bastion Machine quickstart
 
-Assuming you received a scale lab allocation named `cloud99`, this guide will walk you through getting a bare-metal cluster up in your allocation. For purposes of the guide the systems in `cloud99` will be Dell r650s. You should run Jetlag directly on the bastion machine. Jetlag picks the first machine in an allocation as the bastion. There are [ways to trick jetlag into picking a different machine as the bastion](tips-and-vars.md#override-lab-ocpinventory-json-file) but are beyond the scope of this quickstart.
+Assuming you received a scale lab allocation named `cloud99`, this guide will walk you through getting a bare-metal cluster up in your allocation. For purposes of the guide the systems in `cloud99` will be Dell r650s. You should run Jetlag directly on the bastion machine. Jetlag picks the first machine in an allocation as the bastion. You can [trick Jetlag into picking a different machine as the bastion](tips-and-vars.md#override-lab-ocpinventory-json-file) but that is beyond the scope of this quickstart.
 
-Obtain your first machine from the allocation from the [scale lab wiki](http://wiki.rdu2.scalelab.redhat.com/)
+Select the host name or IP for the first machine of your allocation from the
+[scale lab wiki](http://wiki.rdu2.scalelab.redhat.com/) as your bastion.
 
 Update the version of RHEL on the bastion machine if necessary, and reboot.
 
 ```console
-[user@fedora ~]$ ssh root@xxx-h01-000-r650.example.redhat.com
+[user@<local> ~]$ ssh root@<bastion>
 ...
-[root@xxx-h01-000-r650 ~]# cat /etc/redhat-release
+[root@<bastion> ~]# cat /etc/redhat-release
 Red Hat Enterprise Linux release 8.2 (Ootpa)
 
-[root@xxx-h01-000-r650 ~]# ./update-latest-rhel-release.sh 8.9
+[root@<bastion> ~]# ./update-latest-rhel-release.sh 8.9
 Changing repository from 8.2 to 8.9
 Cleaning dnf repo cache..
 
 -------------------------
 Run dnf update to upgrade to RHEL 8.9
 
-[root@xxx-h01-000-r650 ~]# dnf update -y
+[root@<bastion> ~]# dnf update -y
 Updating Subscription Management repositories.
 Unable to read consumer identity
 This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
@@ -30,13 +31,13 @@ Last metadata expiration check: 0:00:01 ago on Tue 02 May 2023 06:58:15 PM UTC.
 Dependencies resolved.
 ...
 Complete!
-[root@xxx-h01-000-r650 ~]# reboot
-Connection to xxx-h01-000-r650.rdu2.scalelab.redhat.com closed by remote host.
-Connection to xxx-h01-000-r650.rdu2.scalelab.redhat.com closed.
+[root@<bastion> ~]# reboot
+Connection to <bastion> closed by remote host.
+Connection to <bastion> closed.
 ...
 [user@fedora ~]$ ssh root@xxx-h01-000-r650.example.redhat.com
 ...
-[root@xxx-h01-000-r650 ~]# cat /etc/redhat-release
+[root@<bastion> ~]# cat /etc/redhat-release
 Red Hat Enterprise Linux release 8.9 (Ootpa)
 ```
 
@@ -67,24 +68,23 @@ listed in your cloud platform's standard inventory display.
 repeatedly log in from your laptop:
 
 ```console
-[user@fedora ~]$ ssh-copy-id root@xxx-h01-000-r650.example.redhat.com
+[user@<local> ~]$ ssh-copy-id root@<bastion>
 /usr/bin/ssh-copy-id: INFO: attempting to log in with the new key(s), to filter out any that are already installed
 /usr/bin/ssh-copy-id: INFO: 2 key(s) remain to be installed -- if you are prompted now it is to install the new keys
-Warning: Permanently added 'xxx-h01-000-r650.example.redhat.com,x.x.x.x' (ECDSA) to the list of known hosts.
-root@xxx-h01-000-r650.example.redhat.com's password:
+Warning: Permanently added '<bastion>,x.x.x.x' (ECDSA) to the list of known hosts.
+root@<bastion>'s password:
 
 Number of key(s) added: 2
-
-# Now try logging into the machine, and confirm that only the expected key(s)
-# were added to ~/.ssh/known_hosts
-[user@fedora ~] ssh root@xxx-h01-000-r650.example.redhat.com
-[user@fedora ~]
 ```
+
+Now log in to the bastion (with `ssh root@<bastion>` if you copied your public key above,
+or using the bastion root account password if not), because the remaining commands
+should be executed from the bastion.
 
 3. Install some additional tools to help after reboot
 
 ```console
-[root@xxx-r660 ~]# dnf install tmux git python3-pip sshpass -y
+[root@<bastion> ~]# dnf install tmux git python3-pip sshpass -y
 Updating Subscription Management repositories.
 ...
 Complete!
@@ -94,7 +94,7 @@ Complete!
 local ansible interactions:
 
 ```console
-[root@xxx-r660 ~]# ssh-keygen
+[root@<bastion> ~]# ssh-keygen
 Generating public/private rsa key pair.
 Enter file in which to save the key (/root/.ssh/id_rsa):
 Enter passphrase (empty for no passphrase):
@@ -102,12 +102,12 @@ Enter same passphrase again:
 Your identification has been saved in /root/.ssh/id_rsa.
 Your public key has been saved in /root/.ssh/id_rsa.pub.
 The key fingerprint is:
-SHA256:uA61+n0w3Dht4/oIy1IKXrSgt9tfC/8zjICd7LJ550s root@xxx-r660.machine.com
+SHA256:uA61+n0w3Dht4/oIy1IKXrSgt9tfC/8zjICd7LJ550s root@<bastion>
 The key's randomart image is:
 +---[RSA 3072]----+
 ...
 +----[SHA256]-----+
-[root@xxx-r660 ~]# ssh-copy-id root@localhost
+[root@<bastion> ~]# ssh-copy-id root@localhost
 /usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/root/.ssh/id_rsa.pub"
 The authenticity of host 'localhost (127.0.0.1)' can't be established.
 ECDSA key fingerprint is SHA256:fvvO3NLxT9FPcoOKQ9ldVdd4aQnwuGVPwa+V1+/c4T8.
@@ -118,15 +118,16 @@ root@localhost's password:
 
 Number of key(s) added: 1
 
-Now try logging into the machine, with:   "ssh 'root@localhost'"
-and check to make sure that only the key(s) you wanted were added.
-[root@xxx-r660 ~]#
+Now try logging into the machine and check to make sure that only the key(s) you wanted were added:
+```console
+[root@<bastion> ~] ssh root@localhost
+[root@<bastion> ~]#
 ```
 
-5. Clone `jetlag`
+5. Clone the `jetlag` GitHub repo
 
 ```console
-[root@xxx-r660 ~]# git clone https://github.com/redhat-performance/jetlag.git
+[root@<bastion> ~]# git clone https://github.com/redhat-performance/jetlag.git
 Cloning into 'jetlag'...
 remote: Enumerating objects: 4510, done.
 remote: Counting objects: 100% (4510/4510), done.
@@ -140,10 +141,21 @@ The `git clone` command will normally set the local head to the Jetlag repo's
 `main` branch. To set your local head to a different branch or tag (for example,
 a development branch), you can add `-b <name>` to the command.
 
-6. Download your pull_secret.txt from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) and place it in the root directory of `jetlag`
+Change your working directory to the repo's `jetlag` directory, which we'll assume
+for subsequent steps:
 
 ```console
-[root@xxx-r660 jetlag]# cat pull_secret.txt
+[root@<bastion> ~] cd jetlag
+[root@<bastion> jetlag]
+```
+
+6. Download your pull_secret.txt from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) and place it in the root directory of the local Jetlag repo. You'll find the Pull Secret near the end of the long downloads
+page, in the section labeled "Tokens". You can either click the "Download" button and then copy `~/Downloads/pull-secret.txt` to `./pull_secret.txt` (notice that Jetlag expects an underscore (`_`) while the file will download with a hyphen (`-`)),
+*or* click on the "Copy" button, and then paste into the terminal after typing `cat >pull_secret.txt` to create the expected
+filename:
+
+```console
+[root@<bastion> jetlag]# cat >pull_secret.txt
 {
   "auths": {
     "quay.io": {
@@ -162,31 +174,30 @@ a development branch), you can add `-b <name>` to the command.
 }
 ```
 
-7. Change to `jetlag` directory, and then run `source bootstrap.sh`. This will
-activate a local virtual Python environment configured with the Jetlag and
+7. Execute the bootstrap script in the current shell, with `source bootstrap.sh`.
+This will activate a local virtual Python environment configured with the Jetlag and
 Ansible dependencies.
 
 ```console
-[root@xxx-r660 ~]# cd jetlag/
-[root@xxx-r660 jetlag]# source bootstrap.sh
+[root@<bastion> jetlag]# source bootstrap.sh
 Collecting pip
 ...
-(.ansible) [root@xxx-r660 jetlag]#
+(.ansible) [root@<bastion> jetlag]#
 ```
 
 You can re-enter that virtual environment when you log in to the bastion again
 with:
 
 ```console
-[root@xxx-r660 ~]# cd jetlag
-[root@xxx-r660 ~]# source .ansible/bin/activate
+[root@<bastion> ~]# cd jetlag
+[root@<bastion> jetlag]# source .ansible/bin/activate
 ```
 
 <!-- End of duplicated setup text -->
 
-## Configure vars all.yml
+## Configure Ansible vars in `all.yml`
 
-Copy the vars file and edit it
+Copy the sample vars file and edit it:
 
 ```console
 (.ansible) [root@xxx-h01-000-r650 jetlag]# cp ansible/vars/all.sample.yml ansible/vars/all.yml
@@ -210,7 +221,7 @@ Only change `networktype` if you need to test something other than `OVNKubernete
 
 ### Bastion node vars
 
-Set `smcipmitool_url` to the location of the Supermicro SMCIPMITool binary. Since you must accept a EULA in order to download, it is suggested to download the file and place it onto a local http server, that is accessible to your laptop or deployment machine. You can then always reference that URL. Alternatively, you can download it to the `ansible/` directory of your jetlag repo clone and rename the file to `smcipmitool.tar.gz`. You can find the file [here](https://www.supermicro.com/SwDownload/SwSelect_Free.aspx?cat=IPMI).
+Set `smcipmitool_url` to the location of the Supermicro SMCIPMITool binary. Since you must accept a EULA in order to download, it is suggested to download the file and place it onto a local http server, that is accessible to your laptop or deployment machine. You can then always reference that URL. Alternatively, you can download it to the `ansible/` directory of your Jetlag repo clone and rename the file to `smcipmitool.tar.gz`. You can find the file [here](https://www.supermicro.com/SwDownload/SwSelect_Free.aspx?cat=IPMI).
 
 The system type determines the values of `bastion_lab_interface` and `bastion_controlplane_interface`.
 
@@ -232,7 +243,7 @@ Here you can see a network diagram for the bare metal cluster on Dell r650 with 
 
 Double check your nic names with your actual bastion machine.
 
-** If you desire to use a *different network* than "Network 1" for your controlplane network then you will have to append additional overrides to the extra vars portion of the all.yml vars file.
+** If you desire to use a *different network* than "Network 1" for your controlplane network then you will have to append additional overrides to the extra vars portion of the `all.yml` vars file.
 See [tips and vars](tips-and-vars.md#using-other-network-interfaces) for more information
 
 ### OCP node vars
@@ -255,7 +266,7 @@ For bare-metal deployment of OCP 4.13 or later, it's advisable to configure the 
 - control_plane_install_disk
 - worker_install_disk
 
-These variables ensure disk references are made using by-path notation instead of symbolic links. This approach is recommended due to potential reliability issues with symbolic links. The values mentioned [Review vars all.yml](#review-vars-allyml) are correct for the Scale lab R650 instances. Please refer to [tips and vars](tips-and-vars.md#extra-vars-for-by-path-disk-reference) to determine the correct paths for other instances.
+These variables ensure disk references are made using by-path notation instead of symbolic links. This approach is recommended due to potential reliability issues with symbolic links. The values mentioned [Review `all.yml`](#review-vars-allyml) are correct for the Scale lab R650 instances. Please refer to [tips and vars](tips-and-vars.md#extra-vars-for-by-path-disk-reference) to determine the correct paths for other instances.
 
 ### Disconnected and ipv6 vars
 
@@ -278,7 +289,7 @@ Oddly enough if you run into any routing issues because of duplicate address det
 
 The completed `all.yml` vars file and generated inventory files following this section only reflect that of an ipv4 connected install. If you previously deployed ipv4 stop and remove all running podman containers off the bastion and rerun the `setup-bastion.yml` playbook.
 
-## Review vars all.yml
+## Review vars `all.yml`
 
 The `ansible/vars/all.yml` now resembles ..
 
@@ -322,8 +333,8 @@ networktype: OVNKubernetes
 
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
-# Place your pull_secret.txt in the base directory of the cloned jetlag repo, Example:
-# [user@fedora jetlag]$ ls pull_secret.txt
+# Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
+# [user@<bastion> jetlag]$ ls pull_secret.txt
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
 
 ################################################################################
@@ -376,7 +387,7 @@ worker_install_disk: /dev/disk/by-path/pci-0000:67:00.0-scsi-0:2:0:0
 Run the create inventory playbook
 
 ```console
-(.ansible) [root@xxx-h01-000-r650 jetlag]# ansible-playbook ansible/create-inventory.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook ansible/create-inventory.yml
 ...
 ```
 
@@ -453,14 +464,14 @@ dns1=198.18.10.1
 Next run the `setup-bastion.yml` playbook ...
 
 ```console
-(.ansible) [root@xxx-h01-000-r650 jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/setup-bastion.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/setup-bastion.yml
 ...
 ```
 
 Finally run the `bm-deploy.yml` playbook ...
 
 ```console
-(.ansible) [root@xxx-h01-000-r650 jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/bm-deploy.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/bm-deploy.yml
 ...
 ```
 
@@ -471,12 +482,12 @@ It is suggested to monitor your first deployment to see if anything hangs on boo
 If everything goes well you should have a cluster in about 60-70 minutes. You can interact with the cluster from the bastion via the kubeconfig or kubeadmin password.
 
 ```console
-(.ansible) [root@xxx-h01-000-r650 ~]# export KUBECONFIG=/root/bm/kubeconfig
-(.ansible) [root@xxx-h01-000-r650 ~]# oc get no
+(.ansible) [root@<bastion> jetlag]# export KUBECONFIG=/root/bm/kubeconfig
+(.ansible) [root@<bastion> jetlag]# oc get no
 NAME               STATUS   ROLES                         AGE    VERSION
 xxx-h02-000-r650   Ready    control-plane,master,worker   73m    v1.25.7+eab9cc9
 xxx-h03-000-r650   Ready    control-plane,master,worker   103m   v1.25.7+eab9cc9
 xxx-h05-000-r650   Ready    control-plane,master,worker   105m   v1.25.7+eab9cc9
-(.ansible) [root@xxx-h01-000-r650 jetlag]# cat /root/bm/kubeadmin-password
+(.ansible) [root@<bastion> jetlag]# cat /root/bm/kubeadmin-password
 xxxxx-xxxxx-xxxxx-xxxxx
 ```

--- a/docs/bastion-deploy-bm.md
+++ b/docs/bastion-deploy-bm.md
@@ -1,9 +1,7 @@
 # Deploy a Bare Metal cluster via Jetlag from a Scale Lab Bastion Machine quickstart
 
-Assuming you received a scale lab allocation named `cloud99`, this guide will walk you through getting a bare-metal cluster up in your allocation. For purposes of the guide the systems in `cloud99` will be Dell r650s. You should run Jetlag directly on the bastion machine. Jetlag picks the first machine in an allocation as the bastion. You can [trick Jetlag into picking a different machine as the bastion](tips-and-vars.md#override-lab-ocpinventory-json-file) but that is beyond the scope of this quickstart.
-
-Select the host name or IP for the first machine of your allocation from the
-[scale lab wiki](http://wiki.rdu2.scalelab.redhat.com/) as your bastion.
+Assuming you received a scale lab allocation named `cloud99`, this guide will walk you through getting a bare-metal cluster up in your allocation. For purposes of the guide the systems in `cloud99` will be Dell r650s. You should run Jetlag directly on the bastion machine. Jetlag picks the first machine in an allocation as the bastion. You can [trick Jetlag into picking a different machine as the bastion](tips-and-vars.md#override-lab-ocpinventory-json-file) but that is beyond the scope of this quickstart. You can find the machines in your cloud allocation on
+[the scale lab wiki](http://wiki.rdu2.scalelab.redhat.com/)
 
 Update the version of RHEL on the bastion machine if necessary, and reboot.
 
@@ -150,10 +148,10 @@ for subsequent steps:
 ```
 
 6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
-the long downloads page, in the section labeled "Tokens". You can either click the "Download" button and then copy the
+the long downloads page, in the section labeled "Tokens". You can either click the "Download" button, and then copy the
 downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
-file will download with a hyphen (`-`)), *or* click on the "Copy" button, and then paste into the terminal after typing
-`cat >pull_secret.txt` on the bastion to create the expected filename:
+file will download with a hyphen (`-`)); *or* click on the "Copy" button, and then paste the clipboard into the terminal
+after typing `cat >pull_secret.txt` on the bastion to create the expected filename:
 
 ```console
 [root@<bastion> jetlag]# cat >pull_secret.txt

--- a/docs/bastion-deploy-bm.md
+++ b/docs/bastion-deploy-bm.md
@@ -118,7 +118,7 @@ Number of key(s) added: 1
 
 Now try logging into the machine and check to make sure that only the key(s) you wanted were added:
 ```console
-[root@<bastion> ~] ssh root@localhost
+[root@<bastion> ~]# ssh root@localhost
 [root@<bastion> ~]#
 ```
 
@@ -143,8 +143,8 @@ Change your working directory to the repo's `jetlag` directory, which we'll assu
 for subsequent steps:
 
 ```console
-[root@<bastion> ~] cd jetlag
-[root@<bastion> jetlag]
+[root@<bastion> ~]# cd jetlag
+[root@<bastion> jetlag]#
 ```
 
 6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
@@ -337,7 +337,7 @@ networktype: OVNKubernetes
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
 # Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
-# [root@<bastion> jetlag]$ ls pull_secret.txt
+# [root@<bastion> jetlag]# ls pull_secret.txt
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
 
 ################################################################################

--- a/docs/bastion-deploy-bm.md
+++ b/docs/bastion-deploy-bm.md
@@ -35,7 +35,7 @@ Complete!
 Connection to <bastion> closed by remote host.
 Connection to <bastion> closed.
 ...
-[user@fedora ~]$ ssh root@xxx-h01-000-r650.example.redhat.com
+[user@<local> ~]$ ssh root@<bastion>
 ...
 [root@<bastion> ~]# cat /etc/redhat-release
 Red Hat Enterprise Linux release 8.9 (Ootpa)
@@ -149,10 +149,11 @@ for subsequent steps:
 [root@<bastion> jetlag]
 ```
 
-6. Download your pull_secret.txt from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) and place it in the root directory of the local Jetlag repo. You'll find the Pull Secret near the end of the long downloads
-page, in the section labeled "Tokens". You can either click the "Download" button and then copy `~/Downloads/pull-secret.txt` to `./pull_secret.txt` (notice that Jetlag expects an underscore (`_`) while the file will download with a hyphen (`-`)),
-*or* click on the "Copy" button, and then paste into the terminal after typing `cat >pull_secret.txt` to create the expected
-filename:
+6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
+the long downloads page, in the section labeled "Tokens". You can either click the "Download" button and then copy the
+downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
+file will download with a hyphen (`-`)), *or* click on the "Copy" button, and then paste into the terminal after typing
+`cat >pull_secret.txt` on the bastion to create the expected filename:
 
 ```console
 [root@<bastion> jetlag]# cat >pull_secret.txt
@@ -338,7 +339,7 @@ networktype: OVNKubernetes
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
 # Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
-# [user@<bastion> jetlag]$ ls pull_secret.txt
+# [root@<bastion> jetlag]$ ls pull_secret.txt
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
 
 ################################################################################

--- a/docs/deploy-bm-ibmcloud.md
+++ b/docs/deploy-bm-ibmcloud.md
@@ -98,7 +98,7 @@ Now try logging into the machine and check to make sure that only the key(s) you
 [root@<bastion> ~]# ssh root@localhost
 [root@<bastion> ~]#
 ```
-S
+
 5. Clone the `jetlag` GitHub repo
 
 ```console
@@ -125,10 +125,10 @@ for subsequent steps:
 ```
 
 6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
-the long downloads page, in the section labeled "Tokens". You can either click the "Download" button and then copy the
+the long downloads page, in the section labeled "Tokens". You can either click the "Download" button, and then copy the
 downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
-file will download with a hyphen (`-`)), *or* click on the "Copy" button, and then paste into the terminal after typing
-`cat >pull_secret.txt` on the bastion to create the expected filename:
+file will download with a hyphen (`-`)); *or* click on the "Copy" button, and then paste the clipboard into the terminal
+after typing `cat >pull_secret.txt` on the bastion to create the expected filename:
 
 ```console
 [root@<bastion> jetlag]# cat >pull_secret.txt

--- a/docs/deploy-bm-ibmcloud.md
+++ b/docs/deploy-bm-ibmcloud.md
@@ -1,53 +1,125 @@
 # Deploy a Bare Metal cluster on IBMcloud via jetlag quickstart
 
-To deploy a bare metal OpenShift cluster, order 6 machines from the [IBM bare metal server catalog](https://cloud.ibm.com/gen1/infrastructure/provision/bm).
-For guidance on how to order hardware on IBMcloud, see [order-hardware-ibmcloud.md](order-hardware-ibmcloud.md) in [docs](../docs) directory.
+To deploy a bare metal OpenShift cluster, order 6 machines from the [IBM bare metal server catalog](https://cloud.ibm.com/gen1/infrastructure/provision/bm). For guidance on how to order hardware on IBMcloud, see [order-hardware-ibmcloud.md](order-hardware-ibmcloud.md) in [docs](../docs) directory.
+
 The machines used to test this are of Server profile E5-2620 in DAL10 datacenter with automatic port redundancy. One machine will become the bastion, 3 machines will become control-plane nodes, and the remaining 2 nodes will be worker nodes. Ensure that you order either CentOS or RHEL machines with a new enough version (8.6) otherwise podman will not have host networking functionality. The bastion machine should have a public accessible ip and will NAT traffic for the cluster to the public network. The other machines can have a public ip address but it is not currently in use with this deployment method.
 
 Once your machines are delivered, login to the ibmcloud cli using the cut and paste link from the cloud portal. You should be able to list the machines from your local machine, for example:
 
 ```console
 $ ibmcloud sl hardware list
-id        hostname     domain                    public_ip        private_ip    datacenter   status   
-960237    jetlag-bm0   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE   
-1165601   jetlag-bm1   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE   
-1112925   jetlag-bm2   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE   
-1163781   jetlag-bm3   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE   
-1165519   jetlag-bm4   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE   
-1117051   jetlag-bm5   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE  
+id        hostname     domain                    public_ip        private_ip    datacenter   status
+960237    jetlag-bm0   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE
+1165601   jetlag-bm1   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE
+1112925   jetlag-bm2   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE
+1163781   jetlag-bm3   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE
+1165519   jetlag-bm4   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE
+1117051   jetlag-bm5   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE
 ```
 
-## Clone Jetlag
+_**Table of Contents**_
 
-Clone jetlag on to your laptop and change to the jetlag directory
+<!-- TOC -->
+- [Bastion setup](#bastion-setup)
+- [Configure vars ibmcloud.yml](#configure-vars-ibmcloudyml)
+- [Review ibmcloud.yml](#review-ibmcloudyml)
+- [Run playbooks](#run-playbooks)
+<!-- /TOC -->
+
+<!-- Bastion setup is duplicated in multiple files and should be kept in sync!
+     - bastion-deploy-bm-byol.md
+     - bastion-bm-ibmcloud.md
+     - deploy-sno-ibmcloud.md
+     - deploy-sno-quickstart.md
+ -->
+## Bastion setup
+
+1. Select the bastion machine from the allocation. You should run Jetlag on the
+bastion machine, to ensure full connectivity and fastest access. By convention
+this is usually the first node of your allocation: for example, the first machine
+listed in your cloud platform's standard inventory display.
+
+2. You can copy your ssh public key to the designated bastion machine to make it easier to
+repeatedly log in from your laptop:
 
 ```console
-[user@fedora ~]$ git clone https://github.com/redhat-performance/jetlag.git
-Cloning into 'jetlag'...
-remote: Enumerating objects: 1639, done.
-remote: Counting objects: 100% (393/393), done.
-remote: Compressing objects: 100% (210/210), done.
-remote: Total 1639 (delta 233), reused 232 (delta 160), pack-reused 1246
-Receiving objects: 100% (1639/1639), 253.01 KiB | 1.07 MiB/s, done.
-Resolving deltas: 100% (704/704), done.
-[user@fedora ~]$ cd jetlag
+[user@fedora ~]$ ssh-copy-id root@xxx-h01-000-r650.example.redhat.com
+/usr/bin/ssh-copy-id: INFO: attempting to log in with the new key(s), to filter out any that are already installed
+/usr/bin/ssh-copy-id: INFO: 2 key(s) remain to be installed -- if you are prompted now it is to install the new keys
+Warning: Permanently added 'xxx-h01-000-r650.example.redhat.com,x.x.x.x' (ECDSA) to the list of known hosts.
+root@xxx-h01-000-r650.example.redhat.com's password:
+
+Number of key(s) added: 2
+
+# Now try logging into the machine, and confirm that only the expected key(s)
+# were added to ~/.ssh/known_hosts
+[user@fedora ~] ssh root@xxx-h01-000-r650.example.redhat.com
+[user@fedora ~]
 ```
 
-## Prerequisites
-
-Source bootstrap to install/setup Ansible
+3. Install some additional tools to help after reboot
 
 ```console
-[user@fedora jetlag]$ source bootstrap.sh
-Collecting pip
+[root@xxx-r660 ~]# dnf install tmux git python3-pip sshpass -y
+Updating Subscription Management repositories.
 ...
-(.ansible) [user@fedora jetlag]$
+Complete!
 ```
 
-Set your pull secret file `pull_secret.txt` in the base directory of the cloned jetlag repo. The contents should resemble this json:
+4. Setup ssh keys for the bastion root account and copy to itself to permit
+local ansible interactions:
 
+```console
+[root@xxx-r660 ~]# ssh-keygen
+Generating public/private rsa key pair.
+Enter file in which to save the key (/root/.ssh/id_rsa):
+Enter passphrase (empty for no passphrase):
+Enter same passphrase again:
+Your identification has been saved in /root/.ssh/id_rsa.
+Your public key has been saved in /root/.ssh/id_rsa.pub.
+The key fingerprint is:
+SHA256:uA61+n0w3Dht4/oIy1IKXrSgt9tfC/8zjICd7LJ550s root@xxx-r660.machine.com
+The key's randomart image is:
++---[RSA 3072]----+
+...
++----[SHA256]-----+
+[root@xxx-r660 ~]# ssh-copy-id root@localhost
+/usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/root/.ssh/id_rsa.pub"
+The authenticity of host 'localhost (127.0.0.1)' can't be established.
+ECDSA key fingerprint is SHA256:fvvO3NLxT9FPcoOKQ9ldVdd4aQnwuGVPwa+V1+/c4T8.
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+/usr/bin/ssh-copy-id: INFO: attempting to log in with the new key(s), to filter out any that are already installed
+/usr/bin/ssh-copy-id: INFO: 1 key(s) remain to be installed -- if you are prompted now it is to install the new keys
+root@localhost's password:
+
+Number of key(s) added: 1
+
+Now try logging into the machine, with:   "ssh 'root@localhost'"
+and check to make sure that only the key(s) you wanted were added.
+[root@xxx-r660 ~]#
 ```
-[user@fedora jetlag]$ cat pull_secret.txt
+
+5. Clone `jetlag`
+
+```console
+[root@xxx-r660 ~]# git clone https://github.com/redhat-performance/jetlag.git
+Cloning into 'jetlag'...
+remote: Enumerating objects: 4510, done.
+remote: Counting objects: 100% (4510/4510), done.
+remote: Compressing objects: 100% (1531/1531), done.
+remote: Total 4510 (delta 2450), reused 4384 (delta 2380), pack-reused 0
+Receiving objects: 100% (4510/4510), 831.98 KiB | 21.33 MiB/s, done.
+Resolving deltas: 100% (2450/2450), done.
+```
+
+The `git clone` command will normally set the local head to the Jetlag repo's
+`main` branch. To set your local head to a different branch or tag (for example,
+a development branch), you can add `-b <name>` to the command.
+
+6. Download your pull_secret.txt from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) and place it in the root directory of `jetlag`
+
+```console
+[root@xxx-r660 jetlag]# cat pull_secret.txt
 {
   "auths": {
     "quay.io": {
@@ -66,9 +138,29 @@ Set your pull secret file `pull_secret.txt` in the base directory of the cloned 
 }
 ```
 
-If you are deploying nightly builds then you will need a ci token and an entry for `registry.ci.openshift.org`. If you plan on deploying an ACM downstream build be sure to include an entry for `quay.io:443`
+7. Change to `jetlag` directory, and then run `source bootstrap.sh`. This will
+activate a local virtual Python environment configured with the Jetlag and
+Ansible dependencies.
 
-## ibmcloud.yml vars file
+```console
+[root@xxx-r660 ~]# cd jetlag/
+[root@xxx-r660 jetlag]# source bootstrap.sh
+Collecting pip
+...
+(.ansible) [root@xxx-r660 jetlag]#
+```
+
+You can re-enter that virtual environment when you log in to the bastion again
+with:
+
+```console
+[root@xxx-r660 ~]# cd jetlag
+[root@xxx-r660 ~]# source .ansible/bin/activate
+```
+
+<!-- End of duplicated setup text -->
+
+## Configure vars ibmcloud.yml
 
 Next copy the vars file so we can edit it.
 
@@ -227,7 +319,7 @@ Run the ibmcloud create inventory playbook
 
 The `ibmcloud-create-inventory.yml` playbook will create an inventory file `ansible/inventory/ibmcloud.local` from the ibmcloud cli data and the vars file.
 
-** For custom master/worker node name: replace first parameter in ibmcloud.local file under [controlplane] and [worker] sections   
+** For custom master/worker node name: replace first parameter in ibmcloud.local file under [controlplane] and [worker] sections
 
 The inventory file should resemble the [sample one provided](../ansible/inventory/ibmcloud-inventory-bm.sample).
 

--- a/docs/deploy-bm-ibmcloud.md
+++ b/docs/deploy-bm-ibmcloud.md
@@ -21,7 +21,7 @@ _**Table of Contents**_
 
 <!-- TOC -->
 - [Bastion setup](#bastion-setup)
-- [Configure vars ibmcloud.yml](#configure-vars-ibmcloudyml)
+- [Configure Ansible vars `ibmcloud.yml`](#configure-ansible-vars-ibmcloudyml)
 - [Review ibmcloud.yml](#review-ibmcloudyml)
 - [Run playbooks](#run-playbooks)
 <!-- /TOC -->
@@ -149,6 +149,10 @@ filename:
 }
 ```
 
+If you are deploying nightly builds then you will need to add a ci token and an entry for
+`registry.ci.openshift.org`. If you plan on deploying an ACM downstream build be sure to
+include an entry for `quay.io:443`.
+
 7. Execute the bootstrap script in the current shell, with `source bootstrap.sh`.
 This will activate a local virtual Python environment configured with the Jetlag and
 Ansible dependencies.
@@ -175,8 +179,8 @@ with:
 Next copy the vars file so we can edit it.
 
 ```console
-[root@<bastion> jetlag]$ cp ansible/vars/ibmcloud.sample.yml ansible/vars/ibmcloud.yml
-[root@<bastion> jetlag]$ vi ansible/vars/ibmcloud.yml
+(.ansible) [root@<bastion> jetlag]$ cp ansible/vars/ibmcloud.sample.yml ansible/vars/ibmcloud.yml
+(.ansible) [root@<bastion> jetlag]$ vi ansible/vars/ibmcloud.yml
 ```
 
 ### Lab & cluster infrastructure vars
@@ -323,7 +327,7 @@ $ echo id_rsa.pub >> authorized_keys
 Run the ibmcloud create inventory playbook
 
 ```console
-[root@<bastion> jetlag]$ ansible-playbook ansible/ibmcloud-create-inventory.yml
+(.ansible) [root@<bastion> jetlag]$ ansible-playbook ansible/ibmcloud-create-inventory.yml
 ...
 ```
 
@@ -336,22 +340,22 @@ The inventory file should resemble the [sample one provided](../ansible/inventor
 Next run the `ibmcloud-setup-bastion.yml` playbook ...
 
 ```console
-[root@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/ibmcloud.local ansible/ibmcloud-setup-bastion.yml
+(.ansible) [root@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/ibmcloud.local ansible/ibmcloud-setup-bastion.yml
 ...
 ```
 
 Lastly, run the `ibmcloud-bm-deploy.yml` playbook ...
 
 ```console
-[root@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/ibmcloud.local ansible/ibmcloud-bm-deploy.yml
+(.ansible) [root@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/ibmcloud.local ansible/ibmcloud-bm-deploy.yml
 ...
 ```
 
 If everything goes well you should have a cluster in about 60-70 minutes. You can interact with the cluster from the bastion.
 
 ```console
-[root@<bastion> jetlag]# export KUBECONFIG=/root/bm/kubeconfig
-[root@<bastion> jetlag]# oc get no
+(.ansible) [root@<bastion> jetlag]# export KUBECONFIG=/root/bm/kubeconfig
+(.ansible) [root@<bastion> jetlag]# oc get no
 NAME         STATUS   ROLES    AGE     VERSION
 jetlag-bm1   Ready    master   3h34m   v1.21.1+051ac4f
 jetlag-bm2   Ready    master   3h7m    v1.21.1+051ac4f

--- a/docs/deploy-bm-ibmcloud.md
+++ b/docs/deploy-bm-ibmcloud.md
@@ -7,7 +7,7 @@ The machines used to test this are of Server profile E5-2620 in DAL10 datacenter
 Once your machines are delivered, login to the ibmcloud cli using the cut and paste link from the cloud portal. You should be able to list the machines from your local machine, for example:
 
 ```console
-[user@localhost ~]$ ibmcloud sl hardware list
+[user@<local> ~]$ ibmcloud sl hardware list
 id        hostname     domain                    public_ip        private_ip    datacenter   status
 960237    jetlag-bm0   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE
 1165601   jetlag-bm1   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE
@@ -95,10 +95,10 @@ Number of key(s) added: 1
 
 Now try logging into the machine and check to make sure that only the key(s) you wanted were added:
 ```console
-[root@<bastion> ~] ssh root@localhost
+[root@<bastion> ~]# ssh root@localhost
 [root@<bastion> ~]#
 ```
-
+S
 5. Clone the `jetlag` GitHub repo
 
 ```console
@@ -124,10 +124,11 @@ for subsequent steps:
 [root@<bastion> jetlag]
 ```
 
-6. Download your pull_secret.txt from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) and place it in the root directory of the local Jetlag repo. You'll find the Pull Secret near the end of the long downloads
-page, in the section labeled "Tokens". You can either click the "Download" button and then copy `~/Downloads/pull-secret.txt` to `./pull_secret.txt` (notice that Jetlag expects an underscore (`_`) while the file will download with a hyphen (`-`)),
-*or* click on the "Copy" button, and then paste into the terminal after typing `cat >pull_secret.txt` to create the expected
-filename:
+6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
+the long downloads page, in the section labeled "Tokens". You can either click the "Download" button and then copy the
+downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
+file will download with a hyphen (`-`)), *or* click on the "Copy" button, and then paste into the terminal after typing
+`cat >pull_secret.txt` on the bastion to create the expected filename:
 
 ```console
 [root@<bastion> jetlag]# cat >pull_secret.txt
@@ -260,7 +261,7 @@ networktype: OVNKubernetes
 ssh_private_key_file: ~/.ssh/ibmcloud_id_rsa
 ssh_public_key_file: ~/.ssh/ibmcloud_id_rsa.pub
 # Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
-# [user@<bastion> jetlag]$ ls pull_secret.txt
+# [root@<bastion> jetlag]$ ls pull_secret.txt
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
 
 ################################################################################

--- a/docs/deploy-bm-ibmcloud.md
+++ b/docs/deploy-bm-ibmcloud.md
@@ -120,8 +120,8 @@ Change your working directory to the repo's `jetlag` directory, which we'll assu
 for subsequent steps:
 
 ```console
-[root@<bastion> ~] cd jetlag
-[root@<bastion> jetlag]
+[root@<bastion> ~]# cd jetlag
+[root@<bastion> jetlag]#
 ```
 
 6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
@@ -180,8 +180,8 @@ with:
 Next copy the vars file so we can edit it.
 
 ```console
-(.ansible) [root@<bastion> jetlag]$ cp ansible/vars/ibmcloud.sample.yml ansible/vars/ibmcloud.yml
-(.ansible) [root@<bastion> jetlag]$ vi ansible/vars/ibmcloud.yml
+(.ansible) [root@<bastion> jetlag]# cp ansible/vars/ibmcloud.sample.yml ansible/vars/ibmcloud.yml
+(.ansible) [root@<bastion> jetlag]# vi ansible/vars/ibmcloud.yml
 ```
 
 ### Lab & cluster infrastructure vars
@@ -261,7 +261,7 @@ networktype: OVNKubernetes
 ssh_private_key_file: ~/.ssh/ibmcloud_id_rsa
 ssh_public_key_file: ~/.ssh/ibmcloud_id_rsa.pub
 # Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
-# [root@<bastion> jetlag]$ ls pull_secret.txt
+# [root@<bastion> jetlag]# ls pull_secret.txt
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
 
 ################################################################################
@@ -328,7 +328,7 @@ $ echo id_rsa.pub >> authorized_keys
 Run the ibmcloud create inventory playbook
 
 ```console
-(.ansible) [root@<bastion> jetlag]$ ansible-playbook ansible/ibmcloud-create-inventory.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook ansible/ibmcloud-create-inventory.yml
 ...
 ```
 
@@ -341,14 +341,14 @@ The inventory file should resemble the [sample one provided](../ansible/inventor
 Next run the `ibmcloud-setup-bastion.yml` playbook ...
 
 ```console
-(.ansible) [root@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/ibmcloud.local ansible/ibmcloud-setup-bastion.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/ibmcloud.local ansible/ibmcloud-setup-bastion.yml
 ...
 ```
 
 Lastly, run the `ibmcloud-bm-deploy.yml` playbook ...
 
 ```console
-(.ansible) [root@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/ibmcloud.local ansible/ibmcloud-bm-deploy.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/ibmcloud.local ansible/ibmcloud-bm-deploy.yml
 ...
 ```
 

--- a/docs/deploy-sno-ibmcloud.md
+++ b/docs/deploy-sno-ibmcloud.md
@@ -42,6 +42,10 @@ Number of key(s) added: 2
 [root@<bastion> ~]
 ```
 
+Now log in to the bastion (with `ssh root@<bastion>` if you copied your public key above,
+or using the bastion root account password if not), because the remaining commands
+should be executed from the bastion.
+
 3. Install some additional tools to help after reboot
 
 ```console
@@ -109,10 +113,11 @@ for subsequent steps:
 [root@<bastion> jetlag]
 ```
 
-6. Download your pull_secret.txt from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) and place it in the root directory of the local Jetlag repo. You'll find the Pull Secret near the end of the long downloads
-page, in the section labeled "Tokens". You can either click the "Download" button and then copy `~/Downloads/pull-secret.txt` to `./pull_secret.txt` (notice that Jetlag expects an underscore (`_`) while the file will download with a hyphen (`-`)),
-*or* click on the "Copy" button, and then paste into the terminal after typing `cat >pull_secret.txt` to create the expected
-filename:
+6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
+the long downloads page, in the section labeled "Tokens". You can either click the "Download" button and then copy the
+downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
+file will download with a hyphen (`-`)), *or* click on the "Copy" button, and then paste into the terminal after typing
+`cat >pull_secret.txt` on the bastion to create the expected filename:
 
 ```console
 [root@<bastion> jetlag]# cat >pull_secret.txt
@@ -212,7 +217,7 @@ networktype: OVNKubernetes
 ssh_private_key_file: ~/.ssh/ibmcloud_id_rsa
 ssh_public_key_file: ~/.ssh/ibmcloud_id_rsa.pub
 # Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
-# [user@fedora jetlag]$ ls pull_secret.txt
+# [root@<bastion> jetlag]$ ls pull_secret.txt
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
 
 ################################################################################

--- a/docs/deploy-sno-ibmcloud.md
+++ b/docs/deploy-sno-ibmcloud.md
@@ -38,8 +38,8 @@ Number of key(s) added: 2
 
 # Now try logging into the machine, and confirm that only the expected key(s)
 # were added to ~/.ssh/known_hosts
-[user@<local> ~] ssh root@<bastion>
-[root@<bastion> ~]
+[user@<local> ~]$ ssh root@<bastion>
+[root@<bastion> ~]#
 ```
 
 Now log in to the bastion (with `ssh root@<bastion>` if you copied your public key above,
@@ -109,8 +109,8 @@ Change your working directory to the repo's `jetlag` directory, which we'll assu
 for subsequent steps:
 
 ```console
-[root@<bastion> ~] cd jetlag
-[root@<bastion> jetlag]
+[root@<bastion> ~]# cd jetlag
+[root@<bastion> jetlag]#
 ```
 
 6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
@@ -169,8 +169,8 @@ with:
 Next copy the vars file so we can edit it.
 
 ```console
-(.ansible) [root@<bastion> jetlag]$ cp ansible/vars/ibmcloud.sample.yml ansible/vars/ibmcloud.yml
-(.ansible) [root@<bastion> jetlag]$ vi ansible/vars/ibmcloud.yml
+(.ansible) [root@<bastion> jetlag]# cp ansible/vars/ibmcloud.sample.yml ansible/vars/ibmcloud.yml
+(.ansible) [root@<bastion> jetlag]# vi ansible/vars/ibmcloud.yml
 ```
 
 Change `cluster_type` to `cluster_type: sno`
@@ -217,7 +217,7 @@ networktype: OVNKubernetes
 ssh_private_key_file: ~/.ssh/ibmcloud_id_rsa
 ssh_public_key_file: ~/.ssh/ibmcloud_id_rsa.pub
 # Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
-# [root@<bastion> jetlag]$ ls pull_secret.txt
+# [root@<bastion> jetlag]# ls pull_secret.txt
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
 
 ################################################################################
@@ -265,7 +265,7 @@ controlplane_network_ingress:
 Run the ibmcloud create inventory playbook
 
 ```console
-(.ansible) [root@<bastion> jetlag]$ ansible-playbook ansible/ibmcloud-create-inventory.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook ansible/ibmcloud-create-inventory.yml
 ...
 ```
 
@@ -276,14 +276,14 @@ The inventory file should resemble the [sample one provided](../ansible/inventor
 Next run the `ibmcloud-setup-bastion.yml` playbook ...
 
 ```console
-(.ansible) [root@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/ibmcloud.local ansible/ibmcloud-setup-bastion.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/ibmcloud.local ansible/ibmcloud-setup-bastion.yml
 ...
 ```
 
 Finally run the `ibmcloud-sno-deploy.yml` playbook ...
 
 ```console
-(.ansible) [root@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/ibmcloud.local ansible/ibmcloud-sno-deploy.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/ibmcloud.local ansible/ibmcloud-sno-deploy.yml
 ...
 ```
 

--- a/docs/deploy-sno-ibmcloud.md
+++ b/docs/deploy-sno-ibmcloud.md
@@ -114,10 +114,10 @@ for subsequent steps:
 ```
 
 6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
-the long downloads page, in the section labeled "Tokens". You can either click the "Download" button and then copy the
+the long downloads page, in the section labeled "Tokens". You can either click the "Download" button, and then copy the
 downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
-file will download with a hyphen (`-`)), *or* click on the "Copy" button, and then paste into the terminal after typing
-`cat >pull_secret.txt` on the bastion to create the expected filename:
+file will download with a hyphen (`-`)); *or* click on the "Copy" button, and then paste the clipboard into the terminal
+after typing `cat >pull_secret.txt` on the bastion to create the expected filename:
 
 ```console
 [root@<bastion> jetlag]# cat >pull_secret.txt

--- a/docs/deploy-sno-ibmcloud.md
+++ b/docs/deploy-sno-ibmcloud.md
@@ -6,8 +6,8 @@ _**Table of Contents**_
 
 <!-- TOC -->
 - [Bastion setup](#bastion-setup)
-- [SNO var changes](#sno-var-changes)
-- [Review SNO ibmcloud.yml](#review-sno-ibmcloudyml)
+- [Configure Ansible vars `ibmcloud.yml`](#configure-ansible-vars-ibmcloudyml)
+- [Review SNO `ibmcloud.yml`](#review-sno-ibmcloudyml)
 - [Run playbooks](#run-playbooks)
 <!-- /TOC -->
 
@@ -134,6 +134,10 @@ filename:
 }
 ```
 
+If you are deploying nightly builds then you will need to add a ci token and an entry for
+`registry.ci.openshift.org`. If you plan on deploying an ACM downstream build be sure to
+include an entry for `quay.io:443`.
+
 7. Execute the bootstrap script in the current shell, with `source bootstrap.sh`.
 This will activate a local virtual Python environment configured with the Jetlag and
 Ansible dependencies.
@@ -160,8 +164,8 @@ with:
 Next copy the vars file so we can edit it.
 
 ```console
-[root@<bastion> jetlag]$ cp ansible/vars/ibmcloud.sample.yml ansible/vars/ibmcloud.yml
-[root@<bastion> jetlag]$ vi ansible/vars/ibmcloud.yml
+(.ansible) [root@<bastion> jetlag]$ cp ansible/vars/ibmcloud.sample.yml ansible/vars/ibmcloud.yml
+(.ansible) [root@<bastion> jetlag]$ vi ansible/vars/ibmcloud.yml
 ```
 
 Change `cluster_type` to `cluster_type: sno`
@@ -256,7 +260,7 @@ controlplane_network_ingress:
 Run the ibmcloud create inventory playbook
 
 ```console
-[user@<bastion> jetlag]$ ansible-playbook ansible/ibmcloud-create-inventory.yml
+(.ansible) [root@<bastion> jetlag]$ ansible-playbook ansible/ibmcloud-create-inventory.yml
 ...
 ```
 
@@ -267,25 +271,25 @@ The inventory file should resemble the [sample one provided](../ansible/inventor
 Next run the `ibmcloud-setup-bastion.yml` playbook ...
 
 ```console
-[user@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/ibmcloud.local ansible/ibmcloud-setup-bastion.yml
+(.ansible) [root@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/ibmcloud.local ansible/ibmcloud-setup-bastion.yml
 ...
 ```
 
 Finally run the `ibmcloud-sno-deploy.yml` playbook ...
 
 ```console
-[user@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/ibmcloud.local ansible/ibmcloud-sno-deploy.yml
+(.ansible) [root@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/ibmcloud.local ansible/ibmcloud-sno-deploy.yml
 ...
 ```
 
 If everything goes well you should have SNO(s) in about 50-60 minutes. You can interact with the SNOs from the bastion.
 
 ```console
-[root@<bastion> jetlag]# cd sno/
-[root@<bastion> sno]# oc --kubeconfig=jetlag-bm5/kubeconfig get no
+(.ansible) [root@<bastion> jetlag]# cd sno/
+(.ansible) [root@<bastion> sno]# oc --kubeconfig=jetlag-bm5/kubeconfig get no
 NAME         STATUS   ROLES           AGE   VERSION
 jetlag-bm5   Ready    master,worker   48m   v1.21.1+051ac4f
-[root@<bastion> sno]# oc --kubeconfig=jetlag-bm4/kubeconfig get no
+(.ansible) [root@<bastion> sno]# oc --kubeconfig=jetlag-bm4/kubeconfig get no
 NAME         STATUS   ROLES           AGE   VERSION
 jetlag-bm4   Ready    master,worker   48m   v1.21.1+051ac4f
 

--- a/docs/deploy-sno-quickstart.md
+++ b/docs/deploy-sno-quickstart.md
@@ -19,67 +19,43 @@ _**Table of Contents**_
  -->
 ## Bastion setup
 
-Sometimes the bastion machine may have firewall rules in place that prevent proper connectivity from the target cluster machines to the assisted-service API hosted on the bastion. Depending on the lab setup, you might need to add rules to allow this traffic, or if the bastion machine is already behind a firewall, the firewall could be disabled. One can, for instance, check for `firewalld` or `iptables`.
-
 1. Select the bastion machine from the allocation. You should run Jetlag on the
 bastion machine, to ensure full connectivity and fastest access. By convention
 this is usually the first node of your allocation: for example, the first machine
 listed in your cloud platform's standard inventory display.
 
-2. Copy your ssh public key to the designated bastion machine to make it easier to
+2. You can copy your ssh public key to the designated bastion machine to make it easier to
 repeatedly log in from your laptop:
 
 ```console
-[user@fedora ~]$ ssh-copy-id root@xxx-h01-000-r650.example.redhat.com
+[user@<local> ~]$ ssh-copy-id root@<bastion>
 /usr/bin/ssh-copy-id: INFO: attempting to log in with the new key(s), to filter out any that are already installed
 /usr/bin/ssh-copy-id: INFO: 2 key(s) remain to be installed -- if you are prompted now it is to install the new keys
-Warning: Permanently added 'xxx-h01-000-r650.example.redhat.com,x.x.x.x' (ECDSA) to the list of known hosts.
-root@xxx-h01-000-r650.example.redhat.com's password:
+Warning: Permanently added '<bastion>,x.x.x.x' (ECDSA) to the list of known hosts.
+root@<bastion>'s password:
 
 Number of key(s) added: 2
 
-Now try logging into the machine, with:   "ssh 'root@xxx-h01-000-r650.example.redhat.com'"
-and check to make sure that only the key(s) you wanted were added.
-[user@fedora ~]$
+# Now try logging into the machine, and confirm that only the expected key(s)
+# were added to ~/.ssh/known_hosts
+[user@<local> ~] ssh root@<bastion>
+[root@<bastion> ~]
 ```
 
-3. Update the version of RHEL on the bastion machine and reboot. Making sure that you
-have all patches available for your default RPM repository is always a good idea, unless
-you have specific testing requirements. The mechanism for changing repository may vary
-by your cloud setup, but, for example, the SCALE lab deploys with a script to alter
-the RHEL release repository that might be handy.
-
-Jetlag currently supports RHEL 8.6 and later as well as RHEL 9. Earlier versions of
-RHEL 8 have older components which can cause problems.
+3. Install some additional tools to help after reboot
 
 ```console
-[root@xxx-h01-000-r650 ~]# dnf update -y
-...
-Complete!
-[root@xxx-h01-000-r650 ~]# reboot
-Connection to xxx-h01-000-r650.rdu2.scalelab.redhat.com closed by remote host.
-Connection to xxx-h01-000-r650.rdu2.scalelab.redhat.com closed.
-...
-[user@fedora ~]$ ssh root@xxx-h01-000-r650.example.redhat.com
-...
-[root@xxx-h01-000-r650 ~]# cat /etc/redhat-release
-Red Hat Enterprise Linux release 8.9 (Ootpa)
-```
-
-2. Install some additional tools to help after reboot
-
-```console
-[root@xxx-r660 ~]# dnf install tmux git python3-pip sshpass -y
+[root@<bastion> ~]# dnf install tmux git python3-pip sshpass -y
 Updating Subscription Management repositories.
 ...
 Complete!
 ```
 
-3. Setup ssh keys for the bastion root account and copy to itself to permit
+4. Setup ssh keys for the bastion root account and copy to itself to permit
 local ansible interactions:
 
 ```console
-[root@xxx-r660 ~]# ssh-keygen
+[root@<bastion> ~]# ssh-keygen
 Generating public/private rsa key pair.
 Enter file in which to save the key (/root/.ssh/id_rsa):
 Enter passphrase (empty for no passphrase):
@@ -87,12 +63,12 @@ Enter same passphrase again:
 Your identification has been saved in /root/.ssh/id_rsa.
 Your public key has been saved in /root/.ssh/id_rsa.pub.
 The key fingerprint is:
-SHA256:uA61+n0w3Dht4/oIy1IKXrSgt9tfC/8zjICd7LJ550s root@xxx-r660.machine.com
+SHA256:uA61+n0w3Dht4/oIy1IKXrSgt9tfC/8zjICd7LJ550s root@<bastion>
 The key's randomart image is:
 +---[RSA 3072]----+
 ...
 +----[SHA256]-----+
-[root@xxx-r660 ~]# ssh-copy-id root@localhost
+[root@<bastion> ~]# ssh-copy-id root@localhost
 /usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/root/.ssh/id_rsa.pub"
 The authenticity of host 'localhost (127.0.0.1)' can't be established.
 ECDSA key fingerprint is SHA256:fvvO3NLxT9FPcoOKQ9ldVdd4aQnwuGVPwa+V1+/c4T8.
@@ -102,16 +78,16 @@ Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
 root@localhost's password:
 
 Number of key(s) added: 1
-
-Now try logging into the machine, with:   "ssh 'root@localhost'"
-and check to make sure that only the key(s) you wanted were added.
-[root@xxx-r660 ~]#
 ```
 
-4. Clone `jetlag`
+Now log in to the bastion (with `ssh root@<bastion>` if you copied your public key above,
+or using the bastion root account password if not), because the remaining commands
+should be executed from the bastion.
+
+5. Clone the `jetlag` GitHub repo
 
 ```console
-[root@xxx-r660 ~]# git clone https://github.com/redhat-performance/jetlag.git
+[root@<bastion> ~]# git clone https://github.com/redhat-performance/jetlag.git
 Cloning into 'jetlag'...
 remote: Enumerating objects: 4510, done.
 remote: Counting objects: 100% (4510/4510), done.
@@ -125,10 +101,21 @@ The `git clone` command will normally set the local head to the Jetlag repo's
 `main` branch. To set your local head to a different branch or tag (for example,
 a development branch), you can add `-b <name>` to the command.
 
-5. Download your pull_secret.txt from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) and place it in the root directory of `jetlag`
+Change your working directory to the repo's `jetlag` directory, which we'll assume
+for subsequent steps:
 
 ```console
-[root@xxx-r660 jetlag]# cat pull_secret.txt
+[root@<bastion> ~] cd jetlag
+[root@<bastion> jetlag]
+```
+
+6. Download your pull_secret.txt from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) and place it in the root directory of the local Jetlagrepo. You'll find the Pull Secret near the end of the long downloads
+page, in the section labeled "Tokens". You can either click the "Download" button and then copy `~/Downloads/pull-secret.txt` to `./pull_secret.txt` (notice that Jetlag expects an underscore (`_`) while the file will download with a hyphen (`-`)),
+*or* click on the "Copy" button, and then paste into the terminal after typing `cat >pull_secret.txt` to create the expected
+filename:
+
+```console
+[root@<bastion> jetlag]# cat >pull_secret.txt
 {
   "auths": {
     "quay.io": {
@@ -147,35 +134,34 @@ a development branch), you can add `-b <name>` to the command.
 }
 ```
 
-6. Change to `jetlag` directory, and then run `source bootstrap.sh`. This will
-activate a local virtual Python environment configured with the Jetlag and
+7. Execute the bootstrap script in the current shell, with `source bootstrap.sh`.
+This will activate a local virtual Python environment configured with the Jetlag and
 Ansible dependencies.
 
 ```console
-[root@xxx-r660 ~]# cd jetlag/
-[root@xxx-r660 jetlag]# source bootstrap.sh
+[root@<bastion> jetlag]# source bootstrap.sh
 Collecting pip
 ...
-(.ansible) [root@xxx-r660 jetlag]#
+(.ansible) [root@<bastion> jetlag]#
 ```
 
 You can re-enter that virtual environment when you log in to the bastion again
 with:
 
 ```console
-[root@xxx-r660 ~]# cd jetlag
-[root@xxx-r660 ~]# source .ansible/bin/activate
+[root@<bastion> ~]# cd jetlag
+[root@<bastion> jetlag]# source .ansible/bin/activate
 ```
 
 <!-- End of duplicated setup text -->
 
-## all.yml vars file
+## Configure Ansible vars in `all.yml`
 
 Next copy the vars file so we can edit it.
 
 ```console
-[user@fedora jetlag]$ cp ansible/vars/all.sample.yml ansible/vars/all.yml
-[user@fedora jetlag]$ vi ansible/vars/all.yml
+[user@<bastion> jetlag]$ cp ansible/vars/all.sample.yml ansible/vars/all.yml
+[user@<bastion> jetlag]$ vi ansible/vars/all.yml
 ```
 
 ### Lab & cluster infrastructure vars
@@ -197,7 +183,7 @@ For the ssh keys we have a chicken before the egg problem in that our bastion ma
 
 By default, Jetlag will choose the first node in an allocation as the bastion node.
 
-Set `smcipmitool_url` to the location of the Supermicro SMCIPMITool binary. Since you must accept a EULA in order to download, it is suggested to download the file and place it onto a local http server, that is accessible to your laptop or deployment machine. You can then always reference that URL. Alternatively, you can download it to the `ansible/` directory of your jetlag repo clone and rename the file to `smcipmitool.tar.gz`. You can find the file [here](https://www.supermicro.com/SwDownload/SwSelect_Free.aspx?cat=IPMI).
+Set `smcipmitool_url` to the location of the Supermicro SMCIPMITool binary. Since you must accept a EULA in order to download, it is suggested to download the file and place it onto a local http server, that is accessible to your laptop or deployment machine. You can then always reference that URL. Alternatively, you can download it to the `ansible/` directory of your Jetlag repo clone and rename the file to `smcipmitool.tar.gz`. You can find the file [here](https://www.supermicro.com/SwDownload/SwSelect_Free.aspx?cat=IPMI).
 
 The system type determines the values of `bastion_lab_interface` and `bastion_controlplane_interface`.
 
@@ -321,7 +307,7 @@ Oddly enough if you run into any routing issues because of duplicate address det
 
 The completed `all.yml` vars file and generated inventory files following this section only reflect that of an ipv4 connected install. If you previously deployed ipv4 stop and remove all running podman containers off the bastion and rerun the `setup-bastion.yml` playbook.
 
-## Review all.yml
+## Review `all.yml`
 
 The `ansible/vars/all.yml` now resembles ..
 
@@ -365,7 +351,7 @@ networktype: OVNKubernetes
 
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
-# Place your pull_secret.txt in the base directory of the cloned jetlag repo, Example:
+# Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
 # [user@fedora jetlag]$ ls pull_secret.txt
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
 
@@ -417,7 +403,7 @@ rwn_network_interface: ens1f1
 Run the create inventory playbook
 
 ```console
-[user@fedora jetlag]$ ansible-playbook ansible/create-inventory.yml
+[user@<bastion> jetlag]$ ansible-playbook ansible/create-inventory.yml
 ...
 ```
 
@@ -483,14 +469,14 @@ dns2=10.1.36.2
 Next run the `setup-bastion.yml` playbook ...
 
 ```console
-[user@fedora jetlag]$ ansible-playbook -i ansible/inventory/cloud99.local ansible/setup-bastion.yml
+[user@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/cloud99.local ansible/setup-bastion.yml
 ...
 ```
 
 We can now set the ssh vars in the `ansible/vars/all.yml` file since `setup-bastion.yml` has completed. For bare metal clusters only `ssh_public_key_file` is required to be filled out. The recommendation is to copy the public ssh key file from your bastion local to your laptop and set `ssh_public_key_file` to the location of that file. This file determines which ssh key will be automatically permitted to ssh into the cluster's nodes.
 
 ```console
-[user@fedora jetlag]$ scp root@f12-h05-000-1029u.rdu2.scalelab.redhat.com:/root/.ssh/id_rsa.pub .
+[user@<bastion> jetlag]$ scp root@f12-h05-000-1029u.rdu2.scalelab.redhat.com:/root/.ssh/id_rsa.pub .
 Warning: Permanently added 'f12-h05-000-1029u.rdu2.scalelab.redhat.com,10.1.43.101' (ECDSA) to the list of known hosts.
 id_rsa.pub                                                                                100%  554    22.6KB/s   00:00
 ```
@@ -500,7 +486,7 @@ Then set `ssh_public_key_file: /home/user/jetlag/id_rsa.pub` or to wherever you 
 Finally run the `sno-deploy.yml` playbook ...
 
 ```console
-[user@fedora jetlag]$ ansible-playbook -i ansible/inventory/cloud99.local ansible/sno-deploy.yml
+[user@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/cloud99.local ansible/sno-deploy.yml
 ...
 ```
 
@@ -509,7 +495,7 @@ A typical deployment will require around 60-70 minutes to complete mostly depend
 If everything goes well you should have a cluster in about 60-70 minutes. You can interact with the cluster from the bastion. Look for the kubeconfig file under `/root/sno/...`
 
 ```console
-[root@f12-h05-000-1029p ~]# export KUBECONFIG=/root/sno/<SNO's hostname>/kubeconfig
-[root@f12-h05-000-1029p ~]# oc get no
+[root@<bastion> jetlag]# export KUBECONFIG=/root/sno/<SNO's hostname>/kubeconfig
+[root@<bastion> jetlag]# oc get no
 ...
 ```

--- a/docs/deploy-sno-quickstart.md
+++ b/docs/deploy-sno-quickstart.md
@@ -6,7 +6,7 @@ _**Table of Contents**_
 
 <!-- TOC -->
 - [Bastion setup](#bastion-setup)
-- [all.yml vars file](#allyml-vars-file)
+- [Configure Ansible vars in `all.yml`](#configure-ansible-vars-in-allyml)
 - [Review all.yml](#review-allyml)
 - [Run playbooks](#run-playbooks)
 <!-- /TOC -->
@@ -134,6 +134,10 @@ filename:
 }
 ```
 
+If you are deploying nightly builds then you will need to add a ci token and an entry for
+`registry.ci.openshift.org`. If you plan on deploying an ACM downstream build be sure to
+include an entry for `quay.io:443`.
+
 7. Execute the bootstrap script in the current shell, with `source bootstrap.sh`.
 This will activate a local virtual Python environment configured with the Jetlag and
 Ansible dependencies.
@@ -160,8 +164,8 @@ with:
 Next copy the vars file so we can edit it.
 
 ```console
-[user@<bastion> jetlag]$ cp ansible/vars/all.sample.yml ansible/vars/all.yml
-[user@<bastion> jetlag]$ vi ansible/vars/all.yml
+(.ansible) [root@<bastion> jetlag]$ cp ansible/vars/all.sample.yml ansible/vars/all.yml
+(.ansible) [root@<bastion> jetlag]$ vi ansible/vars/all.yml
 ```
 
 ### Lab & cluster infrastructure vars
@@ -403,7 +407,7 @@ rwn_network_interface: ens1f1
 Run the create inventory playbook
 
 ```console
-[user@<bastion> jetlag]$ ansible-playbook ansible/create-inventory.yml
+(.ansible) [root@<bastion> jetlag]$ ansible-playbook ansible/create-inventory.yml
 ...
 ```
 
@@ -469,14 +473,14 @@ dns2=10.1.36.2
 Next run the `setup-bastion.yml` playbook ...
 
 ```console
-[user@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/cloud99.local ansible/setup-bastion.yml
+(.ansible) [root@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/cloud99.local ansible/setup-bastion.yml
 ...
 ```
 
 We can now set the ssh vars in the `ansible/vars/all.yml` file since `setup-bastion.yml` has completed. For bare metal clusters only `ssh_public_key_file` is required to be filled out. The recommendation is to copy the public ssh key file from your bastion local to your laptop and set `ssh_public_key_file` to the location of that file. This file determines which ssh key will be automatically permitted to ssh into the cluster's nodes.
 
 ```console
-[user@<bastion> jetlag]$ scp root@f12-h05-000-1029u.rdu2.scalelab.redhat.com:/root/.ssh/id_rsa.pub .
+(.ansible) [root@<bastion> jetlag]$ scp root@f12-h05-000-1029u.rdu2.scalelab.redhat.com:/root/.ssh/id_rsa.pub .
 Warning: Permanently added 'f12-h05-000-1029u.rdu2.scalelab.redhat.com,10.1.43.101' (ECDSA) to the list of known hosts.
 id_rsa.pub                                                                                100%  554    22.6KB/s   00:00
 ```
@@ -486,7 +490,7 @@ Then set `ssh_public_key_file: /home/user/jetlag/id_rsa.pub` or to wherever you 
 Finally run the `sno-deploy.yml` playbook ...
 
 ```console
-[user@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/cloud99.local ansible/sno-deploy.yml
+(.ansible) [root@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/cloud99.local ansible/sno-deploy.yml
 ...
 ```
 
@@ -495,7 +499,7 @@ A typical deployment will require around 60-70 minutes to complete mostly depend
 If everything goes well you should have a cluster in about 60-70 minutes. You can interact with the cluster from the bastion. Look for the kubeconfig file under `/root/sno/...`
 
 ```console
-[root@<bastion> jetlag]# export KUBECONFIG=/root/sno/<SNO's hostname>/kubeconfig
-[root@<bastion> jetlag]# oc get no
+(.ansible) [root@<bastion> jetlag]# export KUBECONFIG=/root/sno/<SNO's hostname>/kubeconfig
+(.ansible) [root@<bastion> jetlag]# oc get no
 ...
 ```

--- a/docs/deploy-sno-quickstart.md
+++ b/docs/deploy-sno-quickstart.md
@@ -75,8 +75,8 @@ Number of key(s) added: 2
 
 # Now try logging into the machine, and confirm that only the expected key(s)
 # were added to ~/.ssh/known_hosts
-[user@<local> ~] ssh root@<bastion>
-[root@<bastion> ~]
+[user@<local> ~]$ ssh root@<bastion>
+[root@<bastion> ~]#
 ```
 
 Now log in to the bastion (with `ssh root@<bastion>` if you copied your public key above,
@@ -146,8 +146,8 @@ Change your working directory to the repo's `jetlag` directory, which we'll assu
 for subsequent steps:
 
 ```console
-[root@<bastion> ~] cd jetlag
-[root@<bastion> jetlag]
+[root@<bastion> ~]# cd jetlag
+[root@<bastion> jetlag]#
 ```
 
 6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
@@ -206,8 +206,8 @@ with:
 Next copy the vars file so we can edit it.
 
 ```console
-(.ansible) [root@<bastion> jetlag]$ cp ansible/vars/all.sample.yml ansible/vars/all.yml
-(.ansible) [root@<bastion> jetlag]$ vi ansible/vars/all.yml
+(.ansible) [root@<bastion> jetlag]# cp ansible/vars/all.sample.yml ansible/vars/all.yml
+(.ansible) [root@<bastion> jetlag]# vi ansible/vars/all.yml
 ```
 
 ### Lab & cluster infrastructure vars
@@ -398,7 +398,7 @@ networktype: OVNKubernetes
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
 # Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
-# [root@<bastion> jetlag]$ ls pull_secret.txt
+# [root@<bastion> jetlag]# ls pull_secret.txt
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
 
 ################################################################################
@@ -449,7 +449,7 @@ rwn_network_interface: ens1f1
 Run the create inventory playbook
 
 ```console
-(.ansible) [root@<bastion> jetlag]$ ansible-playbook ansible/create-inventory.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook ansible/create-inventory.yml
 ...
 ```
 
@@ -515,24 +515,24 @@ dns2=10.1.36.2
 Next run the `setup-bastion.yml` playbook ...
 
 ```console
-(.ansible) [root@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/cloud99.local ansible/setup-bastion.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/setup-bastion.yml
 ...
 ```
 
 We can now set the ssh vars in the `ansible/vars/all.yml` file since `setup-bastion.yml` has completed. For bare metal clusters only `ssh_public_key_file` is required to be filled out. The recommendation is to copy the public ssh key file from your bastion local to your laptop and set `ssh_public_key_file` to the location of that file. This file determines which ssh key will be automatically permitted to ssh into the cluster's nodes.
 
 ```console
-(.ansible) [root@<bastion> jetlag]$ scp root@f12-h05-000-1029u.rdu2.scalelab.redhat.com:/root/.ssh/id_rsa.pub .
-Warning: Permanently added 'f12-h05-000-1029u.rdu2.scalelab.redhat.com,10.1.43.101' (ECDSA) to the list of known hosts.
+[user@<local> ~]$ scp root@<bastion>:/root/.ssh/id_rsa.pub .
+Warning: Permanently added '<bastion>,10.1.43.101' (ECDSA) to the list of known hosts.
 id_rsa.pub                                                                                100%  554    22.6KB/s   00:00
 ```
 
 Then set `ssh_public_key_file: /home/user/jetlag/id_rsa.pub` or to wherever you copied the file down to.
 
-Finally run the `sno-deploy.yml` playbook ...
+Finally run the `sno-deploy.yml` playbook from the bastion ...
 
 ```console
-(.ansible) [root@<bastion> jetlag]$ ansible-playbook -i ansible/inventory/cloud99.local ansible/sno-deploy.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/sno-deploy.yml
 ...
 ```
 

--- a/docs/deploy-sno-quickstart.md
+++ b/docs/deploy-sno-quickstart.md
@@ -1,9 +1,7 @@
 # Deploy a Single Node OpenShift cluster via Jetlag quickstart
 
-Assuming you received a scale lab allocation named `cloud99`, this guide will walk you through getting a Single Node OpenShift (SNO) cluster up in your allocation. For purposes of the guide the systems in `cloud99` will be Supermicro 1029U. You should run Jetlag directly on the bastion machine. Jetlag picks the first machine in an allocation as the bastion. You can [trick Jetlag into picking a different machine as the bastion](tips-and-vars.md#override-lab-ocpinventory-json-file) but that is beyond the scope of this quickstart.
-
-Select the host name or IP for the first machine of your allocation from the
-[scale lab wiki](http://wiki.rdu2.scalelab.redhat.com/) as your bastion.
+Assuming you received a scale lab allocation named `cloud99`, this guide will walk you through getting a Single Node OpenShift (SNO) cluster up in your allocation. For purposes of the guide the systems in `cloud99` will be Supermicro 1029U. You should run Jetlag directly on the bastion machine. Jetlag picks the first machine in an allocation as the bastion. You can [trick Jetlag into picking a different machine as the bastion](tips-and-vars.md#override-lab-ocpinventory-json-file) but that is beyond the scope of this quickstart. You can find the machines in your cloud allocation on
+[the scale lab wiki](http://wiki.rdu2.scalelab.redhat.com/)
 
 Update the version of RHEL on the bastion machine if necessary, and reboot.
 
@@ -153,10 +151,10 @@ for subsequent steps:
 ```
 
 6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
-the long downloads page, in the section labeled "Tokens". You can either click the "Download" button and then copy the
+the long downloads page, in the section labeled "Tokens". You can either click the "Download" button, and then copy the
 downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
-file will download with a hyphen (`-`)), *or* click on the "Copy" button, and then paste into the terminal after typing
-`cat >pull_secret.txt` on the bastion to create the expected filename:
+file will download with a hyphen (`-`)); *or* click on the "Copy" button, and then paste the clipboard into the terminal
+after typing `cat >pull_secret.txt` on the bastion to create the expected filename:
 
 ```console
 [root@<bastion> jetlag]# cat >pull_secret.txt

--- a/docs/deploy-sno-quickstart.md
+++ b/docs/deploy-sno-quickstart.md
@@ -1,6 +1,45 @@
 # Deploy a Single Node OpenShift cluster via Jetlag quickstart
 
-Assuming you received a scale lab allocation named `cloud99`, this guide will walk you through getting a Single Node OpenShift (SNO) cluster up in your allocation. For purposes of the guide the systems in `cloud99` will be Supermicro 1029U.
+Assuming you received a scale lab allocation named `cloud99`, this guide will walk you through getting a Single Node OpenShift (SNO) cluster up in your allocation. For purposes of the guide the systems in `cloud99` will be Supermicro 1029U. You should run Jetlag directly on the bastion machine. Jetlag picks the first machine in an allocation as the bastion. You can [trick Jetlag into picking a different machine as the bastion](tips-and-vars.md#override-lab-ocpinventory-json-file) but that is beyond the scope of this quickstart.
+
+Select the host name or IP for the first machine of your allocation from the
+[scale lab wiki](http://wiki.rdu2.scalelab.redhat.com/) as your bastion.
+
+Update the version of RHEL on the bastion machine if necessary, and reboot.
+
+```console
+[user@<local> ~]$ ssh root@<bastion>
+...
+[root@<bastion> ~]# cat /etc/redhat-release
+Red Hat Enterprise Linux release 8.2 (Ootpa)
+
+[root@<bastion> ~]# ./update-latest-rhel-release.sh 8.9
+Changing repository from 8.2 to 8.9
+Cleaning dnf repo cache..
+
+-------------------------
+Run dnf update to upgrade to RHEL 8.9
+
+[root@<bastion> ~]# dnf update -y
+Updating Subscription Management repositories.
+Unable to read consumer identity
+This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
+rhel89 AppStream                                                                                                                                              245 MB/s | 7.8 MB     00:00
+rhel89 BaseOS                                                                                                                                                 119 MB/s | 2.4 MB     00:00
+Extra Packages for Enterprise Linux 8 - x86_64                                                                                                                 14 MB/s |  14 MB     00:00
+Last metadata expiration check: 0:00:01 ago on Tue 02 May 2023 06:58:15 PM UTC.
+Dependencies resolved.
+...
+Complete!
+[root@<bastion> ~]# reboot
+Connection to <bastion> closed by remote host.
+Connection to <bastion> closed.
+...
+[user@<local> ~]$ ssh root@<bastion>
+...
+[root@<bastion> ~]# cat /etc/redhat-release
+Red Hat Enterprise Linux release 8.9 (Ootpa)
+```
 
 _**Table of Contents**_
 
@@ -41,6 +80,10 @@ Number of key(s) added: 2
 [user@<local> ~] ssh root@<bastion>
 [root@<bastion> ~]
 ```
+
+Now log in to the bastion (with `ssh root@<bastion>` if you copied your public key above,
+or using the bastion root account password if not), because the remaining commands
+should be executed from the bastion.
 
 3. Install some additional tools to help after reboot
 
@@ -109,10 +152,11 @@ for subsequent steps:
 [root@<bastion> jetlag]
 ```
 
-6. Download your pull_secret.txt from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) and place it in the root directory of the local Jetlagrepo. You'll find the Pull Secret near the end of the long downloads
-page, in the section labeled "Tokens". You can either click the "Download" button and then copy `~/Downloads/pull-secret.txt` to `./pull_secret.txt` (notice that Jetlag expects an underscore (`_`) while the file will download with a hyphen (`-`)),
-*or* click on the "Copy" button, and then paste into the terminal after typing `cat >pull_secret.txt` to create the expected
-filename:
+6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
+the long downloads page, in the section labeled "Tokens". You can either click the "Download" button and then copy the
+downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
+file will download with a hyphen (`-`)), *or* click on the "Copy" button, and then paste into the terminal after typing
+`cat >pull_secret.txt` on the bastion to create the expected filename:
 
 ```console
 [root@<bastion> jetlag]# cat >pull_secret.txt
@@ -356,7 +400,7 @@ networktype: OVNKubernetes
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
 # Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
-# [user@fedora jetlag]$ ls pull_secret.txt
+# [root@<bastion> jetlag]$ ls pull_secret.txt
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
 
 ################################################################################

--- a/docs/deploy-sno-quickstart.md
+++ b/docs/deploy-sno-quickstart.md
@@ -3,42 +3,6 @@
 Assuming you received a scale lab allocation named `cloud99`, this guide will walk you through getting a Single Node OpenShift (SNO) cluster up in your allocation. For purposes of the guide the systems in `cloud99` will be Supermicro 1029U. You should run Jetlag directly on the bastion machine. Jetlag picks the first machine in an allocation as the bastion. You can [trick Jetlag into picking a different machine as the bastion](tips-and-vars.md#override-lab-ocpinventory-json-file) but that is beyond the scope of this quickstart. You can find the machines in your cloud allocation on
 [the scale lab wiki](http://wiki.rdu2.scalelab.redhat.com/)
 
-Update the version of RHEL on the bastion machine if necessary, and reboot.
-
-```console
-[user@<local> ~]$ ssh root@<bastion>
-...
-[root@<bastion> ~]# cat /etc/redhat-release
-Red Hat Enterprise Linux release 8.2 (Ootpa)
-
-[root@<bastion> ~]# ./update-latest-rhel-release.sh 8.9
-Changing repository from 8.2 to 8.9
-Cleaning dnf repo cache..
-
--------------------------
-Run dnf update to upgrade to RHEL 8.9
-
-[root@<bastion> ~]# dnf update -y
-Updating Subscription Management repositories.
-Unable to read consumer identity
-This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
-rhel89 AppStream                                                                                                                                              245 MB/s | 7.8 MB     00:00
-rhel89 BaseOS                                                                                                                                                 119 MB/s | 2.4 MB     00:00
-Extra Packages for Enterprise Linux 8 - x86_64                                                                                                                 14 MB/s |  14 MB     00:00
-Last metadata expiration check: 0:00:01 ago on Tue 02 May 2023 06:58:15 PM UTC.
-Dependencies resolved.
-...
-Complete!
-[root@<bastion> ~]# reboot
-Connection to <bastion> closed by remote host.
-Connection to <bastion> closed.
-...
-[user@<local> ~]$ ssh root@<bastion>
-...
-[root@<bastion> ~]# cat /etc/redhat-release
-Red Hat Enterprise Linux release 8.9 (Ootpa)
-```
-
 _**Table of Contents**_
 
 <!-- TOC -->
@@ -83,7 +47,51 @@ Now log in to the bastion (with `ssh root@<bastion>` if you copied your public k
 or using the bastion root account password if not), because the remaining commands
 should be executed from the bastion.
 
-3. Install some additional tools to help after reboot
+3. Upgrade RHEL to at least RHEL 8.6
+
+You need to be running at least RHEL 8.6 to have the minimal `podman`. By default,
+the SCALE lab installs RHEL 8.2. We recommend upgrading to RHEL 8.9
+using the `/root/update-latest-rhel-release.sh` script provisioned by the QUADS
+system. You can determine the installed version by looking at `/etc/redhat-release`,
+and the update script allows you to ask what versions are supported:
+
+```console
+[root@<bastion> ~]# cat /etc/redhat-release
+Red Hat Enterprise Linux release 8.2 (Ootpa)
+[root@<bastion> ~]# /root/update-latest-rhel-release.sh list`
+8.2 8.6 8.9
+```
+
+```console
+[root@<bastion> ~]# ./update-latest-rhel-release.sh 8.9
+Changing repository from 8.2 to 8.9
+Cleaning dnf repo cache..
+
+-------------------------
+Run dnf update to upgrade to RHEL 8.9
+
+[root@<bastion> ~]# dnf update -y
+Updating Subscription Management repositories.
+Unable to read consumer identity
+This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
+rhel89 AppStream                                                                                                                                              245 MB/s | 7.8 MB     00:00
+rhel89 BaseOS                                                                                                                                                 119 MB/s | 2.4 MB     00:00
+Extra Packages for Enterprise Linux 8 - x86_64                                                                                                                 14 MB/s |  14 MB     00:00
+Last metadata expiration check: 0:00:01 ago on Tue 02 May 2023 06:58:15 PM UTC.
+Dependencies resolved.
+...
+Complete!
+[root@<bastion> ~]# reboot
+Connection to <bastion> closed by remote host.
+Connection to <bastion> closed.
+...
+[user@<local> ~]$ ssh root@<bastion>
+...
+[root@<bastion> ~]# cat /etc/redhat-release
+Red Hat Enterprise Linux release 8.9 (Ootpa)
+```
+
+4. Install some additional tools to help after reboot
 
 ```console
 [root@<bastion> ~]# dnf install tmux git python3-pip sshpass -y
@@ -92,7 +100,7 @@ Updating Subscription Management repositories.
 Complete!
 ```
 
-4. Setup ssh keys for the bastion root account and copy to itself to permit
+5. Setup ssh keys for the bastion root account and copy to itself to permit
 local ansible interactions:
 
 ```console
@@ -125,7 +133,7 @@ Now log in to the bastion (with `ssh root@<bastion>` if you copied your public k
 or using the bastion root account password if not), because the remaining commands
 should be executed from the bastion.
 
-5. Clone the `jetlag` GitHub repo
+6. Clone the `jetlag` GitHub repo
 
 ```console
 [root@<bastion> ~]# git clone https://github.com/redhat-performance/jetlag.git
@@ -150,7 +158,7 @@ for subsequent steps:
 [root@<bastion> jetlag]#
 ```
 
-6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
+7. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
 the long downloads page, in the section labeled "Tokens". You can either click the "Download" button, and then copy the
 downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
 file will download with a hyphen (`-`)); *or* click on the "Copy" button, and then paste the clipboard into the terminal
@@ -180,7 +188,7 @@ If you are deploying nightly builds then you will need to add a ci token and an 
 `registry.ci.openshift.org`. If you plan on deploying an ACM downstream build be sure to
 include an entry for `quay.io:443`.
 
-7. Execute the bootstrap script in the current shell, with `source bootstrap.sh`.
+8. Execute the bootstrap script in the current shell, with `source bootstrap.sh`.
 This will activate a local virtual Python environment configured with the Jetlag and
 Ansible dependencies.
 

--- a/docs/hypervisors.md
+++ b/docs/hypervisors.md
@@ -17,11 +17,13 @@ BM/RWN cluster types will allocate remaining hardware that was not put in the in
 
 Make sure to set and append the following vars in the "extra vars" section of the `vars/all.yml`
 
-* `hv_inventory` - Enables placing remaining cloud hardware into hypervisor host group in inventory file
-* `hv_ssh_pass` - The ssh password to the hypervisor machines
-* `hv_ip_offset` - Offsets hypervisor ip addresses to allow for future expansion of the "hub" cluster. For example, a setting of `10` allows the hub cluster to grow 10 nodes before the ip addresses will conflict with the hypervisors.
-* `hv_vm_prefix` - Set to a specific prefix. Defaults to `sno` which produces vms with hostnames sno00001, sno00002, ... snoXXXXX
-* `hypervisor_nic_interface_idx` - Defaults to `1` and corresponds to Network 1 in the scalelab. The index is used to lookup which nic name will be bridged for the VMs.
+| Variable | Meaning |
+| - | - |
+| `hv_inventory` | Enables placing remaining cloud hardware into hypervisor host group in inventory file
+| `hv_ssh_pass` | The ssh password to the hypervisor machines
+| `hv_ip_offset` | Offsets hypervisor ip addresses to allow for future expansion of the "hub" cluster. For example, a setting of `10` allows the hub cluster to grow 10 nodes before the ip addresses will conflict with the hypervisors.
+| `hv_vm_prefix` | Set to a specific prefix. Defaults to `sno` which produces VMs with hostnames `sno00001`, `sno00002`, ... `snoXXXXX`
+| `hypervisor_nic_interface_idx` | Defaults to `1` and corresponds to Network 1 in the scalelab. The index is used to lookup which nic name will be bridged for the VMs.
 
 The default VM resource configuration is:
 
@@ -46,10 +48,12 @@ After generating an inventory with the `create-inventory.yml` playbook, the hype
 
 Pay close attention to these vars:
 
-* `lab` - Likely `scalelab` as that is the only lab this has been setup and tested in.
-* `setup_hv_vm_dhcp` - Set to true if dnsmasq should be configured on each hypervisor to hand out static addresses to each vm
-* `base_dns_name` - If you set this for your hub cluster, then set it identically here
-* `controlplane_network` - If you adjusted this for the hub cluster, make sure it matches for the hypervisors
+| Variable | Comment |
+| - | - |
+| `lab` | Likely `scalelab` as that is the only lab where this has been tested.
+| `setup_hv_vm_dhcp` | Set to true if `dnsmasq` should be configured on each hypervisor to hand out static addresses to each VM.
+| `base_dns_name` | If you set this for your hub cluster, then set it identically here
+| `controlplane_network` | If you adjusted this for the hub cluster, make sure it matches for the hypervisors
 
 Run hv-setup playbook
 
@@ -70,11 +74,13 @@ To apply network impairments, first copy the network-impairments sample vars fil
 
 Make sure to set/review the following vars:
 
-* `install_tc` - toggles installing traffic control
-* `apply_egress_impairments` and `apply_ingress_impairments` - toggles out-going or incoming traffic impairments
-* `egress_delay` and `ingress_delay` - latency for egress/ingress in milliseconds
-* `egress_packet_loss` and `ingress_packet_loss` - packet loss in percent (Example `0.01` for 0.01%)
-* `egress_bandwidth` and `ingress_bandwidth` - bandwidth in kilobits (Example `100000` which is 100000kbps or 100Mbps)
+| Variable | Description |
+| - | - |
+| `install_tc` | toggles installing traffic control
+| `apply_egress_impairments` and `apply_ingress_impairments` | toggles out-going or incoming traffic impairments
+| `egress_delay` and `ingress_delay` | latency for egress/ingress in milliseconds
+| `egress_packet_loss` and `ingress_packet_loss` | packet loss in percent (Example `0.01` for 0.01%)
+| `egress_bandwidth` and `ingress_bandwidth` | bandwidth in kilobits (Example `100000` which is 100000kbps or 100Mbps)
 
 Apply impairments:
 

--- a/docs/hypervisors.md
+++ b/docs/hypervisors.md
@@ -134,7 +134,7 @@ When you create vms, depending upon what `hv_vm_manifest_type`, you will find pr
 # ls -lh /root/hv-vm/
 total 0
 drwxr-xr-x. 3 root root 23 Jul 22 18:34 jumbo
-(.ansible) [root@f31-h05-000-r640 jetlag]# ls -lh /root/hv-vm/jumbo/manifests/
+(.ansible) [root@<bastion> jetlag]# ls -lh /root/hv-vm/jumbo/manifests/
 total 456K
 -rw-r--r--. 1 root root 453K Jul 22 18:51 manifest.yml
 ```
@@ -142,7 +142,7 @@ total 456K
 As expected, cluster type of `jumbo` includes just one yaml file with all the manifests to create the jumbo cluster.
 
 ```console
-(.ansible) [root@f31-h05-000-r640 jetlag]# ls -lh /root/hv-vm/compact/siteconfigs/
+(.ansible) [root@<bastion>jetlag]# ls -lh /root/hv-vm/compact/siteconfigs/
 total 400K
 -rw-r--r--. 1 root root 97K Jul 22 19:30 compact-00001-resources.yml
 -rw-r--r--. 1 root root 97K Jul 22 19:30 compact-00001-siteconfig.yml

--- a/docs/hypervisors.md
+++ b/docs/hypervisors.md
@@ -40,8 +40,8 @@ The hypervisors bridge a network interface that was determined at the `create-in
 After generating an inventory with the `create-inventory.yml` playbook, the hypervisor can be setup. Start by editing the vars
 
 ```console
-cp ansible/vars/hv.sample.yml ansible/vars/hv.yml
-vi ansible/vars/hv.yml
+(.ansible) [root@<bastion> jetlag]# cp ansible/vars/hv.sample.yml ansible/vars/hv.yml
+(.ansible) [root@<bastion> jetlag]# vi ansible/vars/hv.yml
 ```
 
 Pay close attention to these vars:
@@ -54,7 +54,7 @@ Pay close attention to these vars:
 Run hv-setup playbook
 
 ```console
-ansible-playbook -i ansible/inventory/cloud42.local ansible/hv-setup.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud42.local ansible/hv-setup.yml
 ```
 
 ## Hypervisor Network-Impairments
@@ -64,8 +64,8 @@ For testing where network impairments are required, we can apply latency/packet-
 To apply network impairments, first copy the network-impairments sample vars file
 
 ```console
-cp ansible/vars/network-impairments.sample.yml ansible/vars/network-impairments.yml
-vi ansible/vars/network-impairments.yml
+(.ansible) [root@<bastion> jetlag]# cp ansible/vars/network-impairments.sample.yml ansible/vars/network-impairments.yml
+(.ansible) [root@<bastion> jetlag]# vi ansible/vars/network-impairments.yml
 ```
 
 Make sure to set/review the following vars:
@@ -79,13 +79,13 @@ Make sure to set/review the following vars:
 Apply impairments:
 
 ```console
-ansible-playbook -i ansible/inventory/cloud03.local ansible/hv-network-impairments.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud03.local ansible/hv-network-impairments.yml
 ```
 
 Remove impairments:
 
 ```console
-ansible-playbook -i ansible/inventory/cloud03.local ansible/hv-network-impairments.yml -e 'apply_egress_impairments=false apply_ingress_impairments=false'
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud03.local ansible/hv-network-impairments.yml -e 'apply_egress_impairments=false apply_ingress_impairments=false'
 ```
 
 Note, egress impairments are applied directly to the impaired nic. Ingress impairments are applied to an ifb interface that handles ingress traffic for the impaired nic.
@@ -95,8 +95,8 @@ Note, egress impairments are applied directly to the impaired nic. Ingress impai
 Three playbooks are included to create, delete and replace the vms. All three playbooks depend on the same vars file and it should be copied in the same fashion as previous vars files:
 
 ```console
-cp ansible/vars/hv.sample.yml ansible/vars/hv.yml
-vi ansible/vars/hv.yml
+(.ansible) [root@<bastion> jetlag]# cp ansible/vars/hv.sample.yml ansible/vars/hv.yml
+(.ansible) [root@<bastion> jetlag]# vi ansible/vars/hv.yml
 ```
 
 The following vars apply to the manifests which are generated for deploying OCP clusters from ACM/MCE using the VMs as "emulated BareMetal Nodes":
@@ -111,19 +111,19 @@ The following vars apply to the manifests which are generated for deploying OCP 
 Run create vms:
 
 ```console
-ansible-playbook -i ansible/inventory/cloud42.local ansible/hv-vm-create.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud42.local ansible/hv-vm-create.yml
 ```
 
 Run replace vms (Deletes then creates vms):
 
 ```console
-ansible-playbook -i ansible/inventory/cloud42.local ansible/hv-vm-replace.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud42.local ansible/hv-vm-replace.yml
 ```
 
 Run delete vms:
 
 ```console
-ansible-playbook -i ansible/inventory/cloud42.local ansible/hv-vm-delete.yml
+(.ansible) [root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud42.local ansible/hv-vm-delete.yml
 ```
 
 ## Manifests and Siteconfigs

--- a/docs/hypervisors.md
+++ b/docs/hypervisors.md
@@ -112,7 +112,7 @@ The following vars apply to the manifests which are generated for deploying OCP 
 | `ssh_public_key_file` | Sets the permitted ssh key to ssh into the node |
 | `setup_hv_vm_dhcp` | Leaves the nmstateconfig portion out of the manifests |
 | `hv_vm_manifest_type` | Determines which kind of manifest(s) the playbook will generate, choose from `sno`, `compact`, `standard`, and `jumbo` |
-| `hv_vm_manifest_acm_cr` | Set to true if ACM CRs are desired to be generated with the manifests |
+| `hv_vm_manifest_acm_cr` | Set to true if you want ACM CRs generated with the manifests |
 | `compact_cluster_count` | If `hv_vm_manifest_type: compact`, then this determines the number of compact cluster siteconfigs to generate. Each compact cluster consists of 3 vms, be careful not to exceed the entire count of vms. |
 | `standard_cluster_count` | If `hv_vm_manifest_type: standard`, then this determines the number of standard cluster siteconfigs to generate. It will include `standard_cluster_node_count` count of vms in each standard cluster siteconfig. Be careful not to exceed the entire count of vms. |
 

--- a/docs/hypervisors.md
+++ b/docs/hypervisors.md
@@ -101,12 +101,14 @@ Three playbooks are included to create, delete and replace the vms. All three pl
 
 The following vars apply to the manifests which are generated for deploying OCP clusters from ACM/MCE using the VMs as "emulated BareMetal Nodes":
 
-* `ssh_public_key_file` - Sets the permitted ssh key to ssh into the node
-* `setup_hv_vm_dhcp` - Leaves the nmstateconfig portion out of the manifests
-* `hv_vm_manifest_type` - Determines which kind of manifest(s) the playbook will generate, choose from `sno`, `compact`, `standard`, and `jumbo`
-* `hv_vm_manifest_acm_cr` - Set to true if ACM CRs are desired to be generated with the manifests
-* `compact_cluster_count` - If `hv_vm_manifest_type: compact`, then this determines the number of compact cluster siteconfigs to generate. Each compact cluster consists of 3 vms, be careful not to exceed the entire count of vms.
-* `standard_cluster_count` - If `hv_vm_manifest_type: standard`, then this determines the number of standard cluster siteconfigs to generate. It will include `standard_cluster_node_count` count of vms in each standard cluster siteconfig. Be careful not to exceed the entire count of vms.
+| Variable name | Meaning |
+| - | - |
+| `ssh_public_key_file` | Sets the permitted ssh key to ssh into the node |
+| `setup_hv_vm_dhcp` | Leaves the nmstateconfig portion out of the manifests |
+| `hv_vm_manifest_type` | Determines which kind of manifest(s) the playbook will generate, choose from `sno`, `compact`, `standard`, and `jumbo` |
+| `hv_vm_manifest_acm_cr` | Set to true if ACM CRs are desired to be generated with the manifests |
+| `compact_cluster_count` | If `hv_vm_manifest_type: compact`, then this determines the number of compact cluster siteconfigs to generate. Each compact cluster consists of 3 vms, be careful not to exceed the entire count of vms. |
+| `standard_cluster_count` | If `hv_vm_manifest_type: standard`, then this determines the number of standard cluster siteconfigs to generate. It will include `standard_cluster_node_count` count of vms in each standard cluster siteconfig. Be careful not to exceed the entire count of vms. |
 
 Run create vms:
 

--- a/docs/order-hardware-ibmcloud.md
+++ b/docs/order-hardware-ibmcloud.md
@@ -57,13 +57,13 @@ To get started with IBMcloud shell, refer to https://cloud.ibm.com/docs/cloud-sh
 Once you have successfully logged into the IBMcloud Shell, you should be able to list  your devices using the following command:
 
 ```console
-[user@fedora]$ ibmcloud sl hardware list
+[user@<local>]$ ibmcloud sl hardware list
 ```
 
 Sample output:
 
 ```console
-$ ibmcloud sl hardware list
+[user@<local>]$ ibmcloud sl hardware list
 id        hostname     domain                    public_ip        private_ip    datacenter   status
 960237    jetlag-bm0   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE
 1165601   jetlag-bm1   performance-scale.cloud   X.X.X.X          X.X.X.X       dal10        ACTIVE

--- a/docs/order-hardware-ibmcloud.md
+++ b/docs/order-hardware-ibmcloud.md
@@ -18,7 +18,7 @@ You can select the location/datacenter and the Server profile based on cost esti
 For baremetal deployment, you will need:
 
 * One server to be provisioned as your bastion machine
-* Three additional servers to serve as control-plane nodes 
+* Three additional servers to serve as control-plane nodes
 * At least two more servers to serve as worker nodes in your openshift cluster
 
 The following guides can also assist you with procurement of devices:
@@ -36,7 +36,7 @@ Points to keep in mind while ordering hardware:
 * Port speed of 10 Gbps at minimum
 * The bastion machine should have a public accessible ip and will NAT traffic for the cluster to the public network. Other machines can have a public ip address but it is not currently in use with this deployment method.
 
-You might not receive an immediate notification on the order you just placed. 
+You might not receive an immediate notification on the order you just placed.
 If there are significant delays, IBMcloud will open up a support ticket on your behalf to notify about the readiness status of your servers.
 
 Once you are notified of the servers being ready, login to IBMcloud and navigate to 'Classic Infrastructure' to view your devices.
@@ -46,7 +46,7 @@ Once you are notified of the servers being ready, login to IBMcloud and navigate
 
 **IBMcloud VPN access:**
 
-To manage your servers remotely and securely over the IBM Cloud private network, you need to connect to IBMcloud VPN. 
+To manage your servers remotely and securely over the IBM Cloud private network, you need to connect to IBMcloud VPN.
 
 To get started, refer to https://cloud.ibm.com/docs/iaas-vpn?topic=iaas-vpn-getting-started
 
@@ -77,4 +77,3 @@ id        hostname     domain                    public_ip        private_ip    
 
 To open a support case with IBMcloud, access the link below:
 https://cloud.ibm.com/unifiedsupport/supportcenter
-

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -45,7 +45,7 @@ Alias lab chart is available [here](http://wiki.alias.bos.scalelab.redhat.com/fa
 By default Jetlag selects machines for the roles bastion, control-plane, and worker in that order from the ocpinventory.json file. You can create a new json file with the desired order to match desired roles if the auto selection is incorrect. After creating a new json file, host this where your machine running the playbooks can reach and set the following var such that the modified ocpinventory json file is used:
 
 ```yaml
-ocp_inventory_override: http://example.redhat.com/cloud12-inventories/cloud12-cp_r640-w_5039ms.json
+ocp_inventory_override: http://<http-server>/<inventory-file>.json
 ```
 ## DU Profile for SNOs
 

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -42,7 +42,7 @@ Alias lab chart is available [here](http://wiki.alias.bos.scalelab.redhat.com/fa
 
 ## Override lab ocpinventory json file
 
-Current jetlag lab use selects machines for roles bastion, control-plane, and worker in that order from the ocpinventory.json file. You may have to create a new json file with the desired order to match desired roles if the auto selection is incorrect. After creating a new json file, host this where your machine running the playbooks can reach and set the following var such that the modified ocpinventory json file is used:
+Current Jetlag lab use selects machines for roles bastion, control-plane, and worker in that order from the ocpinventory.json file. You may have to create a new json file with the desired order to match desired roles if the auto selection is incorrect. After creating a new json file, host this where your machine running the playbooks can reach and set the following var such that the modified ocpinventory json file is used:
 
 ```yaml
 ocp_inventory_override: http://example.redhat.com/cloud12-inventories/cloud12-cp_r640-w_5039ms.json
@@ -293,9 +293,9 @@ controlplane_nvme_device: /dev/disk/by-path/pci-0000:b2:00.0-nvme-1
 controlplane_etcd_on_nvme: true
 ```
 
-**Note:** The values seen in `/dev/disk/by-path` may differ between RHEL8 and RHEL9.  
+**Note:** The values seen in `/dev/disk/by-path` may differ between RHEL8 and RHEL9.
 If your OpenShift version is based on RHEL9 (4.13+), you should install RHEL9 on the nodes
-first to ensure the paths are correct.  
+first to ensure the paths are correct.
 eg: `/dev/sda` - Seen on Supermicro 1029U
 ```
 RHEL8:

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -175,7 +175,7 @@ When worikng with OCP development builds/nightly releases, it might be required 
 * Execute the command shown below to print out the pull secret:
 
 ```console
-[user@fedora jetlag]$ oc registry login --to=-
+(.ansible) [root@<bastion> jetlag]# oc registry login --to=-
 ```
 * Append or update the pull secret retrieved from above under pull_secret.txt in repo base directory.
 
@@ -198,7 +198,7 @@ spec:
 
 For on-demand mirroring, the next command run on the bastion will mirror the image from quay.io to perf176b's disconnected registry.
 ```yaml
-oc image mirror -a /opt/registry/pull-secret-bastion.txt perf176b.xxx.com:5000/XXX/client-server:<tag> --keep-manifest-list --continue-on-error=true
+(.ansible) [root@<bastion> jetlag]# oc image mirror -a /opt/registry/pull-secret-bastion.txt perf176b.xxx.com:5000/XXX/client-server:<tag> --keep-manifest-list --continue-on-error=true
 ```
 Once the image has successfully mirrored onto the disconnected registry, your deployment will be able to create the container.
 
@@ -321,7 +321,7 @@ execute this command on each host in your deployment, setting the `control_plane
 `worker_install_disk` paths manually for each host in the inventory file.)
 
 ```
-[root@<bastion> jetlag]# ls -la /dev/disk/by-path/
+(.ansible) [root@<bastion> jetlag]# ls -la /dev/disk/by-path/
 total 0
 drwxr-xr-x. 2 root root 160 Apr 11 19:40 .
 drwxr-xr-x. 6 root root 120 Apr 11 19:40 ..

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -197,14 +197,15 @@ spec:
 ```
 
 For on-demand mirroring, the next command run on the bastion will mirror the image from quay.io to perf176b's disconnected registry.
-```yaml
+
+```console
 (.ansible) [root@<bastion> jetlag]# oc image mirror -a /opt/registry/pull-secret-bastion.txt perf176b.xxx.com:5000/XXX/client-server:<tag> --keep-manifest-list --continue-on-error=true
 ```
 Once the image has successfully mirrored onto the disconnected registry, your deployment will be able to create the container.
 
 For image deletion, use the Docker V2 REST API to delete the object. Note that the deletion operation argument has to be an image's digest not image's tag. So if you mirrored your image by tag in the previous step, on deletion you have to get its digest first. The following is a convenient script that deletes an image by tag.
 
-```yaml
+```console
 ### script
 #!/bin/bash
 registry='[fc00:1000::1]:5000'   <===== IPv6 address and port of perf176b disconnected registry
@@ -227,17 +228,20 @@ function rm_XXX_tag {
 If you want to use a NIC other than the default, you need to override the `controlplane_network_interface_idx` variable in the `Extra vars` section of `ansible/vars/all.yml`.
 In this example using nic `ens2f0` in a cluster of r650 nodes is shown.
 1. Select which NIC you want to use instead of the default, in this example, `ens2f0`.
-2. Look for your server model number in [your labs wiki page](http://docs.scalelab.redhat.com/trac/scalelab/wiki/ScaleLabTipsAndTricks#RDU2ScaleLabPrivateNetworksandInterfaces) then select the network you want configured as your primary network using the following mapping
-```
-* Network 1 = `controlplane_network_interface_idx: 0`
-* Network 2 = `controlplane_network_interface_idx: 1`
-* Network 3 = `controlplane_network_interface_idx: 2`
-* Network 4 = `controlplane_network_interface_idx: 3`
-* Network 5 = `controlplane_network_interface_idx: 4`
-```
+2. Look for your server model number in [your labs wiki page](http://docs.scalelab.redhat.com/trac/scalelab/wiki/ScaleLabTipsAndTricks#RDU2ScaleLabPrivateNetworksandInterfaces) then select the network you want configured as your primary network using the following mapping:
+
+| Network | YAML variable |
+| ------- | ------------- |
+| Network 1 | `controlplane_network_interface_idx: 0` |
+| Network 2 | `controlplane_network_interface_idx: 1` |
+| Network 3 | `controlplane_network_interface_idx: 2` |
+| Network 4 | `controlplane_network_interface_idx: 3` |
+| Network 5 | `controlplane_network_interface_idx: 4` |
+
 3. Since the desired NIC in this exampls,`ens2f0`, is listed under the column "Network 3" the value **2** is correct.
 4. Set **2** as the value of the variable `controlplane_network_interface_idx` in `ansible/vars/all.yaml`.
-```
+
+```yaml
 ################################################################################
 # Extra vars
 ################################################################################
@@ -256,7 +260,7 @@ they can be specified directly through the vars file `all.yml`.
 To ensure the drive will be correctly mapped at each boot,
 we will locate the `/dev/disk/by-path` link to each drive.
 
-```
+```console
 # Locate names of the drives identified on your system
 $ lsblk | grep nvme
 nvme3n1     259:0    0   1.5T  0 disk
@@ -309,7 +313,6 @@ lrwxrwxrwx. 1 root root  9 Feb  5 19:22 pci-0000:00:11.5-ata-1.0 -> ../../sda  <
 ### Extra vars for by-path disk reference
 **Note:** For bare-metal deployment of OCP 4.13 or greater it is advisable to set the extra vars for by-path reference for the installation. Below are the extra vars along with the hardware used.
 
-
 | Hardware           | control_plane_install_disk                      | worker_install_disk                             |
 | ------------------ | ----------------------------------------------- | ----------------------------------------------- |
 | Dell r650          | /dev/disk/by-path/pci-0000:67:00.0-scsi-0:2:0:0 | /dev/disk/by-path/pci-0000:67:00.0-scsi-0:2:0:0 |
@@ -320,7 +323,7 @@ assumes that the bastion hardware configuration is identical: in a heterogeneous
 execute this command on each host in your deployment, setting the `control_plane_install_disk` and
 `worker_install_disk` paths manually for each host in the inventory file.)
 
-```
+```console
 (.ansible) [root@<bastion> jetlag]# ls -la /dev/disk/by-path/
 total 0
 drwxr-xr-x. 2 root root 160 Apr 11 19:40 .

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -238,7 +238,7 @@ In this example using nic `ens2f0` in a cluster of r650 nodes is shown.
 | Network 4 | `controlplane_network_interface_idx: 3` |
 | Network 5 | `controlplane_network_interface_idx: 4` |
 
-3. Since the desired NIC in this exampls,`ens2f0`, is listed under the column "Network 3" the value **2** is correct.
+3. Since the desired NIC in this example,`ens2f0`, is listed under the column "Network 3" the value **2** is correct.
 4. Set **2** as the value of the variable `controlplane_network_interface_idx` in `ansible/vars/all.yaml`.
 
 ```yaml

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -42,7 +42,7 @@ Alias lab chart is available [here](http://wiki.alias.bos.scalelab.redhat.com/fa
 
 ## Override lab ocpinventory json file
 
-Current Jetlag lab use selects machines for roles bastion, control-plane, and worker in that order from the ocpinventory.json file. You may have to create a new json file with the desired order to match desired roles if the auto selection is incorrect. After creating a new json file, host this where your machine running the playbooks can reach and set the following var such that the modified ocpinventory json file is used:
+By default Jetlag selects machines for the roles bastion, control-plane, and worker in that order from the ocpinventory.json file. You can create a new json file with the desired order to match desired roles if the auto selection is incorrect. After creating a new json file, host this where your machine running the playbooks can reach and set the following var such that the modified ocpinventory json file is used:
 
 ```yaml
 ocp_inventory_override: http://example.redhat.com/cloud12-inventories/cloud12-cp_r640-w_5039ms.json
@@ -315,10 +315,13 @@ lrwxrwxrwx. 1 root root  9 Feb  5 19:22 pci-0000:00:11.5-ata-1.0 -> ../../sda  <
 | Dell r650          | /dev/disk/by-path/pci-0000:67:00.0-scsi-0:2:0:0 | /dev/disk/by-path/pci-0000:67:00.0-scsi-0:2:0:0 |
 | Dell r640          | /dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:0:0 | /dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:0:0 |
 
-To find your machine's by-path reference use the following command and choose the install disk
+To find your machine's by-path reference use the following command and choose the install disk. (Note, this
+assumes that the bastion hardware configuration is identical: in a heterogeneous cluster you may need to
+execute this command on each host in your deployment, setting the `control_plane_install_disk` and
+`worker_install_disk` paths manually for each host in the inventory file.)
 
 ```
-[root@xxx-h06-000-r640 jetlag]# ls -la /dev/disk/by-path/
+[root@<bastion> jetlag]# ls -la /dev/disk/by-path/
 total 0
 drwxr-xr-x. 2 root root 160 Apr 11 19:40 .
 drwxr-xr-x. 6 root root 120 Apr 11 19:40 ..

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,4 +1,4 @@
-# Troubleshooting jetlag
+# Troubleshooting Jetlag
 
 _**Table of Contents**_
 
@@ -68,7 +68,7 @@ For disconnected environments, the bastion machine will serve all OCP, operator 
 
 ## Accessing services
 
-Several services are run on the bastion in order to automate the tasks that jetlag performs. You can access them via the following ports:
+Several services are run on the bastion in order to automate the tasks that Jetlag performs. You can access them via the following ports:
 
 * On-prem assisted-installer GUI - 8080
 * On-prem assisted-installer API - 8090
@@ -88,7 +88,7 @@ HTTP Server - http://f99-h11-000-1029p.rdu2.scalelab.redhat.com:8081/
 
 Example accessing the bastion registry and listing repositories:
 ```console
-[root@f99-h11-000-1029p akrzos]# curl -u registry:registry -k https://f99-h11-000-1029p.rdu2.scalelab.redhat.com:5000/v2/_catalog?n=100 | jq
+[root@<bastion> akrzos]# curl -u registry:registry -k https://f99-h11-000-1029p.rdu2.scalelab.redhat.com:5000/v2/_catalog?n=100 | jq
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100   532  100   532    0     0    104      0  0:00:05  0:00:05 --:--:--   120
@@ -130,9 +130,9 @@ If you are planning a redeploy with new versions and new container images it may
 On the bastion machine:
 
 ```console
-[root@f16-h11-000-1029p ~]# cd /opt/registry
-[root@f16-h11-000-1029p registry]#
-[root@f16-h11-000-1029p registry]# ls -lah
+[root@<bastion> ~]# cd /opt/registry
+[root@<bastion> registry]#
+[root@<bastion> registry]# ls -lah
 total 12K
 drwxr-xr-x. 6 root root  144 Jul 20 12:14 .
 drwxr-xr-x. 6 root root   83 Jul 16 15:01 ..
@@ -143,7 +143,7 @@ drwxr-xr-x. 3 root root   20 Jul 20 02:27 data
 -rw-r--r--. 1 root root 3.0K Jul 20 20:31 pull-secret-bastion.txt
 -rw-r--r--. 1 root root 2.9K Jul 20 02:27 pull-secret.txt
 drwxr-xr-x. 2 root root  191 Jul 21 12:26 sync-acm-d
-[root@f16-h11-000-1029p registry]# du -sh *
+[root@<bastion> registry]# du -sh *
 4.0K    auth
 8.0K    certs
 27G     data
@@ -151,7 +151,7 @@ drwxr-xr-x. 2 root root  191 Jul 21 12:26 sync-acm-d
 4.0K    pull-secret-bastion.txt
 4.0K    pull-secret.txt
 48K     sync-acm-d
-[root@f16-h11-000-1029p registry]# rm -rf data/docker/
+[root@<bastion> registry]# rm -rf data/docker/
 ```
 
 ## Rebooted Bastion
@@ -163,7 +163,7 @@ If the bastion has been rebooted, you may experience ImagePullBackOff on contain
 
 ## Ipv4 to ipv6 deployed cluster
 
-When moving from an ipv4 cluster installation to ipv6 (or vice-versa), instead of rebuilding the bastion with foreman or badfish, use *nmcli* to disable one of the IP addresses. For example, the following commands disables ipv6:
+When moving from an ipv4 cluster installation to ipv6 (or vice-versa), instead of rebuilding the bastion with foreman or badfish, use *nmcli* to disable one of the IP addresses. For example, the following commands disable ipv6:
 
 ```console
 # nmcli c modify ens6f0 ipv6.method "disabled"
@@ -244,14 +244,14 @@ How to verify that ipmi privilege set to administrator level permissions
 
 1. SMCIPMITool:
 ```console
-[root@jetlag-bm0 ~]# SMCIPMITool x.x.x.x root xxxxxxxxx user list
+[root@<bastion> ~]# SMCIPMITool x.x.x.x root xxxxxxxxx user list
 Maximum number of Users          : 10
 Count of currently enabled Users : 8
  User ID | User Name       | Privilege Level    | Enable
  ------- | -----------     | ---------------    | ------
        3 | root            | Operator           | Yes
 
-[root@jetlag-bm0 ~]# SMCIPMITool y.y.y.y root yyyyyyyy user list
+[root@<bastion> ~]# SMCIPMITool y.y.y.y root yyyyyyyy user list
 Maximum number of Users          : 10
 Count of currently enabled Users : 8
  User ID | User Name       | Privilege Level    | Enable
@@ -264,7 +264,7 @@ Machine `y.y.y.y` has the correct permissions.
 2. ipmitool:
 
 ```console
-[root@hwprov2-bs ~]# ipmitool -I lanplus -L ADMINISTRATOR -H <IPMIADDRESS> -p 623 -U root -P <PASSWORD> power status
+[root@<bastion> ~]# ipmitool -I lanplus -L ADMINISTRATOR -H <IPMIADDRESS> -p 623 -U root -P <PASSWORD> power status
 ```
 
 Expected result: Chassis Power is on
@@ -329,7 +329,7 @@ Also, watch for the output of **--boot-to-type foreman**, because the correct bo
 The values in *config/idrac_interfaces.yml* are first of all for the SCALE lab.
 
 ```console
-[user@fedora badfish]$ ./src/badfish/badfish.py -H mgmt-computer.example.com -u user -p password -i config/idrac_interfaces.yml -t foreman
+[user@<local> badfish]$ ./src/badfish/badfish.py -H mgmt-computer.example.com -u user -p password -i config/idrac_interfaces.yml -t foreman
 - INFO     - Job queue for iDRAC mgmt-computer.example.com successfully cleared.
 - INFO     - PATCH command passed to update boot order.
 - INFO     - POST command passed to create target config job.
@@ -343,14 +343,14 @@ The values in *config/idrac_interfaces.yml* are first of all for the SCALE lab.
 On the bastion machine:
 
 ```console
-[root@f16-h11-000-1029p ~]# ./update-latest-rhel-release.sh 8.9
+[root@<bastion> ~]# ./update-latest-rhel-release.sh 8.9
 Changing repository from 8.2 to 8.9
 Cleaning dnf repo cache..
 
 -------------------------
 Run dnf update to upgrade to RHEL 8.9
 
-[root@f16-h21-000-1029p ~]# dnf update -y
+[root@<bastion> ~]# dnf update -y
 ...
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -81,14 +81,6 @@ Several services are run on the bastion in order to automate the tasks that Jetl
 | Gogs - Self-hosted Git (When `setup_bastion_gogs=true`) | 10881 (http), 10022 (git)
 | Dnsmasq / Coredns | 53
 
-Examples, change the FQDN to your bastion machine and open in your browser
-
-| Interface | Address |
-| :-: | :- |
-| AI Gui | `http://<bastion>:8080/` |
-| AI API | `http://<bastion>:8090/` |
-| HTTP Server | `http://<bastion>:8081/` |
-
 Example accessing the bastion registry and listing repositories:
 ```console
 (.ansible) [root@<bastion> jetlag]# curl -u registry:registry -k https://<bastion>:5000/v2/_catalog?n=100 | jq
@@ -121,7 +113,7 @@ In the event your bastion's running containers have incorrect data or you are de
 Clean **all** containers (on bastion machine):
 
 ```console
-(.ansible) [root@<bastion> jetlag]# podman ps | awk '{print $1}' | xargs -I % podman stop %; podman ps -a | awk '{print $1}' | xargs -I % podman rm %; podman pod ps | awk '{print $1}' | xargs -I % podman pod rm %
+podman ps | awk '{print $1}' | xargs -I % podman stop %; podman ps -a | awk '{print $1}' | xargs -I % podman rm %; podman pod ps | awk '{print $1}' | xargs -I % podman pod rm %
 ```
 
 When replacing the ocp version, just remove the assisted-installer pod and container, then rerun the `setup-bastion.yml` playbook.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -35,9 +35,9 @@ _**Table of Contents**_
 
 ## Running Jetlag after Jetski
 
-If Jetlag is ran after attempting an installation with Jetski, there are several configuration items that are known to conflict and prevents successful install:
+If Jetlag is run after attempting an installation with Jetski, there are several configuration items that are known to conflict and prevent successful install:
 
-* Polluted dnsmasq configuration and dns services (depending on if jetlag was ran dnsmasq or coredns via jetlag)
+* Polluted dnsmasq configuration and dns services (depending on if jetlag ran dnsmasq or coredns)
 * The Jetski configured virtual bridge network could cause additional networking headaches preventing successful install
 
 That may not be all of the conflicts, thus the preferred method to remediate this situation is to cleanly rebuild the RHEL OS running on the bastion machine for Jetlag.
@@ -62,7 +62,7 @@ Since Jetlag has external dependencies on repos available by your machines as we
 
 ## Root disk too small on bastion
 
-For disconnected environments, the bastion machine will serve all OCP, operator and additional container images from its local disconnected registry. Some machines in the lab have been found to have root disks which are on the order of only 70G and can easily fill with 1 or 2 OCP releases synced. If the bastion is one of those machines, relocate `/opt` to a separate larger disk so the machines does not run out of space on the root disk.
+For disconnected environments, the bastion machine will serve all OCP, operator and additional container images from its local disconnected registry. Some machines in the lab have been found to have root disks which are on the order of only 70G and can easily fill with 1 or 2 OCP releases synced. If the bastion is one of those machines, relocate `/opt` to a separate larger disk so the machine does not run out of space on the root disk.
 
 # Bastion
 
@@ -183,9 +183,9 @@ Review the [OpenShift documentation to understand what minimum firmware versions
 
 # Dell
 
-## Reset BMC / iDrac
+## Reset BMC / iDRAC
 
-In some cases the Dell idrac might need to be reset per host. This can be done with the following command:
+In some cases the Dell iDRAC might need to be reset per host. This can be done with the following command:
 
 ```console
 sshpass -p "password" ssh -o StrictHostKeyChecking=no user@mgmt-computer.example.com "racadm racreset"
@@ -297,11 +297,11 @@ Expected the host to boot from disk, but it booted the installation image - plea
 
 Other things to look at:
 
-1) Check the disk name (default in jetlag is /dev/sda, but it could be sdb, sdl, etc.), depending on how the machine's disks are configured. Verify where OCP is being installed and booted up compared to jetlag's default disk name.
+1) Check the disk name (default in Jetlag is /dev/sda, but it could be sdb, sdl, etc.), depending on how the machine's disks are configured. Verify where OCP is being installed and booted up compared to jetlag's default disk name.
 
-2) Did the machine boot the virtual media (management interface, i.e., idrac for Dell machines)?
+2) Did the machine boot the virtual media (management interface, i.e., iDRAC for Dell machines)?
 If the virtual media did not boot, it is most likely a *boot order* issue.
-Three other things to consider, however less common, are: 1) An old firmware that requires an idrac/bmc reset, 2) the DNS settings in the bmc cannot resolve the bastion, and 3) Check for subnet address collision in your local inventory file.
+Three other things to consider, however less common, are: 1) An old firmware that requires an iDRAC/bmc reset, 2) the DNS settings in the bmc cannot resolve the bastion, and 3) Check for subnet address collision in your local inventory file.
 
 ## Network pre-configuration
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -88,7 +88,7 @@ HTTP Server - http://f99-h11-000-1029p.rdu2.scalelab.redhat.com:8081/
 
 Example accessing the bastion registry and listing repositories:
 ```console
-[root@<bastion> akrzos]# curl -u registry:registry -k https://f99-h11-000-1029p.rdu2.scalelab.redhat.com:5000/v2/_catalog?n=100 | jq
+(.ansible) [root@<bastion> jetlag]# curl -u registry:registry -k https://f99-h11-000-1029p.rdu2.scalelab.redhat.com:5000/v2/_catalog?n=100 | jq
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100   532  100   532    0     0    104      0  0:00:05  0:00:05 --:--:--   120
@@ -118,7 +118,7 @@ In the event your bastion's running containers have incorrect data or you are de
 Clean **all** containers (on bastion machine):
 
 ```console
-podman ps | awk '{print $1}' | xargs -I % podman stop %; podman ps -a | awk '{print $1}' | xargs -I % podman rm %; podman pod ps | awk '{print $1}' | xargs -I % podman pod rm %
+(.ansible) [root@<bastion> jetlag]# podman ps | awk '{print $1}' | xargs -I % podman stop %; podman ps -a | awk '{print $1}' | xargs -I % podman rm %; podman pod ps | awk '{print $1}' | xargs -I % podman pod rm %
 ```
 
 When replacing the ocp version, just remove the assisted-installer pod and container, then rerun the `setup-bastion.yml` playbook.
@@ -130,9 +130,9 @@ If you are planning a redeploy with new versions and new container images it may
 On the bastion machine:
 
 ```console
-[root@<bastion> ~]# cd /opt/registry
-[root@<bastion> registry]#
-[root@<bastion> registry]# ls -lah
+(.ansible) [root@<bastion> jetlag]# cd /opt/registry
+(.ansible) [root@<bastion> registry]#
+(.ansible) [root@<bastion> registry]# ls -lah
 total 12K
 drwxr-xr-x. 6 root root  144 Jul 20 12:14 .
 drwxr-xr-x. 6 root root   83 Jul 16 15:01 ..
@@ -143,7 +143,7 @@ drwxr-xr-x. 3 root root   20 Jul 20 02:27 data
 -rw-r--r--. 1 root root 3.0K Jul 20 20:31 pull-secret-bastion.txt
 -rw-r--r--. 1 root root 2.9K Jul 20 02:27 pull-secret.txt
 drwxr-xr-x. 2 root root  191 Jul 21 12:26 sync-acm-d
-[root@<bastion> registry]# du -sh *
+(.ansible) [root@<bastion> registry]# du -sh *
 4.0K    auth
 8.0K    certs
 27G     data
@@ -151,7 +151,7 @@ drwxr-xr-x. 2 root root  191 Jul 21 12:26 sync-acm-d
 4.0K    pull-secret-bastion.txt
 4.0K    pull-secret.txt
 48K     sync-acm-d
-[root@<bastion> registry]# rm -rf data/docker/
+(.ansible) [root@<bastion> registry]# rm -rf data/docker/
 ```
 
 ## Rebooted Bastion

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -80,11 +80,12 @@ Several services are run on the bastion in order to automate the tasks that Jetl
 * Dnsmasq / Coredns - 53
 
 Examples, change the FQDN to your bastion machine and open in your browser
-```
-AI Gui - http://f99-h11-000-1029p.rdu2.scalelab.redhat.com:8080/
-AI API - http://f99-h11-000-1029p.rdu2.scalelab.redhat.com:8090/
-HTTP Server - http://f99-h11-000-1029p.rdu2.scalelab.redhat.com:8081/
-```
+
+| Interface | Address |
+| :-: | :- |
+| AI Gui | `http://f99-h11-000-1029p.rdu2.scalelab.redhat.com:8080/` |
+| AI API | `http://f99-h11-000-1029p.rdu2.scalelab.redhat.com:8090/` |
+| HTTP Server | `http://f99-h11-000-1029p.rdu2.scalelab.redhat.com:8081/` |
 
 Example accessing the bastion registry and listing repositories:
 ```console
@@ -210,7 +211,7 @@ ipmitool -I lanplus -H mgmt-computer.example.com -U user -P password mc reset co
 
 The following example errors can be corrected after resetting the bmc of the machines.
 
-```console
+```
 TASK [boot-iso : SuperMicro - Mount ISO] *****************************************************************************************
 Tuesday 05 October 2021  12:20:23 -0500 (0:00:01.256)       0:01:10.117 *******
 fatal: [jetlag-bm0]: FAILED! => {"changed": true, "cmd": "SMCIPMITool x.x.x.x root xxxxxxxxx wsiso mount \"http://x.x.x.x:8081\" /iso/discovery.iso\n", "delta": "0:00:00.903331", "end": "2021-10-05 12:20:24.841290", "msg": "non-zero return code", "rc": 204, "start": "2021-10-05 12:20:23.937959", "stderr": "", "stderr_lines": [], "stdout": "An ISO file already mounted. Please umount ISO first", "stdout_lines": ["An ISO file already mounted. Please umount ISO first"]}
@@ -224,7 +225,7 @@ Failed GET request to 'https://address.example.com/redfish/v1/Systems/1': 'The r
 
 Error: The node product key needs to be activated for this device
 
-```console
+```
 TASK [boot-iso : SuperMicro - Unmount ISO] ***************************************************************************************************************************************************
 Thursday 30 September 2021  15:04:14 -0400 (0:00:04.861)       0:01:51.715 ****
 fatal: [jetlag-bm0]: FAILED! => {"changed": true, "cmd": "SMCIPMITool x.x.x.x root xxxxxxxxx wsiso umount\n", "delta": "0:00:00.857430", "end": "2021-09-30 14:04:15.985123", "msg": "non-zero return code", "rc": 155, "start": "2021-09-30 14:04:15.127693", "stderr": "", "stderr_lines": [], "stdout": "The node product key needs to be activated for this device", "stdout_lines": ["The node product key needs to be activated for this device"]}
@@ -232,7 +233,7 @@ fatal: [jetlag-bm0]: FAILED! => {"changed": true, "cmd": "SMCIPMITool x.x.x.x ro
 
 Error: This device doesn't support WSISO commands
 
-```console
+```
 TASK [boot-iso : SuperMicro - Unmount ISO] *************************************
 Sunday 04 September 2022  15:10:25 -0500 (0:00:03.603)       0:00:21.026 ******
 fatal: [jetlag-bm0]: FAILED! => {"changed": true, "cmd": "SMCIPMITool 10.220.217.126 root bybdjEBW5y wsiso umount\n", "delta": "0:00:01.319311", "end": "2022-09-04 15:10:27.754259", "msg": "non-zero return code", "rc": 153, "start": "2022-09-04 15:10:26.434948", "stderr": "", "stderr_lines": [], "stdout": "This device doesn't support WSISO commands", "stdout_lines": ["This device doesn't support WSISO commands"]}
@@ -285,7 +286,7 @@ When set to ignore the error, Jetlag can proceed, but you will need to manually 
 
 In the ALIAS lab working with Dell machines, the boot mode of the nodes where OCP should be installed should be set to **UEFI** regardless of BM or SNO cluster types. In the SCALE lab there is no evidence of this issue, the machines are usually delivered with the **BIOS** mode set. This can be easily done with badfish:
 
-```
+```console
 badfish -H mgmt-<fqdn> -u user -p password --set-bios-attribute --attribute BootMode --value Uefi
 ```
 
@@ -315,7 +316,7 @@ Before the OCP install and any boot order changes, ssh on the machines to nuke t
 
 If a machine needs to be rebuilt in the Scale Lab and refuses to correctly rebuild, it is likely a boot order issue. Using badfish, you can correct boot order issues by performing the following:
 
-```
+```console
 badfish -H mgmt-hostname -u user -p password -i config/idrac_interfaces.yml --boot-to-type foreman
 badfish -H mgmt-hostname -u user -p password -i config/idrac_interfaces.yml --check-boot
 badfish -H mgmt-hostname -u user -p password -i config/idrac_interfaces.yml --power-cycle

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,7 +54,7 @@ controlplane_lab_interface
 
 If the machines are reachable, but never registered with the assisted-installer, then check if the assisted-installer-agent container image was pulled and running. You can inspect journal logs to see if this occurred. Possible failures or misconfiguration preventing progress here could be incorrect dns, bad pull-secret, or NAT on bastion is incorrect and not forwarding traffic.
 
-If some nodes correctly registered but some did not, then the missing nodes need to be individually diagnosed. On a missing node, check if the bmc actually mounted the virtual media. Typically the machine just requires a bmc reset due to not booting virtual media which is described in below sections. Another possibility includes non-functional hardware and thus the machine does not boot into the discovery image.
+If some nodes correctly registered but some did not, then the missing nodes need to be individually diagnosed. On a missing node, check if the BMC actually mounted the virtual media. Typically the machine just requires a BMC reset due to not booting virtual media which is described in below sections. Another possibility includes non-functional hardware and thus the machine does not boot into the discovery image.
 
 ## Intermittent failures by repos or container registry
 
@@ -70,26 +70,28 @@ For disconnected environments, the bastion machine will serve all OCP, operator 
 
 Several services are run on the bastion in order to automate the tasks that Jetlag performs. You can access them via the following ports:
 
-* On-prem assisted-installer GUI - 8080
-* On-prem assisted-installer API - 8090
-* On-prem assisted-image-service - 8888
-* HTTP server - 8081
-* Container Registry (When setup_bastion_registry=true) - 5000
-* HAProxy (When disconnected) - 6443, 443, 80
-* Gogs - Self-hosted Git (When setup_bastion_gogs=true) - 10881 (http), 10022 (git)
-* Dnsmasq / Coredns - 53
+| Service | Port |
+| - | - |
+| On-prem `assisted-installer` GUI | 8080
+| On-prem `assisted-installer` API | 8090
+| On-prem `assisted-image-service` | 8888
+| HTTP server | 8081
+| Container Registry (When `setup_bastion_registry=true`) | 5000
+| HAProxy (When disconnected) | 6443, 443, 80
+| Gogs - Self-hosted Git (When `setup_bastion_gogs=true`) | 10881 (http), 10022 (git)
+| Dnsmasq / Coredns | 53
 
 Examples, change the FQDN to your bastion machine and open in your browser
 
 | Interface | Address |
 | :-: | :- |
-| AI Gui | `http://f99-h11-000-1029p.rdu2.scalelab.redhat.com:8080/` |
-| AI API | `http://f99-h11-000-1029p.rdu2.scalelab.redhat.com:8090/` |
-| HTTP Server | `http://f99-h11-000-1029p.rdu2.scalelab.redhat.com:8081/` |
+| AI Gui | `http://<bastion>:8080/` |
+| AI API | `http://<bastion>:8090/` |
+| HTTP Server | `http://<bastion>:8081/` |
 
 Example accessing the bastion registry and listing repositories:
 ```console
-(.ansible) [root@<bastion> jetlag]# curl -u registry:registry -k https://f99-h11-000-1029p.rdu2.scalelab.redhat.com:5000/v2/_catalog?n=100 | jq
+(.ansible) [root@<bastion> jetlag]# curl -u registry:registry -k https://<bastion>:5000/v2/_catalog?n=100 | jq
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100   532  100   532    0     0    104      0  0:00:05  0:00:05 --:--:--   120
@@ -203,13 +205,13 @@ To change this, navigate to Configuration -> Virtual Console -> Plug-in Type and
 
 ## Reset BMC / Resolving redfish connection error
 
-In some cases, issues during a deployment can be the result of a bmc issue. To reset a Supermicro bmc use `ipmitool` with the following example:
+In some cases, issues during a deployment can be the result of a BMC issue. To reset a Supermicro BMC use `ipmitool` with the following example:
 
 ```console
 ipmitool -I lanplus -H mgmt-computer.example.com -U user -P password mc reset cold
 ```
 
-The following example errors can be corrected after resetting the bmc of the machines.
+The following example errors can be corrected after resetting the BMC of the machines.
 
 ```
 TASK [boot-iso : SuperMicro - Mount ISO] *****************************************************************************************
@@ -239,7 +241,7 @@ Sunday 04 September 2022  15:10:25 -0500 (0:00:03.603)       0:00:21.026 ******
 fatal: [jetlag-bm0]: FAILED! => {"changed": true, "cmd": "SMCIPMITool 10.220.217.126 root bybdjEBW5y wsiso umount\n", "delta": "0:00:01.319311", "end": "2022-09-04 15:10:27.754259", "msg": "non-zero return code", "rc": 153, "start": "2022-09-04 15:10:26.434948", "stderr": "", "stderr_lines": [], "stdout": "This device doesn't support WSISO commands", "stdout_lines": ["This device doesn't support WSISO commands"]}
 ```
 
-The permissions of the ipmi/bmc user are likely that of operator and not administrator. Open a support case to set ipmi privilege level permissions to administrator. If you have the permissions already set correctly, try to reset bmc [here](#reset-bmc--resolving-redfish-connection-error).
+The permissions of the ipmi/BMC user are likely that of operator and not administrator. Open a support case to set ipmi privilege level permissions to administrator. If you have the permissions already set correctly, try to reset BMC [here](#reset-bmc--resolving-redfish-connection-error).
 
 How to verify that ipmi privilege set to administrator level permissions
 
@@ -302,7 +304,7 @@ Other things to look at:
 
 2) Did the machine boot the virtual media (management interface, i.e., iDRAC for Dell machines)?
 If the virtual media did not boot, it is most likely a *boot order* issue.
-Three other things to consider, however less common, are: 1) An old firmware that requires an iDRAC/bmc reset, 2) the DNS settings in the bmc cannot resolve the bastion, and 3) Check for subnet address collision in your local inventory file.
+Three other things to consider, however less common, are: 1) An old firmware that requires an iDRAC/BMC reset, 2) the DNS settings in the BMC cannot resolve the bastion, and 3) Check for subnet address collision in your local inventory file.
 
 ## Network pre-configuration
 


### PR DESCRIPTION
Rework all startup documents to encourage installing and running Jetlag on the cluster bastion node.

I generally tried to improve consistency between the various guides, creating a "reusable" bastion setup section that's copied into each (which involved shifting some unique segments). My goal was to retain the basic concept of a "single page" quickstart for each platform while helping to avoid drift between the various documents by isolating the bastion setup into a "chunk". (If only GitHub Markdown had an "embed markdown file here".)

PANDA-329
Resolves #440