### PR TITLE
Allow specifying of OpenShift stream for install, closes #501

### DIFF
--- a/ansible/bm-deploy.yml
+++ b/ansible/bm-deploy.yml
@@ -13,6 +13,7 @@
   - vars/all.yml
   roles:
   - validate-vars
+  - ocp-release
   - create-ai-cluster
   - generate-discovery-iso
   - role: boot-iso

--- a/ansible/ibmcloud-bm-deploy.yml
+++ b/ansible/ibmcloud-bm-deploy.yml
@@ -16,6 +16,7 @@
     http_store_host: "{{ hostvars[inventory_hostname]['private_address'] }}"
   roles:
   - validate-vars
+  - ocp-release
   - ibmcloud-create-ai-cluster
   - generate-discovery-iso
   - role: boot-iso

--- a/ansible/ibmcloud-setup-bastion.yml
+++ b/ansible/ibmcloud-setup-bastion.yml
@@ -17,6 +17,7 @@
     http_store_host: "{{ hostvars[inventory_hostname]['private_address'] }}"
   roles:
   - validate-vars
+  - ocp-release
   - bastion-install
   - ibmcloud-bastion-network
   - bastion-dnsmasq

--- a/ansible/ibmcloud-sno-deploy.yml
+++ b/ansible/ibmcloud-sno-deploy.yml
@@ -16,6 +16,7 @@
     http_store_host: "{{ hostvars[inventory_hostname]['private_address'] }}"
   roles:
   - validate-vars
+  - ocp-release
   - ibmcloud-sno-create-ai-cluster
   - sno-generate-discovery-iso
   - role: boot-iso

--- a/ansible/roles/bastion-install/defaults/main.yml
+++ b/ansible/roles/bastion-install/defaults/main.yml
@@ -5,7 +5,6 @@ coredns_url: https://github.com/coredns/coredns/releases/download/v1.10.1/coredn
 grpcurl_url: https://github.com/fullstorydev/grpcurl/releases/download/v1.8.1/grpcurl_1.8.1_linux_x86_64.tar.gz
 kubeburner_url: https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.7.6/kube-burner-V1.7.6-linux-arm64.tar.gz
 minio_client_url: https://dl.min.io/client/mc/release/linux-amd64/mc
-openshift_client_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp
 yq_url: https://github.com/mikefarah/yq/releases/download/v4.40.3/yq_linux_amd64.tar.gz
 
 # Crucible specific vars

--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -163,10 +163,6 @@
   with_items:
   - url: "{{ coredns_url }}"
     dest: "{{ bastion_cluster_config_dir }}/coredns_linux_amd64.tgz"
-  - url: "{{ openshift_client_url }}/latest/oc-mirror.tar.gz"
-    dest: "{{ bastion_cluster_config_dir }}/oc-mirror.tar.gz"
-  - url: "{{ openshift_client_url }}/latest/openshift-client-linux-amd64-rhel8.tar.gz"
-    dest: "{{ bastion_cluster_config_dir }}/openshift-client-linux-amd64-rhel8.tar.gz"
   - url: "{{ kubeburner_url }}"
     dest: "{{ bastion_cluster_config_dir }}/kube-burner-linux.tar.gz"
   - url: "{{ grpcurl_url }}"
@@ -184,7 +180,7 @@
     url: "{{ item.url }}"
     dest: "{{ item.dest }}"
   with_items:
-  -  url: "{{ openshift_client_url }}/latest-4.14/opm-linux.tar.gz"
+  -  url: "{{ release_url }}/latest-4.14/opm-linux.tar.gz"
      dest: "{{ bastion_cluster_config_dir }}/opm-linux.tar.gz"
   when: ansible_facts['distribution_major_version'] is version('8', '==')
 
@@ -195,33 +191,9 @@
     url: "{{ item.url }}"
     dest: "{{ item.dest }}"
   with_items:
-  -  url: "{{ openshift_client_url }}/latest/opm-linux.tar.gz"
+  -  url: "{{ release_url}}/latest/opm-linux.tar.gz"
      dest: "{{ bastion_cluster_config_dir }}/opm-linux.tar.gz"
   when: ansible_facts['distribution_major_version'] is version('9', '==')
-
-# We rename oc/kubectl clients as oc.latest and kubectl.latest since they are
-# likely not the actual version of the intended cluster, those specific clients
-# are obtained during the bastion-ocp-version role in which we use oc.latest to
-# extract the correct oc/kubectl clients for that version. Unfortunately we need
-# an oc client in order to do that so we just use the latest public oc client
-- name: Untar oc/kubectl clients
-  unarchive:
-    src: "{{ bastion_cluster_config_dir }}/openshift-client-linux-amd64-rhel8.tar.gz"
-    dest: "{{ bastion_cluster_config_dir }}"
-    remote_src: yes
-    mode: 0700
-
-- name: Copy oc/kubectl clients into a pathed directory
-  copy:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-    remote_src: true
-    mode: 0700
-  loop:
-  - src: "{{ bastion_cluster_config_dir }}/oc"
-    dest: /usr/local/bin/oc.latest
-  - src: "{{ bastion_cluster_config_dir }}/kubectl"
-    dest: /usr/local/bin/kubectl.latest
 
 - name: Untar coredns, opm, kube-burner and grpcurl client
   unarchive:

--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -163,6 +163,8 @@
   with_items:
   - url: "{{ coredns_url }}"
     dest: "{{ bastion_cluster_config_dir }}/coredns_linux_amd64.tgz"
+  - url: "{{ release_url }}/latest/oc-mirror.tar.gz"
+    dest: "{{ bastion_cluster_config_dir }}/oc-mirror.tar.gz"
   - url: "{{ kubeburner_url }}"
     dest: "{{ bastion_cluster_config_dir }}/kube-burner-linux.tar.gz"
   - url: "{{ grpcurl_url }}"

--- a/ansible/roles/bastion-ocp-version/tasks/main.yml
+++ b/ansible/roles/bastion-ocp-version/tasks/main.yml
@@ -154,10 +154,10 @@
   loop:
   - dest: "{{ ocp_version_path }}/assisted_service_openshift_version-bastion.json"
     content: |
-      {"{{ openshift_version }}":{"display_name": "{{ ocp_version_display_name.stdout }}", "release_version": "{{ ocp_version_display_name.stdout }}", "release_image": "{{ registry_host }}:{{ registry_port }}/{{ registry_repo }}:{{ ocp_release_image.split(":")[1] }}", "rhcos_image": "http://{{ http_store_host }}:{{ http_store_port }}/{{ ocp_version_display_name.stdout }}/{{ ocp_version_disk_location.stdout | basename }}", "rhcos_rootfs": "http://{{ http_store_host }}:{{ http_store_port }}/{{ ocp_version_display_name.stdout }}/{{ ocp_version_rootfs_location.stdout | basename }}", "rhcos_version": "{{ ocp_version_rhcos_version.stdout }}", "support_level": "beta"} }
+      {"{{ openshift_version }}":{"display_name": "{{ ocp_version_display_name.stdout }}", "release_version": "{{ ocp_version_display_name.stdout }}", "release_image": "{{ registry_host }}:{{ registry_port }}/{{ registry_repo }}:{{ ocp_release_version }}-x86_64", "rhcos_image": "http://{{ http_store_host }}:{{ http_store_port }}/{{ ocp_version_display_name.stdout }}/{{ ocp_version_disk_location.stdout | basename }}", "rhcos_rootfs": "http://{{ http_store_host }}:{{ http_store_port }}/{{ ocp_version_display_name.stdout }}/{{ ocp_version_rootfs_location.stdout | basename }}", "rhcos_version": "{{ ocp_version_rhcos_version.stdout }}", "support_level": "beta"} }
   - dest: "{{ ocp_version_path }}/assisted_service_os_images-bastion.json"
     content: |
       [{"openshift_version":"{{ openshift_version }}","cpu_architecture":"x86_64","url":"http://{{ http_store_host }}:{{ http_store_port }}/{{ ocp_version_display_name.stdout }}/{{ ocp_version_disk_location.stdout | basename }}","rootfs_url":"http://{{ http_store_host }}:{{ http_store_port }}/{{ ocp_version_display_name.stdout }}/{{ ocp_version_rootfs_location.stdout | basename }}","version":"{{ ocp_version_rhcos_version.stdout }}"}]
   - dest: "{{ ocp_version_path }}/assisted_service_release_images-bastion.json"
     content: |
-      [{"openshift_version":"{{ openshift_version }}","cpu_architecture":"x86_64","url":"{{ registry_host }}:{{ registry_port }}/{{ registry_repo }}:{{ ocp_release_image.split(":")[1] }}","version":"{{ ocp_version_display_name.stdout }}"}]
+      [{"openshift_version":"{{ openshift_version }}","cpu_architecture":"x86_64","url":"{{ registry_host }}:{{ registry_port }}/{{ registry_repo }}:{{ ocp_release_version }}-x86_64","version":"{{ ocp_version_display_name.stdout }}"}]

--- a/ansible/roles/bastion-ocp-version/tasks/main.yml
+++ b/ansible/roles/bastion-ocp-version/tasks/main.yml
@@ -14,6 +14,11 @@
     content: "{{ pull_secret }}"
     dest: "/root/.docker/config.json"
 
+- name: Cleanup {{ ocp_version_path }}
+  file:
+    path: "{{ ocp_version_path }}"
+    state: absent
+
 - name: Create directory for bastion ocp-version data
   file:
     path: "{{ ocp_version_path }}"
@@ -30,17 +35,28 @@
     bastion_rhel_version: "rhel8"
   when: ansible_facts['distribution_major_version'] is version('8', '==')
 
-- name: Extract/Download the openshift-install binary for the specific release
-  shell: |
-    cd {{ ocp_version_path }}
-    rm -rf openshift-install-linux-*.tar.gz openshift-client-linux-*.tar.gz
-    REGISTRY_AUTH_FILE="/root/.docker/config.json" oc.latest adm release extract --tools {{ ocp_release_image }}
-    tar -xvf openshift-install-linux-*.tar.gz openshift-install
-    {% if openshift_version is version('4.15', ">=") %}
-    tar -xvf openshift-client-linux-amd64-{{ bastion_rhel_version }}*.tar.gz oc kubectl
-    {% else %}
-    tar -xvf openshift-client-linux-*.tar.gz oc kubectl
-    {% endif %}
+- name: Set new fact - oc installer prefix
+  set_fact:
+    installer_oc_installer_prefix: >-
+      {{ (ocp_release_version is version('4.15.0', '>=') and
+          bastion_rhel_version == 'rhel8') |
+          ternary('openshift-client-linux-amd64-' + bastion_rhel_version, 'openshift-client-linux') }}
+
+- name: Get the ocp client tar gunzip file
+  get_url:
+    url: "{{ release_url }}/{{ocp_release_version}}/{{ installer_oc_installer_prefix }}-{{ ocp_release_version }}.tar.gz"
+    dest: "{{ ocp_version_path }}"
+    mode: 0700
+  register: client_chk
+  retries: 3
+  delay: 5
+  until: client_chk is not failed
+
+- name: Unarchive the clients
+  unarchive:
+    src: "{{ ocp_version_path }}/{{ installer_oc_installer_prefix }}-{{ ocp_release_version }}.tar.gz"
+    dest: "{{ ocp_version_path }}"
+    remote_src: yes
 
 - name: Copy correctly versioned oc/kubectl clients into a pathed directory
   copy:
@@ -54,6 +70,13 @@
   - src: "{{ ocp_version_path }}/kubectl"
     dest: /usr/local/bin/kubectl
   when: setup_bastion | default(true)
+
+- name: Extract/Download the openshift-install binary for the specific release
+  shell: |
+    REGISTRY_AUTH_FILE="/root/.docker/config.json" oc adm release extract --tools {{ ocp_release_image }}
+    tar -xvf openshift-install-linux-*.tar.gz openshift-install
+  args:
+    chdir: "{{ ocp_version_path }}"
 
 # Prevents errors when attempting to get the display/release name/version and the cluster
 # auth-ed by the config is inaccessible

--- a/ansible/roles/ocp-release/defaults/main.yml
+++ b/ansible/roles/ocp-release/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# ocp-release default vars
+
+release_url: "{{ 'https://mirror.openshift.com/pub/openshift-v4/clients/ocp' if ocp_build == 'ga' else 'https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview' }}"

--- a/ansible/roles/ocp-release/tasks/main.yml
+++ b/ansible/roles/ocp-release/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+# ocp-release tasks
+
+- name: Get release.txt file
+  uri:
+    url: "{{ release_url }}/{{ ocp_version }}/release.txt"
+    return_content: yes
+  register: result
+  until: result.status == 200
+  retries: 3
+  delay: 5
+  failed_when: result.content|length == 0 or result.status >= 400
+
+- name: Set facts for release version and image
+  set_fact:
+    ocp_release_version: "{{ result.content | regex_search('Version:.*') | regex_replace('Version:\\s*(.*)', '\\1') }}"
+    ocp_release_image: "{{ result.content | regex_search('Pull From:.*') | regex_replace('Pull From:\\s*(.*)', '\\1') }}"
+
+- name: Set fact for OpenShift major version
+  set_fact:
+    openshift_version: "{{ ocp_release_version.split('.')[0] + '.' + ocp_release_version.split('.')[1] }}"
+
+- name: Display release vars
+  debug:
+    msg: "{{ item }}"
+  loop:
+  - "{{ openshift_version }}"
+  - "{{ ocp_release_version }}"
+  - "{{ ocp_release_image }}"

--- a/ansible/roles/sync-ocp-release/tasks/main.yml
+++ b/ansible/roles/sync-ocp-release/tasks/main.yml
@@ -6,5 +6,5 @@
     oc adm release mirror \
       -a {{ registry_path }}/pull-secret-bastion.txt \
       --from={{ ocp_release_image }} \
-      --to-release-image={{ registry_host }}:{{ registry_port }}/{{ registry_repo }}:{{ ocp_release_image.split(":")[1] }} \
+      --to-release-image={{ registry_host }}:{{ registry_port }}/{{ registry_repo }}:{{ ocp_release_version }}-x86_64 \
       --to={{ registry_host }}:{{ registry_port }}/{{ registry_repo }}

--- a/ansible/roles/validate-vars/defaults/main.yml
+++ b/ansible/roles/validate-vars/defaults/main.yml
@@ -16,3 +16,7 @@ ibmcloud_cluster_types:
 bm_network_types:
 - OVNKubernetes
 - OpenShiftSDN
+
+ocp_build_types:
+- ga
+- dev

--- a/ansible/roles/validate-vars/tasks/main.yml
+++ b/ansible/roles/validate-vars/tasks/main.yml
@@ -13,6 +13,21 @@
     msg: "Pull secret appears unset"
   when: pull_secret is not defined
 
+- name: Fail if version is undefined or empty.
+  fail:
+    msg: "The version is undefined or empty. Use a value such as 'latest-4.13' or 'latest-4.14' or an explicit version."
+  when: (ocp_version is undefined) or (ocp_version|length == 0)
+
+- name: Fail if build is undefined or empty
+  fail:
+    msg: "The build is undefined or empty. Use a value of either 'dev' or 'ga'."
+  when: (ocp_build is undefined) or (ocp_build|length == 0)
+
+- name: Fail if build is invalid
+  fail:
+    msg: "The openshift build defined is invalid, Use either 'ga' or 'dev' only"
+  when: (ocp_build != 'ga') and (ocp_build != 'dev')
+
 - name: Check for RHEL/Centos (Bastion Validation)
   fail:
     msg: "Expecting RHEL or Centos for a Bastion OS"
@@ -33,7 +48,7 @@
   when: (cluster_type == "bm" or cluster_type == "rwn") and
         (worker_node_count is undefined or not worker_node_count | int) and
         ansible_play_name != "Create inventory from a lab cloud" and
-        ansible_play_name != "Create inventory from ibmcloud hardware"
+       	ansible_play_name != "Create inventory from ibmcloud hardware"
 
 - name: Set sno_node_count if undefined or empty
   set_fact:
@@ -88,3 +103,27 @@
   fail:
     msg: "isolated_cpus is unset"
   when: (cluster_type == "sno") and (du_profile | default(false) | bool) and isolated_cpus is undefined
+
+- name: Set release_url
+  set_fact:
+    release_url: "{{ 'https://mirror.openshift.com/pub/openshift-v4/clients/ocp' if ocp_build == 'ga' else 'https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview' }}"
+
+- name: Get release.txt file
+  uri:
+    url: "{{ release_url }}/{{ ocp_version }}/release.txt"
+    return_content: yes
+  register: result
+  until: result.status == 200
+  retries: 3
+  delay: 5
+  failed_when: result.content|length == 0 or result.status >= 400
+
+- name: Set facts for release version and image
+  set_fact:
+    ocp_release_version: "{{ result.content | regex_search('Version:.*') | regex_replace('Version:\\s*(.*)', '\\1') }}"
+    ocp_release_image: "{{ result.content | regex_search('Pull From:.*') | regex_replace('Pull From:\\s*(.*)', '\\1') }}"
+
+- name: Set fact for OpenShift major version
+  set_fact:
+    openshift_version: "{{ ocp_release_version.split('.')[0] + '.' + ocp_release_version.split('.')[1] }}"
+

--- a/ansible/roles/validate-vars/tasks/main.yml
+++ b/ansible/roles/validate-vars/tasks/main.yml
@@ -13,15 +13,15 @@
     msg: "Pull secret appears unset"
   when: pull_secret is not defined
 
-- name: Fail if version is undefined or empty.
+- name: Validate ocp_build
   fail:
-    msg: "The version is undefined or empty. Use a value such as 'latest-4.13' or 'latest-4.14' or an explicit version."
-  when: (ocp_version is undefined) or (ocp_version|length == 0)
+    msg: "Invalid ocp_build selected('{{ ocp_build }}') Select from {{ ocp_build_types }}"
+  when: ocp_build not in ocp_build_types
 
-- name: Fail if build is undefined or empty
+- name: Validate ocp_version
   fail:
-    msg: "The build is undefined or empty. Use a value of either 'dev' or 'ga'."
-  when: (ocp_build is undefined) or (ocp_build|length == 0)
+    msg: "The version is undefined or empty. Use a value such as 'latest-4.15' or 'latest-4.16' or '4.16.1'."
+  when: (ocp_version is undefined) or (ocp_version|length == 0)
 
 - name: Fail if build is invalid
   fail:
@@ -103,27 +103,3 @@
   fail:
     msg: "isolated_cpus is unset"
   when: (cluster_type == "sno") and (du_profile | default(false) | bool) and isolated_cpus is undefined
-
-- name: Set release_url
-  set_fact:
-    release_url: "{{ 'https://mirror.openshift.com/pub/openshift-v4/clients/ocp' if ocp_build == 'ga' else 'https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview' }}"
-
-- name: Get release.txt file
-  uri:
-    url: "{{ release_url }}/{{ ocp_version }}/release.txt"
-    return_content: yes
-  register: result
-  until: result.status == 200
-  retries: 3
-  delay: 5
-  failed_when: result.content|length == 0 or result.status >= 400
-
-- name: Set facts for release version and image
-  set_fact:
-    ocp_release_version: "{{ result.content | regex_search('Version:.*') | regex_replace('Version:\\s*(.*)', '\\1') }}"
-    ocp_release_image: "{{ result.content | regex_search('Pull From:.*') | regex_replace('Pull From:\\s*(.*)', '\\1') }}"
-
-- name: Set fact for OpenShift major version
-  set_fact:
-    openshift_version: "{{ ocp_release_version.split('.')[0] + '.' + ocp_release_version.split('.')[1] }}"
-

--- a/ansible/rwn-deploy.yml
+++ b/ansible/rwn-deploy.yml
@@ -14,6 +14,7 @@
   - vars/all.yml
   roles:
   - validate-vars
+  - ocp-release
   - create-ai-cluster
   - generate-discovery-iso
   - role: boot-iso

--- a/ansible/setup-bastion.yml
+++ b/ansible/setup-bastion.yml
@@ -13,6 +13,7 @@
   - vars/all.yml
   roles:
   - validate-vars
+  - ocp-release
   - bastion-install
   - bastion-network
   - role: bastion-dnsmasq

--- a/ansible/sno-deploy.yml
+++ b/ansible/sno-deploy.yml
@@ -13,6 +13,7 @@
   - vars/all.yml
   roles:
   - validate-vars
+  - ocp-release
   - sno-create-ai-cluster
   - sno-generate-discovery-iso
   - role: boot-iso

--- a/ansible/sync-ocp-release.yml
+++ b/ansible/sync-ocp-release.yml
@@ -14,6 +14,7 @@
   vars_files:
   - vars/sync-ocp-release.yml
   roles:
+  - ocp-release
   - role: bastion-ocp-version
     vars:
       setup_bastion: false

--- a/ansible/vars/all.sample.yml
+++ b/ansible/vars/all.sample.yml
@@ -23,14 +23,13 @@ sno_node_count:
 # scalelab cloud
 public_vlan: false
 
-# Versions are controlled by this release image. If you want to change images
-# you must stop and rm all assisted-installer containers on the bastion and rerun
-# the setup-bastion step in order to setup your bastion's assisted-installer to
-# the version you specified
-ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.15.2-x86_64
+# The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
+# Values accepted: 'latest-4.13', 'latest-4.14', explicit version i.e. 4.15.2 or for dev builds, candidate-4.16
+ocp_version: "latest-4.15"
 
-# This should just match the above release image version (Ex: 4.15)
-openshift_version: "4.15"
+# Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift
+# Empty value results in playbook failing with error message. Example of a dev build would be candidate-4.17
+ocp_build: "ga"
 
 # Either "OVNKubernetes" or "OpenShiftSDN" (Only for BM/RWN cluster types)
 networktype: OVNKubernetes

--- a/ansible/vars/all.sample.yml
+++ b/ansible/vars/all.sample.yml
@@ -37,10 +37,6 @@ ocp_build: "ga"
 # For 'dev' builds some examples of what you can use are 'candidate-4.16' or just 'latest'
 ocp_version: "latest-4.15"
 
-# Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift
-# Empty value results in playbook failing with error message. Example of a dev build would be candidate-4.17
-ocp_build: "ga"
-
 # Either "OVNKubernetes" or "OpenShiftSDN" (Only for BM/RWN cluster types)
 networktype: OVNKubernetes
 

--- a/ansible/vars/all.sample.yml
+++ b/ansible/vars/all.sample.yml
@@ -23,8 +23,18 @@ sno_node_count:
 # scalelab cloud
 public_vlan: false
 
-# The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
-# Values accepted: 'latest-4.13', 'latest-4.14', explicit version i.e. 4.15.2 or for dev builds, candidate-4.16
+# Enter whether the build should use 'dev' (early candidate builds) or 'ga' for Generally Available versions of OpenShift
+# Empty value results in playbook failing with error message. Example of dev builds would be 'candidate-4.17', 'candidate-4.16'
+# or 'latest' (which would point to the early candidate build of the latest in development release) and examples of 'ga' builds would 
+# be explicit versions like '4.15.20' or '4.16.0' or you could also use things like latest-4.16 to point to the latest z-stream of 4.16.
+# Checkout https://mirror.openshift.com/pub/openshift-v4/clients/ocp for a list of available builds for 'ga' releases and 
+# https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview for a list of 'dev' releases.
+ocp_build: "ga"
+
+# The version of the openshift-installer binary, undefined or empty results in the playbook failing with error message.
+# Values accepted depended on the build chosen ('ga' or 'dev').
+# For 'ga' builds some examples of what you can use are 'latest-4.13', 'latest-4.14' or explicit versions like 4.15.2
+# For 'dev' builds some examples of what you can use are 'candidate-4.16' or just 'latest'
 ocp_version: "latest-4.15"
 
 # Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift

--- a/ansible/vars/ibmcloud.sample.yml
+++ b/ansible/vars/ibmcloud.sample.yml
@@ -14,13 +14,19 @@ worker_node_count:
 # Applies to sno clusters
 sno_node_count:
 
-# The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
-# Values accepted: 'latest-4.13', 'latest-4.14', explicit version i.e. 4.15.2 or for dev builds, candidate-4.16
-ocp_version: "latest-4.15"
-
-# Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift
-# Empty value results in playbook failing with error message. Example of a dev build would be candidate-4.17
+# Enter whether the build should use 'dev' (early candidate builds) or 'ga' for Generally Available versions of OpenShift
+# Empty value results in playbook failing with error message. Example of dev builds would be 'candidate-4.17', 'candidate-4.16'
+# or 'latest' (which would point to the early candidate build of the latest in development release) and examples of 'ga' builds would 
+# be explicit versions like '4.15.20' or '4.16.0' or you could also use things like latest-4.16 to point to the latest z-stream of 4.16.
+# Checkout https://mirror.openshift.com/pub/openshift-v4/clients/ocp for a list of available builds for 'ga' releases and 
+# https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview for a list of 'dev' releases.
 ocp_build: "ga"
+
+# The version of the openshift-installer binary, undefined or empty results in the playbook failing with error message.
+# Values accepted depended on the build chosen ('ga' or 'dev').
+# For 'ga' builds some examples of what you can use are 'latest-4.13', 'latest-4.14' or explicit versions like 4.15.2
+# For 'dev' builds some examples of what you can use are 'candidate-4.16' or just 'latest'
+ocp_version: "latest-4.15"
 
 # Either "OVNKubernetes" or "OpenShiftSDN" (Only for BM/RWN cluster types)
 networktype: OVNKubernetes

--- a/ansible/vars/ibmcloud.sample.yml
+++ b/ansible/vars/ibmcloud.sample.yml
@@ -14,14 +14,13 @@ worker_node_count:
 # Applies to sno clusters
 sno_node_count:
 
-# Versions are controlled by this release image. If you want to change images
-# you must stop and rm all assisted-installer containers on the bastion and rerun
-# the setup-bastion step in order to setup your bastion's assisted-installer to
-# the version you specified
-ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.15.2-x86_64
+# The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
+# Values accepted: 'latest-4.13', 'latest-4.14', explicit version i.e. 4.15.2 or for dev builds, candidate-4.16
+ocp_version: "latest-4.15"
 
-# This should just match the above release image version (Ex: 4.15)
-openshift_version: "4.15"
+# Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift
+# Empty value results in playbook failing with error message. Example of a dev build would be candidate-4.17
+ocp_build: "ga"
 
 # Either "OVNKubernetes" or "OpenShiftSDN" (Only for BM/RWN cluster types)
 networktype: OVNKubernetes

--- a/ansible/vars/sync-ocp-release.sample.yml
+++ b/ansible/vars/sync-ocp-release.sample.yml
@@ -1,10 +1,16 @@
 ---
-# The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
-# Values accepted: 'latest-4.13', 'latest-4.14', explicit version i.e. 4.15.2 or for dev builds, candidate-4.16
-ocp_version: "latest-4.15"
-
-# Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift
-# Empty value results in playbook failing with error message. Example of a dev build would be candidate-4.17
+# Enter whether the build should use 'dev' (early candidate builds) or 'ga' for Generally Available versions of OpenShift
+# Empty value results in playbook failing with error message. Example of dev builds would be 'candidate-4.17', 'candidate-4.16'
+# or 'latest' (which would point to the early candidate build of the latest in development release) and examples of 'ga' builds would 
+# be explicit versions like '4.15.20' or '4.16.0' or you could also use things like latest-4.16 to point to the latest z-stream of 4.16.
+# Checkout https://mirror.openshift.com/pub/openshift-v4/clients/ocp for a list of available builds for 'ga' releases and 
+# https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview for a list of 'dev' releases.
 ocp_build: "ga"
+
+# The version of the openshift-installer binary, undefined or empty results in the playbook failing with error message.
+# Values accepted depended on the build chosen ('ga' or 'dev').
+# For 'ga' builds some examples of what you can use are 'latest-4.13', 'latest-4.14' or explicit versions like 4.15.2
+# For 'dev' builds some examples of what you can use are 'candidate-4.16' or just 'latest'
+ocp_version: "latest-4.15"
 
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"

--- a/ansible/vars/sync-ocp-release.sample.yml
+++ b/ansible/vars/sync-ocp-release.sample.yml
@@ -1,9 +1,10 @@
 ---
-# Sample sync-ocp-release vars file
+# The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
+# Values accepted: 'latest-4.13', 'latest-4.14', explicit version i.e. 4.15.2 or for dev builds, candidate-4.16
+ocp_version: "latest-4.15"
 
-ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.15.2-x86_64
-
-# This should just match the above release image version (Ex: 4.15)
-openshift_version: "4.15"
+# Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift
+# Empty value results in playbook failing with error message. Example of a dev build would be candidate-4.17
+ocp_build: "ga"
 
 pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"

--- a/docs/bastion-deploy-bm-byol.md
+++ b/docs/bastion-deploy-bm-byol.md
@@ -203,8 +203,9 @@ Set `worker_node_count` it must be correct, in this guide it is set to `2`. Howe
 
 Set `sno_node_count` it must be correct, in this guide it is set it to `0`.
 
-Change `ocp_version` to the desired OpenShift version.
-Set `ocp_build` to either ga or dev depending on whether you want to install a ga version like z-stream or a development version like candidate-4.16.
+Set `ocp_build` to one of 'dev' (early candidate builds) or 'ga' for Generally Available versions of OpenShift. Empty value results in playbook failing with error message. Example of dev builds would be 'candidate-4.17', 'candidate-4.16 or 'latest' (which would point to the early candidate build of the latest in development release) and examples of 'ga' builds would  be explicit versions like '4.15.20' or '4.16.0' or you could also use things like latest-4.16 to point to the latest z-stream of 4.16. Checkout https://mirror.openshift.com/pub/openshift-v4/clients/ocp for a list of available builds for 'ga' releases and https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview for a list of 'dev' releases.
+
+Set `ocp_version` to the version of the openshift-installer binary, undefined or empty results in the playbook failing with error message. Values accepted depended on the build chosen ('ga' or 'dev'). For 'ga' builds some examples of what you can use are 'latest-4.13', 'latest-4.14' or explicit versions like 4.15.2 For 'dev' builds some examples of what you can use are 'candidate-4.16' or just 'latest'.
 
 Only change `networktype` if you need to test something other than `OVNKubernetes`
 
@@ -272,17 +273,19 @@ sno_node_count: 0
 # scalelab cloud
 public_vlan: false
 
-# Versions are controlled by this release image. If you want to change images
-# you must stop and rm all assisted-installer containers on the bastion and rerun
-# the setup-bastion step in order to setup your bastion's assisted-installer to
-# the version you specified
-# The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
-# Values accepted: 'latest-4.13', 'latest-4.14', explicit version i.e. 4.15.2 or for dev builds, candidate-4.16
-ocp_version: "latest-4.15"
-
-# Enter whether the build should use 'dev' (candidate builds) or 'ga' for Generally Available version of OpenShift
-# Empty value results in playbook failing with error message.
+# Enter whether the build should use 'dev' (early candidate builds) or 'ga' for Generally Available versions of OpenShift
+# Empty value results in playbook failing with error message. Example of dev builds would be 'candidate-4.17', 'candidate-4.16'
+# or 'latest' (which would point to the early candidate build of the latest in development release) and examples of 'ga' builds would 
+# be explicit versions like '4.15.20' or '4.16.0' or you could also use things like latest-4.16 to point to the latest z-stream of 4.16.
+# Checkout https://mirror.openshift.com/pub/openshift-v4/clients/ocp for a list of available builds for 'ga' releases and 
+# https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview for a list of 'dev' releases.
 ocp_build: "ga"
+
+# The version of the openshift-installer binary, undefined or empty results in the playbook failing with error message.
+# Values accepted depended on the build chosen ('ga' or 'dev').
+# For 'ga' builds some examples of what you can use are 'latest-4.13', 'latest-4.14' or explicit versions like 4.15.2
+# For 'dev' builds some examples of what you can use are 'candidate-4.16' or just 'latest'
+ocp_version: "latest-4.15"
 
 # Either "OVNKubernetes" or "OpenShiftSDN" (Only for BM/RWN cluster types)
 networktype: OVNKubernetes

--- a/docs/bastion-deploy-bm-byol.md
+++ b/docs/bastion-deploy-bm-byol.md
@@ -203,8 +203,8 @@ Set `worker_node_count` it must be correct, in this guide it is set to `2`. Howe
 
 Set `sno_node_count` it must be correct, in this guide it is set it to `0`.
 
-Change `ocp_release_image` to the desired image if the default (4.15.2) is not the desired version.
-If you change `ocp_release_image` to a different major version (Ex `4.15`), then change `openshift_version` accordingly.
+Change `ocp_version` to the desired OpenShift version.
+Set `ocp_build` to either ga or dev depending on whether you want to install a ga version like z-stream or a development version like candidate-4.16.
 
 Only change `networktype` if you need to test something other than `OVNKubernetes`
 
@@ -276,10 +276,13 @@ public_vlan: false
 # you must stop and rm all assisted-installer containers on the bastion and rerun
 # the setup-bastion step in order to setup your bastion's assisted-installer to
 # the version you specified
-ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.15.2-x86_64
+# The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
+# Values accepted: 'latest-4.13', 'latest-4.14', explicit version i.e. 4.15.2 or for dev builds, candidate-4.16
+ocp_version: "latest-4.15"
 
-# This should just match the above release image version (Ex: 4.15)
-openshift_version: "4.15"
+# Enter whether the build should use 'dev' (candidate builds) or 'ga' for Generally Available version of OpenShift
+# Empty value results in playbook failing with error message.
+ocp_build: "ga"
 
 # Either "OVNKubernetes" or "OpenShiftSDN" (Only for BM/RWN cluster types)
 networktype: OVNKubernetes

--- a/docs/bastion-deploy-bm.md
+++ b/docs/bastion-deploy-bm.md
@@ -225,8 +225,9 @@ Change `cluster_type` to `cluster_type: bm`
 
 Set `worker_node_count` to limit the number of worker nodes from your scale lab allocation. Set it to `0` if you want a 3 node compact cluster.
 
-Change `ocp_version` to the desired OpenShift version.
-Set `ocp_build` to either ga or dev depending on whether you want to install a ga version like z-stream or a development version like candidate-4.16.
+Set `ocp_build` to one of 'dev' (early candidate builds) or 'ga' for Generally Available versions of OpenShift. Empty value results in playbook failing with error message. Example of dev builds would be 'candidate-4.17', 'candidate-4.16 or 'latest' (which would point to the early candidate build of the latest in development release) and examples of 'ga' builds would  be explicit versions like '4.15.20' or '4.16.0' or you could also use things like latest-4.16 to point to the latest z-stream of 4.16. Checkout https://mirror.openshift.com/pub/openshift-v4/clients/ocp for a list of available builds for 'ga' releases and https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview for a list of 'dev' releases.
+
+Set `ocp_version` to the version of the openshift-installer binary, undefined or empty results in the playbook failing with error message. Values accepted depended on the build chosen ('ga' or 'dev'). For 'ga' builds some examples of what you can use are 'latest-4.13', 'latest-4.14' or explicit versions like 4.15.2 For 'dev' builds some examples of what you can use are 'candidate-4.16' or just 'latest'.
 
 Only change `networktype` if you need to test something other than `OVNKubernetes`
 
@@ -330,13 +331,19 @@ sno_node_count:
 # scalelab cloud
 public_vlan: false
 
-# The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
-# Values accepted: 'latest-4.13', 'latest-4.14', explicit version i.e. 4.15.2 or for dev builds, candidate-4.16
-ocp_version: "latest-4.15"
-
-# Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift
-# Empty value results in playbook failing with error message.
+# Enter whether the build should use 'dev' (early candidate builds) or 'ga' for Generally Available versions of OpenShift
+# Empty value results in playbook failing with error message. Example of dev builds would be 'candidate-4.17', 'candidate-4.16'
+# or 'latest' (which would point to the early candidate build of the latest in development release) and examples of 'ga' builds would 
+# be explicit versions like '4.15.20' or '4.16.0' or you could also use things like latest-4.16 to point to the latest z-stream of 4.16.
+# Checkout https://mirror.openshift.com/pub/openshift-v4/clients/ocp for a list of available builds for 'ga' releases and 
+# https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview for a list of 'dev' releases.
 ocp_build: "ga"
+
+# The version of the openshift-installer binary, undefined or empty results in the playbook failing with error message.
+# Values accepted depended on the build chosen ('ga' or 'dev').
+# For 'ga' builds some examples of what you can use are 'latest-4.13', 'latest-4.14' or explicit versions like 4.15.2
+# For 'dev' builds some examples of what you can use are 'candidate-4.16' or just 'latest'
+ocp_version: "latest-4.15"
 
 # Either "OVNKubernetes" or "OpenShiftSDN" (Only for BM/RWN cluster types)
 networktype: OVNKubernetes

--- a/docs/bastion-deploy-bm.md
+++ b/docs/bastion-deploy-bm.md
@@ -225,8 +225,8 @@ Change `cluster_type` to `cluster_type: bm`
 
 Set `worker_node_count` to limit the number of worker nodes from your scale lab allocation. Set it to `0` if you want a 3 node compact cluster.
 
-Change `ocp_release_image` to the intended image if the default (4.15.2) is not the desired version.
-If you change `ocp_release_image` to a different major version (Ex `4.15`), then change `openshift_version` accordingly.
+Change `ocp_version` to the desired OpenShift version.
+Set `ocp_build` to either ga or dev depending on whether you want to install a ga version like z-stream or a development version like candidate-4.16.
 
 Only change `networktype` if you need to test something other than `OVNKubernetes`
 
@@ -330,14 +330,13 @@ sno_node_count:
 # scalelab cloud
 public_vlan: false
 
-# Versions are controlled by this release image. If you want to change images
-# you must stop and rm all assisted-installer containers on the bastion and rerun
-# the setup-bastion step in order to setup your bastion's assisted-installer to
-# the version you specified
-ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.15.2-x86_64
+# The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
+# Values accepted: 'latest-4.13', 'latest-4.14', explicit version i.e. 4.15.2 or for dev builds, candidate-4.16
+ocp_version: "latest-4.15"
 
-# This should just match the above release image version (Ex: 4.15)
-openshift_version: "4.15"
+# Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift
+# Empty value results in playbook failing with error message.
+ocp_build: "ga"
 
 # Either "OVNKubernetes" or "OpenShiftSDN" (Only for BM/RWN cluster types)
 networktype: OVNKubernetes

--- a/docs/deploy-bm-ibmcloud.md
+++ b/docs/deploy-bm-ibmcloud.md
@@ -192,8 +192,8 @@ Change `cluster_type` to `cluster_type: bm`
 
 Set `worker_node_count` if you need to limit the number of worker nodes from available hardware.
 
-Change `ocp_release_image` to the required image if the default (4.15.2) is not the desired version.
-If you change `ocp_release_image` to a different major version (Ex `4.15`), then change `openshift_version` accordingly.
+Change `ocp_version` to the desired OpenShift version.
+Set `ocp_build` to either ga or dev depending on whether you want to install a ga version like z-stream or a development version like candidate-4.16.
 
 Only change `networktype` if you need to test something other than `OVNKubernetes`
 
@@ -246,14 +246,13 @@ worker_node_count: 2
 # Applies to sno clusters
 sno_node_count:
 
-# Versions are controlled by this release image. If you want to change images
-# you must stop and rm all assisted-installer containers on the bastion and rerun
-# the setup-bastion step in order to setup your bastion's assisted-installer to
-# the version you specified
-ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.15.2-x86_64
+# The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
+# Values accepted: 'latest-4.13', 'latest-4.14', explicit version i.e. 4.15.2 or for dev builds, candidate-4.16
+ocp_version: "latest-4.15"
 
-# This should just match the above release image version (Ex: 4.15)
-openshift_version: "4.15"
+# Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift
+# Empty value results in playbook failing with error message.
+ocp_build: "ga"
 
 # Either "OVNKubernetes" or "OpenShiftSDN" (Only for BM/RWN cluster types)
 networktype: OVNKubernetes

--- a/docs/deploy-bm-ibmcloud.md
+++ b/docs/deploy-bm-ibmcloud.md
@@ -192,8 +192,9 @@ Change `cluster_type` to `cluster_type: bm`
 
 Set `worker_node_count` if you need to limit the number of worker nodes from available hardware.
 
-Change `ocp_version` to the desired OpenShift version.
-Set `ocp_build` to either ga or dev depending on whether you want to install a ga version like z-stream or a development version like candidate-4.16.
+Set `ocp_build` to one of 'dev' (early candidate builds) or 'ga' for Generally Available versions of OpenShift. Empty value results in playbook failing with error message. Example of dev builds would be 'candidate-4.17', 'candidate-4.16 or 'latest' (which would point to the early candidate build of the latest in development release) and examples of 'ga' builds would  be explicit versions like '4.15.20' or '4.16.0' or you could also use things like latest-4.16 to point to the latest z-stream of 4.16. Checkout https://mirror.openshift.com/pub/openshift-v4/clients/ocp for a list of available builds for 'ga' releases and https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview for a list of 'dev' releases.
+
+Set `ocp_version` to the version of the openshift-installer binary, undefined or empty results in the playbook failing with error message. Values accepted depended on the build chosen ('ga' or 'dev'). For 'ga' builds some examples of what you can use are 'latest-4.13', 'latest-4.14' or explicit versions like 4.15.2 For 'dev' builds some examples of what you can use are 'candidate-4.16' or just 'latest'.
 
 Only change `networktype` if you need to test something other than `OVNKubernetes`
 
@@ -246,13 +247,19 @@ worker_node_count: 2
 # Applies to sno clusters
 sno_node_count:
 
-# The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
-# Values accepted: 'latest-4.13', 'latest-4.14', explicit version i.e. 4.15.2 or for dev builds, candidate-4.16
-ocp_version: "latest-4.15"
-
-# Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift
-# Empty value results in playbook failing with error message.
+# Enter whether the build should use 'dev' (early candidate builds) or 'ga' for Generally Available versions of OpenShift
+# Empty value results in playbook failing with error message. Example of dev builds would be 'candidate-4.17', 'candidate-4.16'
+# or 'latest' (which would point to the early candidate build of the latest in development release) and examples of 'ga' builds would 
+# be explicit versions like '4.15.20' or '4.16.0' or you could also use things like latest-4.16 to point to the latest z-stream of 4.16.
+# Checkout https://mirror.openshift.com/pub/openshift-v4/clients/ocp for a list of available builds for 'ga' releases and 
+# https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview for a list of 'dev' releases.
 ocp_build: "ga"
+
+# The version of the openshift-installer binary, undefined or empty results in the playbook failing with error message.
+# Values accepted depended on the build chosen ('ga' or 'dev').
+# For 'ga' builds some examples of what you can use are 'latest-4.13', 'latest-4.14' or explicit versions like 4.15.2
+# For 'dev' builds some examples of what you can use are 'candidate-4.16' or just 'latest'
+ocp_version: "latest-4.15"
 
 # Either "OVNKubernetes" or "OpenShiftSDN" (Only for BM/RWN cluster types)
 networktype: OVNKubernetes

--- a/docs/deploy-sno-ibmcloud.md
+++ b/docs/deploy-sno-ibmcloud.md
@@ -202,14 +202,13 @@ worker_node_count:
 # Applies to sno clusters
 sno_node_count: 2
 
-# Versions are controlled by this release image. If you want to change images
-# you must stop and rm all assisted-installer containers on the bastion and rerun
-# the setup-bastion step in order to setup your bastion's assisted-installer to
-# the version you specified
-ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.15.2-x86_64
+# The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
+# Values accepted: 'latest-4.13', 'latest-4.14', explicit version i.e. 4.15.2 or for dev builds, candidate-4.16
+ocp_version: "latest-4.15"
 
-# This should just match the above release image version (Ex: 4.15)
-openshift_version: "4.15"
+# Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift
+# Empty value results in playbook failing with error message.
+ocp_build: "ga"
 
 # Either "OVNKubernetes" or "OpenShiftSDN" (Only for BM/RWN cluster types)
 networktype: OVNKubernetes

--- a/docs/deploy-sno-ibmcloud.md
+++ b/docs/deploy-sno-ibmcloud.md
@@ -202,13 +202,19 @@ worker_node_count:
 # Applies to sno clusters
 sno_node_count: 2
 
-# The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
-# Values accepted: 'latest-4.13', 'latest-4.14', explicit version i.e. 4.15.2 or for dev builds, candidate-4.16
-ocp_version: "latest-4.15"
-
-# Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift
-# Empty value results in playbook failing with error message.
+# Enter whether the build should use 'dev' (early candidate builds) or 'ga' for Generally Available versions of OpenShift
+# Empty value results in playbook failing with error message. Example of dev builds would be 'candidate-4.17', 'candidate-4.16'
+# or 'latest' (which would point to the early candidate build of the latest in development release) and examples of 'ga' builds would 
+# be explicit versions like '4.15.20' or '4.16.0' or you could also use things like latest-4.16 to point to the latest z-stream of 4.16.
+# Checkout https://mirror.openshift.com/pub/openshift-v4/clients/ocp for a list of available builds for 'ga' releases and 
+# https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview for a list of 'dev' releases.
 ocp_build: "ga"
+
+# The version of the openshift-installer binary, undefined or empty results in the playbook failing with error message.
+# Values accepted depended on the build chosen ('ga' or 'dev').
+# For 'ga' builds some examples of what you can use are 'latest-4.13', 'latest-4.14' or explicit versions like 4.15.2
+# For 'dev' builds some examples of what you can use are 'candidate-4.16' or just 'latest'
+ocp_version: "latest-4.15"
 
 # Either "OVNKubernetes" or "OpenShiftSDN" (Only for BM/RWN cluster types)
 networktype: OVNKubernetes

--- a/docs/deploy-sno-quickstart.md
+++ b/docs/deploy-sno-quickstart.md
@@ -228,8 +228,9 @@ Change `cluster_type` to `cluster_type: sno`
 
 Change `sno_node_count` to the number of SNOs that should be provisioned. For example `sno_node_count: 1`
 
-Change `ocp_version` to the desired OpenShift version.
-Set `ocp_build` to either ga or dev depending on whether you want to install a ga version like z-stream or a development version like candidate-4.16.
+Set `ocp_build` to one of 'dev' (early candidate builds) or 'ga' for Generally Available versions of OpenShift. Empty value results in playbook failing with error message. Example of dev builds would be 'candidate-4.17', 'candidate-4.16 or 'latest' (which would point to the early candidate build of the latest in development release) and examples of 'ga' builds would  be explicit versions like '4.15.20' or '4.16.0' or you could also use things like latest-4.16 to point to the latest z-stream of 4.16. Checkout https://mirror.openshift.com/pub/openshift-v4/clients/ocp for a list of available builds for 'ga' releases and https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview for a list of 'dev' releases.
+
+Set `ocp_version` to the version of the openshift-installer binary, undefined or empty results in the playbook failing with error message. Values accepted depended on the build chosen ('ga' or 'dev'). For 'ga' builds some examples of what you can use are 'latest-4.13', 'latest-4.14' or explicit versions like 4.15.2 For 'dev' builds some examples of what you can use are 'candidate-4.16' or just 'latest'.
 
 For the ssh keys we have a chicken before the egg problem in that our bastion machine won't be defined or ensure that keys are created until after we run `create-inventory.yml` and `setup-bastion.yml` playbooks. We will revisit that a little bit later.
 

--- a/docs/deploy-sno-quickstart.md
+++ b/docs/deploy-sno-quickstart.md
@@ -228,8 +228,8 @@ Change `cluster_type` to `cluster_type: sno`
 
 Change `sno_node_count` to the number of SNOs that should be provisioned. For example `sno_node_count: 1`
 
-Change `ocp_release_image` to the desired image if the default (4.15.2) is not the desired version.
-If you change `ocp_release_image` to a different major version (Ex `4.15`), then change `openshift_version` accordingly.
+Change `ocp_version` to the desired OpenShift version.
+Set `ocp_build` to either ga or dev depending on whether you want to install a ga version like z-stream or a development version like candidate-4.16.
 
 For the ssh keys we have a chicken before the egg problem in that our bastion machine won't be defined or ensure that keys are created until after we run `create-inventory.yml` and `setup-bastion.yml` playbooks. We will revisit that a little bit later.
 
@@ -391,14 +391,13 @@ sno_node_count: 1
 # scalelab cloud
 public_vlan: false
 
-# Versions are controlled by this release image. If you want to change images
-# you must stop and rm all assisted-installer containers on the bastion and rerun
-# the setup-bastion step in order to setup your bastion's assisted-installer to
-# the version you specified
-ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.15.2-x86_64
+# The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
+# Values accepted: 'latest-4.13', 'latest-4.14', explicit version i.e. 4.15.2 or for dev builds, candidate-4.16
+ocp_version: "latest-4.15"
 
-# This should just match the above release image version (Ex: 4.15)
-openshift_version: "4.15"
+# Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift
+# Empty value results in playbook failing with error message.
+ocp_build: "ga"
 
 # Either "OVNKubernetes" or "OpenShiftSDN" (Only for BM/RWN cluster types)
 networktype: OVNKubernetes

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -160,12 +160,12 @@ install_performance_addon_operator: true
 
 Versions are controlled by the release image. If you want to change images:
 
-Modify the vars file to update release image path with `ocp_release_image` and the openshift version with `openshift_version`
+Modify the vars file to update the openshift version  with `ocp_version` and the build (ga or dev) with `ocp_build`.
 Example:
 
 ```yaml
-ocp_release_image: registry.ci.openshift.org/ocp/release:4.10.0-0.nightly-2022-01-18-044014
-openshift_version: "4.10"
+ocp_version: "4.15.2" 
+ocp_build: "ga"
 ```
 Ensure that your pull secrets are still valid.
 When worikng with OCP development builds/nightly releases, it might be required to update your pull secret with fresh `registry.ci.openshift.org` credentials as they are bound to expire after a definite period. Follow these steps to update your pull secret:

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -158,10 +158,9 @@ install_performance_addon_operator: true
 
 ## Updating the OCP version
 
-Versions are controlled by the release image. If you want to change images:
+Set `ocp_build` to one of 'dev' (early candidate builds) or 'ga' for Generally Available versions of OpenShift. Empty value results in playbook failing with error message. Example of dev builds would be 'candidate-4.17', 'candidate-4.16 or 'latest' (which would point to the early candidate build of the latest in development release) and examples of 'ga' builds would  be explicit versions like '4.15.20' or '4.16.0' or you could also use things like latest-4.16 to point to the latest z-stream of 4.16. Checkout https://mirror.openshift.com/pub/openshift-v4/clients/ocp for a list of available builds for 'ga' releases and https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview for a list of 'dev' releases.
 
-Modify the vars file to update the openshift version  with `ocp_version` and the build (ga or dev) with `ocp_build`.
-Example:
+Set `ocp_version` to the version of the openshift-installer binary, undefined or empty results in the playbook failing with error message. Values accepted depended on the build chosen ('ga' or 'dev'). For 'ga' builds some examples of what you can use are 'latest-4.13', 'latest-4.14' or explicit versions like 4.15.2 For 'dev' builds some examples of what you can use are 'candidate-4.16' or just 'latest'.
 
 ```yaml
 ocp_version: "4.15.2" 


### PR DESCRIPTION
This removes the need to explicitly define the OCP release image and instead requires `ocp_version` and `ocp_build` from the user. OpenShift version could be specific like 4.15.4 or more generic like latest-4.15. The build should denote whether the required OCP version is ga or under development using the keys `ga` or `dev`. This commit also removes the circular dependency on having oc (installed as `oc.latest` to extract the ocp client/installer binaries). Overall, this greatly simplifies the use of jetlag while at the same time making it intelligent to deploy latest ga/nightly versions across minor releases.

Co-authored-by: Alex Krzos <akrzos@redhat.com>
Closes: https://github.com/redhat-performance/jetlag/issues/501