### PR TITLE
Dell R660

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The listed hardware has been used for cluster deployments successfully. Potentia
 
 | Hardware           | BM  | RWN | SNO |
 | ------------------ | --- | --- | --- |
+| Dell r660          | Yes | No  | No  |
 | Dell r650          | Yes | No  | Yes |
 | Dell r640          | Yes | Yes | Yes |
 | Dell fc640         | Yes | No  | Yes |

--- a/ansible/vars/lab.yml
+++ b/ansible/vars/lab.yml
@@ -80,6 +80,13 @@ hw_nic_name:
     - ens2f0
     - ens2f1
     - eno12409np1
+    r660:
+    - eno12399np0
+    - ens1f0
+    - ens1f1
+    - ens2f0
+    - ens2f1
+    - eno12409np1
     r730xd:
     - eno3
     - eno1
@@ -156,6 +163,9 @@ hw_vm_counts:
       sdb: 12
       nvme0n1: 12
     r650:
+      default: 4
+      nvme0n1: 23
+    r660:
       default: 4
       nvme0n1: 23
     r730xd:

--- a/ansible/vars/lab.yml
+++ b/ansible/vars/lab.yml
@@ -31,6 +31,7 @@ hw_vendor:
   r630: Dell
   r640: Dell
   r650: Dell
+  r660: Dell
   r730xd: Dell
   r750: Dell
   r930: Dell

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -21,6 +21,7 @@ Values here reflect the default (Network 1 which maps to `controlplane_network_i
 
 | Hardware           | bastion_lab_interface | bastion_controlplane_interface | controlplane_lab_interface |
 | ------------------ | --------------------- | ------------------------------ | -------------------------- |
+| Dell r660          | eno12399np0           | ens1f0                         | eno12399np0                |
 | Dell r650          | eno12399np0           | ens1f0                         | eno12399np0                |
 | Dell r640          | eno1np0               | ens1f0                         | eno1np0                    |
 | Dell fc640         | eno1                  | eno2                           | eno1                       |


### PR DESCRIPTION
Scalelab is onboarding Dell R660s. This was the only necessary change needed to the templates.

For the `all.yml` the only modification I had to do,

```
bastion_lab_interface: eno12399np0
```