### PR TITLE
"Promote" configure-local-storage references

### DIFF
--- a/ansible/bm-deploy.yml
+++ b/ansible/bm-deploy.yml
@@ -25,5 +25,6 @@
       inventory_group: worker
       index: "{{ worker_node_count }}"
   - wait-hosts-discovered
+  - configure-local-storage
   - install-cluster
   - bm-post-cluster-install

--- a/ansible/ibmcloud-bm-deploy.yml
+++ b/ansible/ibmcloud-bm-deploy.yml
@@ -28,5 +28,6 @@
       inventory_group: worker
       index: "{{ worker_node_count }}"
   - wait-hosts-discovered
+  - configure-local-storage
   - install-cluster
   - bm-post-cluster-install

--- a/ansible/ibmcloud-sno-deploy.yml
+++ b/ansible/ibmcloud-sno-deploy.yml
@@ -26,5 +26,6 @@
       inventory_group: sno
       index: "1"
   - sno-wait-hosts-discovered
+  - configure-local-storage
   - install-cluster
   - sno-post-cluster-install

--- a/ansible/roles/install-cluster/tasks/main.yml
+++ b/ansible/roles/install-cluster/tasks/main.yml
@@ -20,10 +20,6 @@
     body: "{{ lookup('template', 'install-config-overrides.yml.j2') | from_yaml | to_json(ensure_ascii=False) | string | to_json(ensure_ascii=False) | string }}"
   register: get_install_config
 
-- name: Apply local storage ignition overrides
-  include_role:
-    name: configure-local-storage
-
 - name: Install cluster
   uri:
     url: "http://{{ assisted_installer_host }}:{{ assisted_installer_port }}/api/assisted-install/v2/clusters/{{ ai_cluster_id }}/actions/install"

--- a/ansible/rwn-deploy.yml
+++ b/ansible/rwn-deploy.yml
@@ -22,6 +22,7 @@
       inventory_group: controlplane
       index: 3
   - wait-hosts-discovered
+  - configure-local-storage
   - install-cluster
   - rwn-post-cluster-install
   - generate-livecd

--- a/ansible/sno-deploy.yml
+++ b/ansible/sno-deploy.yml
@@ -23,5 +23,6 @@
       inventory_group: sno
       index: "1"
   - sno-wait-hosts-discovered
+  - configure-local-storage
   - install-cluster
   - sno-post-cluster-install


### PR DESCRIPTION
The new `configure-local-storage` role was called indirectly from `install-cluster`, but calling it directly from the playbooks will make it more visible and maintainable.