### PR TITLE
Update ALIAS (perfscale) lab settings

### DIFF
--- a/ansible/vars/lab.yml
+++ b/ansible/vars/lab.yml
@@ -14,10 +14,10 @@ rh_labs:
 labs:
   alias:
     dns:
-    - 10.19.96.1
-    foreman: foreman.alias.bos.scalelab.redhat.com
+    - 10.6.60.1
+    foreman: foreman.rdu3.labs.perfscale.redhat.com
     ntp_server: clock2.bos.redhat.com
-    quads: quads.alias.bos.scalelab.redhat.com
+    quads: quads.rdu3.labs.perfscale.redhat.com
   scalelab:
     dns:
     - 10.1.36.1


### PR DESCRIPTION
The ALIAS lab (aka performance lab) has moved from BOS to RDU3, so adjust the addresses.

Resolves #517 