### PR TITLE
Dont log ssh keys

### DIFF
--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -112,6 +112,7 @@
   when: lab in cloud_labs
   block:
   - name: Copy ssh keys to bastion
+    no_log: True
     copy:
       content: "{{ item.content }}"
       dest: "{{ item.dest }}"

--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -112,7 +112,7 @@
   when: lab in cloud_labs
   block:
   - name: Copy ssh keys to bastion
-    no_log: True
+    no_log: true
     copy:
       content: "{{ item.content }}"
       dest: "{{ item.dest }}"


### PR DESCRIPTION
The output of the OpenSSH private key in the **bastion-install : Copy ssh keys to bastion** task is making the logs unavailable in Prow, they get removed because of sensitive information:
```
This file contained potentially sensitive information and has been removed.
```