### PR TITLE
Use `ip` instead of `ip-address` in SNO inventory

### DIFF
--- a/ansible/inventory/inventory-sno.sample
+++ b/ansible/inventory/inventory-sno.sample
@@ -29,8 +29,8 @@ bmc_password=password
 
 [sno]
 # Single Node OpenShift Clusters
-sno-0 bmc_address=mgmt-sno-0.example.com boot_iso=sno-0.iso ip_address=10.0.0.1 vendor=Dell lab_mac=00:4e:01:3d:e6:9e network_mac=40:a6:b7:00:63:61 install_disk=/dev/sda
-sno-1 bmc_address=mgmt-sno-1.example.com boot_iso=sno-1.iso ip_address=10.0.0.2 vendor=Dell lab_mac=00:4e:01:3d:e6:ab network_mac=40:a6:b7:00:53:81 install_disk=/dev/sda
+sno-0 bmc_address=mgmt-sno-0.example.com boot_iso=sno-0.iso ip=10.0.0.1 vendor=Dell lab_mac=00:4e:01:3d:e6:9e network_mac=40:a6:b7:00:63:61 install_disk=/dev/sda
+sno-1 bmc_address=mgmt-sno-1.example.com boot_iso=sno-1.iso ip=10.0.0.2 vendor=Dell lab_mac=00:4e:01:3d:e6:ab network_mac=40:a6:b7:00:53:81 install_disk=/dev/sda
 
 [sno:vars]
 bmc_user=quads

--- a/ansible/roles/bastion-dnsmasq/templates/jetlag.conf.j2
+++ b/ansible/roles/bastion-dnsmasq/templates/jetlag.conf.j2
@@ -36,7 +36,7 @@ address=/apps.compact-{{ '%05d' | format(cluster) }}.{{ base_dns_name }}/{{ host
 {% endif %}
 
 {% for item in groups['sno'] %}
-{% if hostvars[item].ip_address is defined %}
-address=/apps.{{ hostvars[item].inventory_hostname }}.{{ base_dns_name }}/{{ hostvars[item].ip_address }}
+{% if hostvars[item].ip is defined %}
+address=/apps.{{ hostvars[item].inventory_hostname }}.{{ base_dns_name }}/{{ hostvars[item].ip }}
 {% endif %}
 {% endfor %}

--- a/ansible/roles/create-inventory/templates/inventory-sno.j2
+++ b/ansible/roles/create-inventory/templates/inventory-sno.j2
@@ -35,13 +35,13 @@ bmc_password={{ bmc_password }}
 #  uncommented.
 {% for sno in ocpinventory_sno_nodes %}
 {%- if use_bastion_registry -%}
-{%-   set ip_address=controlplane_network | ansible.utils.nthhost(loop.index0 + 5) -%}
+{%-   set ip=controlplane_network | ansible.utils.nthhost(loop.index0 + 5) -%}
 {%- elif public_vlan | bool -%}
-{%-   set ip_address=controlplane_pub_network_cidr | ansible.utils.nthhost(loop.index0 + 1) -%}
+{%-   set ip=controlplane_pub_network_cidr | ansible.utils.nthhost(loop.index0 + 1) -%}
 {%- else -%}
-{%- set ip_address=(sno_foreman_data.results|selectattr('json.name', 'eq', sno.pm_addr | replace('mgmt-',''))|first).json.ip -%}
+{%- set ip=(sno_foreman_data.results|selectattr('json.name', 'eq', sno.pm_addr | replace('mgmt-',''))|first).json.ip -%}
 {%- endif -%}
-{% if not loop.first %}# {% endif %}{{ sno.pm_addr.split('.')[0] | replace('mgmt-','') }} bmc_address={{ sno.pm_addr }} boot_iso={{ sno.pm_addr.split('.')[0] | replace('mgmt-','') }}.iso ip_address={{ ip_address }} vendor={{ hw_vendor[(sno.pm_addr.split('.')[0]).split('-')[-1]] }} lab_mac={{ (sno_foreman_data.results|selectattr('json.name', 'eq', sno.pm_addr | replace('mgmt-',''))|first) | json_query(mac_query) | join(', ') }} network_mac={{ sno.mac[0] }} install_disk={{ sno_install_disk }}
+{% if not loop.first %}# {% endif %}{{ sno.pm_addr.split('.')[0] | replace('mgmt-','') }} bmc_address={{ sno.pm_addr }} boot_iso={{ sno.pm_addr.split('.')[0] | replace('mgmt-','') }}.iso ip={{ ip }} vendor={{ hw_vendor[(sno.pm_addr.split('.')[0]).split('-')[-1]] }} lab_mac={{ (sno_foreman_data.results|selectattr('json.name', 'eq', sno.pm_addr | replace('mgmt-',''))|first) | json_query(mac_query) | join(', ') }} network_mac={{ sno.mac[0] }} install_disk={{ sno_install_disk }}
 {% endfor %}
 
 [sno:vars]

--- a/ansible/roles/hv-dnsmasq/templates/jetlag.conf.j2
+++ b/ansible/roles/hv-dnsmasq/templates/jetlag.conf.j2
@@ -40,8 +40,8 @@ address=/apps.compact-{{ '%05d' | format(cluster) }}.{{ base_dns_name }}/{{ host
 {% endif %}
 
 {% for item in groups['sno'] %}
-{% if hostvars[item].ip_address is defined %}
-address=/apps.{{ hostvars[item].inventory_hostname }}.{{ base_dns_name }}/{{ hostvars[item].ip_address }}
+{% if hostvars[item].ip is defined %}
+address=/apps.{{ hostvars[item].inventory_hostname }}.{{ base_dns_name }}/{{ hostvars[item].ip }}
 {% endif %}
 {% endfor %}
 

--- a/ansible/roles/sno-create-ai-cluster/tasks/main.yml
+++ b/ansible/roles/sno-create-ai-cluster/tasks/main.yml
@@ -65,13 +65,13 @@
     path: "/etc/hosts"
     backup: true
     block: |
-      {{ hostvars[item].ip_address }} api.{{ hostvars[item].inventory_hostname }}.{{ base_dns_name }}
-      {{ hostvars[item].ip_address }} api-int.{{ hostvars[item].inventory_hostname }}.{{ base_dns_name }}
+      {{ hostvars[item].ip }} api.{{ hostvars[item].inventory_hostname }}.{{ base_dns_name }}
+      {{ hostvars[item].ip }} api-int.{{ hostvars[item].inventory_hostname }}.{{ base_dns_name }}
       {% for route in etc_hosts_ingress_routes %}
-      {{ hostvars[item].ip_address }} {{ route }}.apps.{{ hostvars[item].inventory_hostname }}.{{ base_dns_name }}
+      {{ hostvars[item].ip }} {{ route }}.apps.{{ hostvars[item].inventory_hostname }}.{{ base_dns_name }}
       {% endfor %}
       {% if public_vlan %}
-      {{ hostvars[item].ip_address }} {{ hostvars[item].inventory_hostname }} # SNO node
+      {{ hostvars[item].ip }} {{ hostvars[item].inventory_hostname }} # SNO node
       {%- endif %}
     insertafter: "EOF"
     marker: "# {mark} {{ hostvars[item].inventory_hostname }} OCP CLUSTER MANAGED BLOCK"

--- a/ansible/roles/sno-create-ai-cluster/templates/nmstate.yml.j2
+++ b/ansible/roles/sno-create-ai-cluster/templates/nmstate.yml.j2
@@ -9,7 +9,7 @@ interfaces:
   ipv6:
 {% endif %}
     address:
-    - ip: {{ hostvars[item]['ip_address'] }}
+    - ip: {{ hostvars[item]['ip'] }}
       prefix-length: {{ hostvars[item]['network_prefix'] }}
     auto-dns: false
     enabled: true

--- a/docs/deploy-sno-quickstart.md
+++ b/docs/deploy-sno-quickstart.md
@@ -492,7 +492,7 @@ bmc_password=xxxx
 
 [sno]
 # Single Node OpenShift Clusters
-f12-h06-000-1029u bmc_address=mgmt-f12-h06-000-1029u.rdu2.scalelab.redhat.com boot_iso=f12-h06-000-1029u.iso ip_address=10.1.38.222 vendor=Supermicro lab_mac=ac:1f:6b:56:57:0e network_mac=00:25:90:5f:5f:5b
+f12-h06-000-1029u bmc_address=mgmt-f12-h06-000-1029u.rdu2.scalelab.redhat.com boot_iso=f12-h06-000-1029u.iso ip=10.1.38.222 vendor=Supermicro lab_mac=ac:1f:6b:56:57:0e network_mac=00:25:90:5f:5f:5b
 
 [sno:vars]
 bmc_user=quads


### PR DESCRIPTION
This change improves consistency between the SNO and BM inventory.

Resolves #239