### PR TITLE
Update default QUADs url

### DIFF
--- a/ansible/roles/create-inventory/tasks/main.yml
+++ b/ansible/roles/create-inventory/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Set ocp inventory download url from lab wiki
   set_fact:
-    ocp_inventory_url: "http://{{ labs[lab]['quads'] }}/cloud/{{ lab_cloud }}_ocpinventory.json"
+    ocp_inventory_url: "https://{{ labs[lab]['quads'] }}/instack/{{ lab_cloud }}_ocpinventory.json"
   when:  ocp_inventory_override | string | length < 1
 
 - name: Set ocp inventory download url to override


### PR DESCRIPTION
Quads was updated to 2.0, this updates the default url to get ocpinventory from /cloud/cloudxx_ocpinventory to
/instack/cloudxx_ocpinventory

SSL was also enabled and has been added to the default url