### PR TITLE
Package nmstate is needed to create Image-Based-Install ISO files usi…

### DIFF
--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -21,6 +21,7 @@
     - jq
     - make
     - net-tools
+    - nmstate
     - python3-pip
     - podman
     - rsync


### PR DESCRIPTION
…ng openshift-install (This is needed for large scale ACM IBI testing)