### PR TITLE
Add controlplane_network to inventory

### DIFF
--- a/ansible/roles/create-inventory/templates/inventory-mno.j2
+++ b/ansible/roles/create-inventory/templates/inventory-mno.j2
@@ -3,6 +3,7 @@ allocation_node_count={{ ocpinventory.json.nodes | length }}
 supermicro_nodes={{ has_supermicro | bool }}
 {% if public_vlan %}
 cluster_name={{ cluster_name }}
+controlplane_network={{ controlplane_network }}
 {% if lab == "scalelab" %}
 base_dns_name=rdu2.scalelab.redhat.com
 {% elif lab == "performancelab" %}


### PR DESCRIPTION
This variable needs to be set at the inventory level (rather than using the default value) when public_vlan is enabled.