### PR TITLE
allow role overrides for VMs in standard clusters

### DIFF
--- a/ansible/roles/hv-vm-manifests-standard/templates/siteconfig.yml.j2
+++ b/ansible/roles/hv-vm-manifests-standard/templates/siteconfig.yml.j2
@@ -72,7 +72,9 @@ spec:
 # "{{ (((item - 1) * standard_cluster_node_count) + offset) }} until {{ ((item * standard_cluster_node_count) - 1 + offset) }}"
 {% for vm in range(((item - 1) * standard_cluster_node_count) + offset, (item * standard_cluster_node_count) + offset, 1) %}
     - hostName: "{{ groups['hv_vm'][vm] }}"
-{% if vm < (((item - 1) * standard_cluster_node_count) + offset + 3) %}
+{% if 'role' in hostvars[groups['hv_vm'][vm]] %}
+      role: "{{ hostvars[groups['hv_vm'][vm]]['role'] }}"
+{% elif vm < (((item - 1) * standard_cluster_node_count) + offset + 3) %}
       role: "master"
 {% else %}
       role: "worker"


### PR DESCRIPTION
adding role=master or role=worker to an hv_vm inventory definition will assign that node to they specified role when the siteconfig is built