### PR TITLE
Removing hybrid_worker_count from non-create inventory roles

### DIFF
--- a/ansible/roles/create-ai-cluster/defaults/main/main.yml
+++ b/ansible/roles/create-ai-cluster/defaults/main/main.yml
@@ -18,7 +18,3 @@ override_kni_infra_haproxy: false
 # Manually override the openshift-kni-haproxy max connections via a machineconfig that replaces the
 # haproxy templatized config file with one with greater max connections (Original default 20000)
 openshift_kni_infra_haproxy_maxconn: 40000
-
-# If HV is setup, how many workers are VMs
-# This runs hosts from hv_vm through the normal workers workflow for deployment
-hybrid_worker_count: 0

--- a/ansible/roles/mno-post-cluster-install/defaults/main/main.yml
+++ b/ansible/roles/mno-post-cluster-install/defaults/main/main.yml
@@ -45,7 +45,3 @@ minio_pv_storageclass: localstorage2-sc
 # Performance-addon-operator vars_files
 install_performance_addon_operator: false
 ocp_channel: "{{ openshift_version }}"
-
-# If HV is setup, how many workers are VMs
-# This runs hosts from hv_vm through the normal workers workflow for deployment
-hybrid_worker_count: 0


### PR DESCRIPTION
- These roles don't use the variable so it doesn't need to be in their defaults.