### PR TITLE
Move crucible install repo to /root and add identity vars on installation invocation.

### DIFF
--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -262,12 +262,15 @@
 - name: Download Red Hat Crucible
   ansible.builtin.git:
     repo: "{{ rh_crucible_url }}"
-    dest: /tmp/crucible
+    dest: /root/crucible
     force: true
   environment:
     GIT_SSL_NO_VERIFY: "False"
   when: install_rh_crucible | bool
 
 - name: Install Red Hat Crucible
-  command: chdir=/tmp/crucible bash rh-install-crucible.sh
+  command: chdir=/root/crucible bash rh-install-crucible.sh
+  environment:
+    CRUCIBLE_NAME: "jetlag"
+    CRUCIBLE_EMAIL: "none"
   when: install_rh_crucible | bool


### PR DESCRIPTION
**Synopsis**: Fine tuning crucible installation by correcting 2 errors.
**Code changes:**
1. The installation process requires "identity" inputs: CRUCIBLE_NAME and CRUCILE_EMAIL. Just feed them via CLI.  
2. The crucible installation repo defined by "rh_crucible_url" will not work when being installed in /tmp.  When crucible runs test, its podman pods cannot access host's /tmp filesystem.  Move this repo to /root.
**Test:**
- Verified crucible installation complete succesfully 
- Verified regulus runs succesfully on top of this installed crucible.
