### PR TITLE
Add missing config path

### DIFF
--- a/ansible/roles/bastion-ocp-version/tasks/main.yml
+++ b/ansible/roles/bastion-ocp-version/tasks/main.yml
@@ -61,7 +61,7 @@
 
 - name: Extract/Download the openshift-install binary for the specific release
   shell: |
-    oc adm release extract --tools {{ ocp_release_image }}
+    oc adm release extract --tools {{ ocp_release_image }} --to {{ ocp_version_path }} --registry-config /root/.docker/config.json
     tar -xvf openshift-install-linux-*.tar.gz openshift-install
   args:
     chdir: "{{ ocp_version_path }}"


### PR DESCRIPTION
The missing config path caused the OpenShift installer download to fail.
Adding the full path using -`-to {{ ocp_version_path }} --registry-config /root/.docker/config.json` resolved the issue.

[IBM Cloud CI installation failed](https://github.com/redhat-performance/benchmark-runner/actions/runs/15894569776/job/44823330911) due to this issue
