### PR TITLE
Add r760 performancelab hw_vm_counts vars

### DIFF
--- a/ansible/vars/lab.yml
+++ b/ansible/vars/lab.yml
@@ -221,6 +221,9 @@ hw_vm_counts:
     r740xd:
       default: 4
       nvme0n1: 5
+    r760:
+      default: 4
+      nvme0n1: 23
 
 # # Based on VM Size (8vCPU, 28GiB Memory, 120G Disk)
 # hw_vm_counts:


### PR DESCRIPTION
This is required for testing the hybrid workers scenario on the metal-perfscale-cpt cluster(cloud31).