### PR TITLE
Extend inventory template for performancelab hypervisors and hw_nic_name

### DIFF
--- a/ansible/roles/create-inventory/templates/inventory-mno.j2
+++ b/ansible/roles/create-inventory/templates/inventory-mno.j2
@@ -88,7 +88,7 @@ dns2={{ labs[lab]['dns'][1] | default('') }}
 {% if hv_inventory %}
 [hv]
 {% for hv in ocpinventory_hv_nodes %}
-{{ hv.pm_addr | replace('mgmt-','') }} bmc_address={{ hv.pm_addr }} vendor={{ hw_vendor[(hv.pm_addr.split('.')[0]).split('-')[-1]] }} ip={{ controlplane_network | ansible.utils.nthhost(loop.index + ocpinventory_worker_nodes|length + mno_worker_node_offset + hv_ip_offset) }} nic={{ hw_nic_name[lab][(hv.pm_addr.split('.')[0]).split('-')[-1]][hypervisor_nic_interface_idx] if lab == 'scalelab' }} disk2_enable={{ hv.disk2_enable }} disk2_device={{ hv.disk2_device }}
+{{ hv.pm_addr | replace('mgmt-','') }} bmc_address={{ hv.pm_addr }} vendor={{ hw_vendor[(hv.pm_addr.split('.')[0]).split('-')[-1]] }} ip={{ controlplane_network | ansible.utils.nthhost(loop.index + ocpinventory_worker_nodes|length + mno_worker_node_offset + hv_ip_offset) }} nic={{ hw_nic_name[lab][(hv.pm_addr.split('.')[0]).split('-')[-1]][hypervisor_nic_interface_idx] }} disk2_enable={{ hv.disk2_enable }} disk2_device={{ hv.disk2_device }}
 {% endfor %}
 
 [hv:vars]

--- a/ansible/vars/lab.yml
+++ b/ansible/vars/lab.yml
@@ -166,6 +166,12 @@ hw_nic_name:
     - eno2
     - ens7f0
     - ens7f1
+    r760:
+    - eno12399
+    - ens3f0
+    - ens3f1
+    - ens6f0
+    - ens6f1
 
 # Based on VM Size (8vCPU, 18GiB Memory, 120G Disk)
 hw_vm_counts:


### PR DESCRIPTION
This is a follow up to https://github.com/redhat-performance/jetlag/pull/671 to allow testing the hybrid workers scenario on the metal-perfscale-cpt cluster(cloud31).