### PR TITLE
Added missing lab variables to MNO (Multi Node Openshift) scale out deployment

### DIFF
--- a/ansible/mno-scale-out.yml
+++ b/ansible/mno-scale-out.yml
@@ -2,6 +2,7 @@
 - name: Adds nodes to a cluster
   hosts: bastion
   vars_files:
+  - vars/lab.yml
   - vars/all.yml
   - vars/scale_out.yml
   roles:


### PR DESCRIPTION
The `mno-scale-out.yml` playbook is failing because the `DELL - Insert Virtual Media task `cannot find the `rh_labs` variable. After some investigation, I discovered that `rh_labs` is correctly defined in `ansible/vars/lab.yml`. To make this variable available to the playbook, We need to add a reference to `vars/lab.yml `within the vars block of the `ansible/mno-scale-out.yml `playbook.