### PR TITLE
Add eno2np1 to r640 scalelab interface list

### DIFF
--- a/ansible/vars/lab.yml
+++ b/ansible/vars/lab.yml
@@ -81,6 +81,7 @@ hw_nic_name:
     - ens1f1
     - ens2f0
     - ens2f1
+    - eno2np1
     r650:
     - eno12399np0
     - ens1f0


### PR DESCRIPTION
This is required for setting up the bridge for hybrid cluster VMs on the jetscale CI cluster.

```
[root@f19-h19-000-r640 ~]# ip link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: eno1np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether bc:97:e1:7d:08:30 brd ff:ff:ff:ff:ff:ff
    altname enp25s0f0np0
3: ens1f0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq master br0 state UP mode DEFAULT group default qlen 1000
    link/ether 40:a6:b7:2a:68:b0 brd ff:ff:ff:ff:ff:ff
    altname enp59s0f0
4: eno2np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether bc:97:e1:7d:08:31 brd ff:ff:ff:ff:ff:ff
    altname enp25s0f1np1
5: ens1f1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 40:a6:b7:2a:68:b1 brd ff:ff:ff:ff:ff:ff
    altname enp59s0f1
6: ens2f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 0c:42:a1:8b:ef:94 brd ff:ff:ff:ff:ff:ff
    altname enp94s0f0np0
7: ens2f1np1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 0c:42:a1:8b:ef:95 brd ff:ff:ff:ff:ff:ff
    altname enp94s0f1np1
```