### PR TITLE
Fix wait for nodes to be discovered race condition

### DIFF
--- a/ansible/roles/wait-hosts-discovered/tasks/main.yml
+++ b/ansible/roles/wait-hosts-discovered/tasks/main.yml
@@ -18,7 +18,9 @@
     status_code: [200, 201]
     return_content: true
   register: cluster
-  until: cluster.json.hosts | length == inventory_nodes | length
+  until:
+    - cluster.json is defined
+    - cluster.json.hosts | length == inventory_nodes | length
   retries: 40
   delay: 60
 


### PR DESCRIPTION
We've observed the following failure in the `Wait up to 40 min for nodes to be discovered` which seems to be caused by the URL not returning a json at the task run time. This change adds an additional check to the until condition to ensure the json is defined

```
TASK [wait-hosts-discovered : Wait up to 40 min for nodes to be discovered] ****
Wednesday 13 August 2025  08:59:42 +0000 (0:00:00.036)       0:00:35.599 ****** 
FAILED - RETRYING: [f19-h01-000-r640.rdu2.scalelab.redhat.com]: Wait up to 40 min for nodes to be discovered (40 retries left).
fatal: [f19-h01-000-r640.rdu2.scalelab.redhat.com]: FAILED! => {"msg": "The conditional check 'cluster.json.hosts | length == inventory_nodes | length' failed. The error was: error while evaluating conditional (cluster.json.hosts | length == inventory_nodes | length): 'dict object' has no attribute 'json'. 'dict object' has no attribute 'json'"}
```
