### PR TITLE
Add r760 to the disk2_enable enable task

### DIFF
--- a/ansible/roles/create-inventory/tasks/main.yml
+++ b/ansible/roles/create-inventory/tasks/main.yml
@@ -255,11 +255,11 @@
     loop_control:
       index_var: idx
 
-  - name: Enable disk2_enable for r660, r650, r750, r730xd, and r930 with nvme0n1
+  - name: Enable disk2_enable for r660, r650, r750, r760, r730xd, and r930 with nvme0n1
     set_fact:
       ocpinventory_hv_nodes: "{{ ocpinventory_hv_nodes[:idx] + [ocpinventory_hv_nodes[idx] | combine({'disk2_enable': true, 'disk2_device': 'nvme0n1'})] + ocpinventory_hv_nodes[idx + 1:] }}"
     when:
-    - (item.pm_addr.split('.')[0]).split('-')[-1] in ['r650', 'r660', 'r750', 'r730xd', 'r740xd', 'r930']
+    - (item.pm_addr.split('.')[0]).split('-')[-1] in ['r650', 'r660', 'r750', 'r760', 'r730xd', 'r740xd', 'r930']
     loop: "{{ ocpinventory_hv_nodes }}"
     loop_control:
       index_var: idx

--- a/ansible/roles/hv-setup-disk2/tasks/main.yml
+++ b/ansible/roles/hv-setup-disk2/tasks/main.yml
@@ -45,3 +45,15 @@
   loop:
   - "{{ disk2_mount_path }}/libvirt"
   - "{{ disk2_mount_path }}/libvirt/images"
+
+- name: Get root logical volume VG and LV names
+  shell: lvs --noheadings --nosuffix --units g -o vg_name,lv_name $(df / | tail -1 | awk '{print $1}')
+  register: root_lv_info
+  changed_when: false
+
+- name: Extend root logical volume to maximum available space
+  lvol:
+    vg: "{{ root_lv_info.stdout_lines[0].split()[0] }}"
+    lv: "{{ root_lv_info.stdout_lines[0].split()[1] }}"
+    size: +100%FREE
+    resizefs: true

--- a/ansible/vars/lab.yml
+++ b/ansible/vars/lab.yml
@@ -230,7 +230,7 @@ hw_vm_counts:
       nvme0n1: 5
     r760:
       default: 4
-      nvme0n1: 23
+      nvme0n1: 30
 
 # # Based on VM Size (8vCPU, 28GiB Memory, 120G Disk)
 # hw_vm_counts:


### PR DESCRIPTION
Required to create VMs on nvme0n1 drive on r760 machines in the performancelab.