### PR TITLE
Add scale out functionality for Compact MNO Cluster

### DIFF
--- a/ansible/roles/mno-scale-out-csr/tasks/main.yml
+++ b/ansible/roles/mno-scale-out-csr/tasks/main.yml
@@ -3,10 +3,10 @@
   include_tasks: check_nodes_joined.yml
   vars:
     qry: "items[?status.conditions==null && spec.username == 'system:serviceaccount:openshift-machine-config-operator:node-bootstrapper']"
-    worker_counter: "grep -c worker"
+    worker_counter: "grep worker | grep -v -c master"
 
 - name: Approve Kublet-serving CSRs and wait for nodes to join cluster
   include_tasks: check_nodes_joined.yml
   vars:
     qry: "items[?status.conditions==null && spec.signerName == 'kubernetes.io/kubelet-serving']"
-    worker_counter: "grep worker | grep -c -v NotReady"
+    worker_counter: "grep worker | grep -v master | grep -c -v NotReady"


### PR DESCRIPTION
A scale-out deployment of two workers on a Compact MNO Cluster was attempted, but it did not work as expected. Although the playbook executed without any errors, the scale-out failed because the workers were not added to the cluster. It was discovered that the "Approve CSRs" task did not work as expected, and after examining the Ansible playbooks, it was realized that the way the worker node count was being filtered was incorrect.

After these changes were implemented, the workers were successfully scaled out in the Compact MNO cluster.