### PR TITLE
Enable remote source copy option for generated scale out iso

### DIFF
--- a/ansible/roles/mno-scale-out/tasks/main.yml
+++ b/ansible/roles/mno-scale-out/tasks/main.yml
@@ -25,6 +25,7 @@
   ansible.builtin.copy:
     src: /root/mno-scale-out/node.x86_64.iso
     dest: /opt/http_store/data/mno-scale-out.x86_64.iso
+    remote_src: true
 
 - name: Delete mno-scale-out directory
   ansible.builtin.file:


### PR DESCRIPTION
During the scale-out operation, I have the faced the below error for COPY Execution task.

`TASK [mno-scale-out : Copy scale out discovery iso to http server] *************
Thursday X8 August X0XX  11:0X:X7 +0000 (0:01:X7.881)       0:01:X0.8X0 ******* 
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: If you are using a module and expect the file to exist on the remote, see the remote_src option
fatal: [f19-h01-000-rXX0.rduX.XXXXXXXX.redhat.com]: FAILED! => {"changed": false, "msg": "Could not find or access '/root/mno-scale-out/node.x8X_XX.iso' on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"}
`

As Source and destination paths are already available on the managed node, we need to use `remote_src: true` option so that copy action can be executed successfully on Managed node.