### PR TITLE
allow user to define controlplane_network_gateway

### DIFF
--- a/ansible/roles/create-inventory/defaults/main/networks.yml
+++ b/ansible/roles/create-inventory/defaults/main/networks.yml
@@ -9,7 +9,6 @@ controlplane_network_interface_idx: 0
 controlplane_network_interface: eth0
 controlplane_network: 198.18.0.0/16
 controlplane_network_prefix: 16
-controlplane_network_gateway: "{{ controlplane_network | ansible.utils.nthhost(1) }}"
 controlplane_network_api: "{{ controlplane_network | ansible.utils.nthhost(3) }}"
 controlplane_network_ingress: "{{ controlplane_network | ansible.utils.nthhost(4) }}"
 # Sets "bastion_controlplane_ip" as primary dns

--- a/ansible/roles/create-inventory/tasks/main.yml
+++ b/ansible/roles/create-inventory/tasks/main.yml
@@ -56,6 +56,13 @@
   set_fact:
     machine_type: "{{ (ocpinventory.json.nodes[0].pm_addr.split('.')[0]).split('-')[-1] }}"
 
+- name: Set Controlplane network gateway
+  set_fact:
+    controlplane_network_gateway: "{{ controlplane_network | ansible.utils.nthhost(1) }}"
+  when:
+    - controlplane_network_gateway is not defined
+    - not public_vlan
+
 - name: Public VLAN autoconfiguration
   when: public_vlan
   block:
@@ -84,7 +91,12 @@
     set_fact:
       controlplane_network: "{{ quads_assignment.json.vlan.ip_range }}"
       controlplane_network_prefix: "{{ quads_assignment.json.vlan.ip_range | ipaddr('prefix') }}"
+
+  - name: Public VLAN - Set Controlplane network gateway
+    set_fact:
       controlplane_network_gateway: "{{ quads_assignment.json.vlan.gateway }}"
+    when:
+      - controlplane_network_gateway is not defined
 
   - name: Public VLAN - Set cluster_name if was set as default
     set_fact:


### PR DESCRIPTION
When public vlan is true, user can't override the value for controlplane_network_gateway. In prow, we want to use the bastion host as the default gateway instead of vlan's default gateway for some workloads. This allows user to specify the default gateway for both the public and private networks. If the user not defines it, then jetlag defines it using the existing mechanism.