### PR TITLE
[PERFSCALE-3943] LACP bonding for perf/scale lab

### DIFF
--- a/ansible/roles/bastion-network/tasks/main.yml
+++ b/ansible/roles/bastion-network/tasks/main.yml
@@ -85,37 +85,103 @@
     enabled: true
     name: frr
 
-# Connections can end up named "Wired Connection X" and prevent the bastion controlplane interface from being configured
-- name: Get NetworkManager connection name for bastion control-plane interface
-  shell: |
-    nmcli d show {{ bastion_controlplane_interface }} | grep "GENERAL.CONNECTION:" | sed 's/GENERAL.CONNECTION://g' | xargs
-  register: cp_int_nmcli
+# Bond configuration for scale/performance labs
+- name: Setup bastion bond configuration
+  when: enable_bond | default(false) and not (public_vlan | default(false)) and (lab in rh_labs)
+  block:
+  - name: Set bastion bond interface names from hardware mapping
+    set_fact:
+      bastion_bond0_interface1: "{{ hw_nic_name[lab][machine_type][bond0_port1|int] }}"
+      bastion_bond0_interface2: "{{ hw_nic_name[lab][machine_type][bond0_port2|int] }}"
+    when:
+      - lab in hw_nic_name
+      - machine_type in hw_nic_name[lab]
+      - hw_nic_name[lab][machine_type] | length > (bond0_port2|int)
 
-- name: Display NetworkManager connection name for bastion control-plane interface
-  debug:
-    msg: "{{ cp_int_nmcli.stdout }}"
+  - name: Remove existing connections for bond slave interfaces
+    nmcli:
+      conn_name: "{{ item }}"
+      state: absent
+    loop:
+      - "{{ bastion_bond0_interface1 }}"
+      - "{{ bastion_bond0_interface2 }}"
+    ignore_errors: true
 
-- name: Disable original bastion control-plane connection to allow reconfiguration
-  nmcli:
-    type: ethernet
-    conn_name: "{{ cp_int_nmcli.stdout }}"
-    state: absent
-  when: cp_int_nmcli.stdout != bastion_controlplane_interface
+  - name: Create bond0 connection for bastion
+    nmcli:
+      type: bond
+      conn_name: bond0
+      ifname: bond0
+      ip4: "{{ bastion_controlplane_ip }}/{{ controlplane_network_prefix }}"
+      state: present
+      bond:
+        mode: 802.3ad
+        miimon: 100
+    when: bastion_controlplane_ip | ansible.utils.ipv4
 
-- name: Setup bastion on control-plane network (ipv4)
-  nmcli:
-    type: ethernet
-    conn_name: "{{ bastion_controlplane_interface }}"
-    ifname: "{{ bastion_controlplane_interface }}"
-    ip4: "{{ bastion_controlplane_ip }}/{{ controlplane_network_prefix }}"
-    state: present
-  when:  bastion_controlplane_ip | ansible.utils.ipv4
+  - name: Create bond0 connection for bastion (ipv6)
+    nmcli:
+      type: bond
+      conn_name: bond0
+      ifname: bond0
+      ip6: "{{ bastion_controlplane_ip }}/{{ controlplane_network_prefix }}"
+      state: present
+      bond:
+        mode: 802.3ad
+        miimon: 100
+    when: bastion_controlplane_ip | ansible.utils.ipv6
 
-- name: Setup bastion on control-plane network (ipv6)
-  nmcli:
-    type: ethernet
-    conn_name: "{{ bastion_controlplane_interface }}"
-    ifname: "{{ bastion_controlplane_interface }}"
-    ip6: "{{ bastion_controlplane_ip }}/{{ controlplane_network_prefix }}"
-    state: present
-  when:  bastion_controlplane_ip | ansible.utils.ipv6
+  - name: Add first interface as bond slave
+    nmcli:
+      type: bond-slave
+      conn_name: "bond0-slave-{{ bastion_bond0_interface1 }}"
+      ifname: "{{ bastion_bond0_interface1 }}"
+      master: bond0
+      state: present
+
+  - name: Add second interface as bond slave
+    nmcli:
+      type: bond-slave
+      conn_name: "bond0-slave-{{ bastion_bond0_interface2 }}"
+      ifname: "{{ bastion_bond0_interface2 }}"
+      master: bond0
+      state: present
+
+# Single interface configuration for non-bonded setups
+- name: Setup bastion single interface configuration
+  when: not (enable_bond | default(false) and not (public_vlan | default(false)) and (lab in rh_labs))
+  block:
+  # Connections can end up named "Wired Connection X" and prevent the bastion controlplane interface from being configured
+  - name: Get NetworkManager connection name for bastion control-plane interface
+    shell: |
+      nmcli d show {{ bastion_controlplane_interface }} | grep "GENERAL.CONNECTION:" | sed 's/GENERAL.CONNECTION://g' | xargs
+    register: cp_int_nmcli
+
+  - name: Display NetworkManager connection name for bastion control-plane interface
+    debug:
+      msg: "{{ cp_int_nmcli.stdout }}"
+
+  - name: Disable original bastion control-plane connection to allow reconfiguration
+    nmcli:
+      type: ethernet
+      conn_name: "{{ cp_int_nmcli.stdout }}"
+      state: absent
+    when: cp_int_nmcli.stdout != bastion_controlplane_interface
+
+  - name: Setup bastion on control-plane network (ipv4)
+    nmcli:
+      type: ethernet
+      conn_name: "{{ bastion_controlplane_interface }}"
+      ifname: "{{ bastion_controlplane_interface }}"
+      ip4: "{{ bastion_controlplane_ip }}/{{ controlplane_network_prefix }}"
+      state: present
+    when:  bastion_controlplane_ip | ansible.utils.ipv4
+
+  - name: Setup bastion on control-plane network (ipv6)
+    nmcli:
+      type: ethernet
+      conn_name: "{{ bastion_controlplane_interface }}"
+      ifname: "{{ bastion_controlplane_interface }}"
+      ip6: "{{ bastion_controlplane_ip }}/{{ controlplane_network_prefix }}"
+      state: present
+    when:  bastion_controlplane_ip | ansible.utils.ipv6

--- a/ansible/roles/bastion-network/tasks/main.yml
+++ b/ansible/roles/bastion-network/tasks/main.yml
@@ -87,7 +87,10 @@
 
 # Bond configuration for scale/performance labs
 - name: Setup bastion bond configuration
-  when: enable_bond | default(false) and not (public_vlan | default(false)) and (lab in rh_labs)
+  when:
+    - enable_bond | default(false)
+    - not (public_vlan | default(false))
+    - lab in rh_labs
   block:
   - name: Set bastion bond interface names from hardware mapping
     set_fact:
@@ -149,7 +152,10 @@
 
 # Single interface configuration for non-bonded setups
 - name: Setup bastion single interface configuration
-  when: not (enable_bond | default(false) and not (public_vlan | default(false)) and (lab in rh_labs))
+  when:
+    - not enable_bond | default(false)
+    - not public_vlan | default(false)
+    - lab in rh_labs
   block:
   # Connections can end up named "Wired Connection X" and prevent the bastion controlplane interface from being configured
   - name: Get NetworkManager connection name for bastion control-plane interface

--- a/ansible/roles/bastion-network/tasks/main.yml
+++ b/ansible/roles/bastion-network/tasks/main.yml
@@ -89,8 +89,6 @@
 - name: Setup bastion bond configuration
   when:
     - enable_bond | default(false)
-    - not (public_vlan | default(false))
-    - lab in rh_labs
   block:
   - name: Set bastion bond interface names from hardware mapping
     set_fact:
@@ -154,8 +152,6 @@
 - name: Setup bastion single interface configuration
   when:
     - not enable_bond | default(false)
-    - not public_vlan | default(false)
-    - lab in rh_labs
   block:
   # Connections can end up named "Wired Connection X" and prevent the bastion controlplane interface from being configured
   - name: Get NetworkManager connection name for bastion control-plane interface

--- a/ansible/roles/create-ai-cluster/tasks/static_network_config.yml
+++ b/ansible/roles/create-ai-cluster/tasks/static_network_config.yml
@@ -6,14 +6,19 @@
     item_network_config:
       network_yaml: "{{ lookup('template', 'rhlab_bond_nmstate.yml.j2') }}"
       mac_interface_map: "{{ lookup('template', 'rhlab_bond_mac_interface_map.json.j2')  }}"
-  when: (lab in rh_labs or lab == "byol") and enable_bond | default(false) and not (public_vlan | default(false))
+  when:
+    - lab in rh_labs or lab == "byol"
+    - enable_bond | default(false)
+    - not (public_vlan | default(false))
 
 - name: RH Lab and BYOL Populate static network configuration (single interface)
   set_fact:
     item_network_config:
       network_yaml: "{{ lookup('template', 'rhlab_nmstate.yml.j2') }}"
       mac_interface_map: "{{ lookup('template', 'rhlab_mac_interface_map.json.j2')  }}"
-  when: (lab in rh_labs or lab == "byol") and (not (enable_bond | default(false)) or (public_vlan | default(false)))
+  when:
+    - lab in rh_labs or lab == "byol"
+    - not (enable_bond | default(false) or (public_vlan | default(false))
 
 - name: Cloud Lab Populate static network configuration
   set_fact:

--- a/ansible/roles/create-ai-cluster/tasks/static_network_config.yml
+++ b/ansible/roles/create-ai-cluster/tasks/static_network_config.yml
@@ -1,12 +1,19 @@
 ---
 # Separate tasks to populate static network configuration
 
-- name: RH Lab and BYOL Populate static network configuration
+- name: RH Lab and BYOL Populate static network configuration (with bonding for private VLANs)
+  set_fact:
+    item_network_config:
+      network_yaml: "{{ lookup('template', 'rhlab_bond_nmstate.yml.j2') }}"
+      mac_interface_map: "{{ lookup('template', 'rhlab_bond_mac_interface_map.json.j2')  }}"
+  when: (lab in rh_labs or lab == "byol") and enable_bond | default(false) and not (public_vlan | default(false))
+
+- name: RH Lab and BYOL Populate static network configuration (single interface)
   set_fact:
     item_network_config:
       network_yaml: "{{ lookup('template', 'rhlab_nmstate.yml.j2') }}"
       mac_interface_map: "{{ lookup('template', 'rhlab_mac_interface_map.json.j2')  }}"
-  when: lab in rh_labs or lab == "byol"
+  when: (lab in rh_labs or lab == "byol") and (not (enable_bond | default(false)) or (public_vlan | default(false)))
 
 - name: Cloud Lab Populate static network configuration
   set_fact:

--- a/ansible/roles/create-ai-cluster/tasks/static_network_config.yml
+++ b/ansible/roles/create-ai-cluster/tasks/static_network_config.yml
@@ -1,7 +1,7 @@
 ---
 # Separate tasks to populate static network configuration
 
-- name: RH Lab and BYOL Populate static network configuration (with bonding for private VLANs)
+- name: RH Lab and BYOL Populate static network configuration (bonded interfaces)
   set_fact:
     item_network_config:
       network_yaml: "{{ lookup('template', 'rhlab_bond_nmstate.yml.j2') }}"
@@ -9,7 +9,6 @@
   when:
     - lab in rh_labs or lab == "byol"
     - enable_bond | default(false)
-    - not (public_vlan | default(false))
 
 - name: RH Lab and BYOL Populate static network configuration (single interface)
   set_fact:
@@ -18,7 +17,7 @@
       mac_interface_map: "{{ lookup('template', 'rhlab_mac_interface_map.json.j2')  }}"
   when:
     - lab in rh_labs or lab == "byol"
-    - not (enable_bond | default(false) or (public_vlan | default(false))
+    - not (enable_bond | default(false))
 
 - name: Cloud Lab Populate static network configuration
   set_fact:

--- a/ansible/roles/create-ai-cluster/templates/rhlab_bond_mac_interface_map.json.j2
+++ b/ansible/roles/create-ai-cluster/templates/rhlab_bond_mac_interface_map.json.j2
@@ -1,0 +1,19 @@
+[
+{% for interface in hostvars[item]['bond0_interfaces'] %}
+    {
+        "mac_address": "{{ (hostvars[item]['bond0_macs'].split(','))[loop.index0] }}",
+        "logical_nic_name": "{{ interface }}"
+  {% if loop.last %}
+    }
+  {% else %}
+    },
+  {% endif %}
+{% endfor %}
+{% if 'lab_mac' in hostvars[item] %}
+    ,
+    {
+        "mac_address": "{{ hostvars[item]['lab_mac'] }}",
+        "logical_nic_name": "{{ hostvars[item]['lab_interface'] }}"
+    }
+{% endif %}
+]

--- a/ansible/roles/create-ai-cluster/templates/rhlab_bond_nmstate.yml.j2
+++ b/ansible/roles/create-ai-cluster/templates/rhlab_bond_nmstate.yml.j2
@@ -10,10 +10,6 @@ interfaces:
     address:
     - ip: {{ hostvars[item]['ip'] }}
       prefix-length: {{ hostvars[item]['network_prefix'] }}
-{% if cluster_type == "sno" and public_vlan and groups['sno'] | default([]) | length == 1  %}
-    - ip: {{ controlplane_network_ingress }}
-      prefix-length: {{ hostvars[item]['network_prefix'] }}
-{% endif %}
     auto-dns: false
     enabled: true
   link-aggregation:
@@ -24,14 +20,12 @@ interfaces:
 {% for interface in hostvars[item]['bond0_interfaces'] %}
     - {{ interface }}
 {% endfor %}
-{% if 'lab_mac' in hostvars[item] %}
 - name: {{ hostvars[item]['lab_interface']}}
   type: ethernet
   state: up
   ipv4:
     auto-dns: false
     enabled: false
-{% endif %}
 dns-resolver:
   config:
     server:

--- a/ansible/roles/create-ai-cluster/templates/rhlab_bond_nmstate.yml.j2
+++ b/ansible/roles/create-ai-cluster/templates/rhlab_bond_nmstate.yml.j2
@@ -1,0 +1,50 @@
+interfaces:
+- name: bond0
+  type: bond
+  state: up
+{% if bastion_controlplane_ip | ansible.utils.ipv4 %}
+  ipv4:
+{% else %}
+  ipv6:
+{% endif %}
+    address:
+    - ip: {{ hostvars[item]['ip'] }}
+      prefix-length: {{ hostvars[item]['network_prefix'] }}
+{% if cluster_type == "sno" and public_vlan and groups['sno'] | default([]) | length == 1  %}
+    - ip: {{ controlplane_network_ingress }}
+      prefix-length: {{ hostvars[item]['network_prefix'] }}
+{% endif %}
+    auto-dns: false
+    enabled: true
+  link-aggregation:
+    mode: 802.3ad
+    options:
+      miimon: '100'
+    port:
+{% for interface in hostvars[item]['bond0_interfaces'] %}
+    - {{ interface }}
+{% endfor %}
+{% if 'lab_mac' in hostvars[item] %}
+- name: {{ hostvars[item]['lab_interface']}}
+  type: ethernet
+  state: up
+  ipv4:
+    auto-dns: false
+    enabled: false
+{% endif %}
+dns-resolver:
+  config:
+    server:
+    - {{ hostvars[item]['dns1'] }}
+{% if 'dns2' in hostvars[item] %}
+    - {{ hostvars[item]['dns2'] }}
+{% endif %}
+routes:
+  config:
+{% if bastion_controlplane_ip | ansible.utils.ipv4 %}
+  - destination: 0.0.0.0/0
+{% else %}
+  - destination: ::/0
+{% endif %}
+    next-hop-address: {{ hostvars[item]['gateway'] }}
+    next-hop-interface: bond0

--- a/ansible/roles/create-inventory/defaults/main/networks.yml
+++ b/ansible/roles/create-inventory/defaults/main/networks.yml
@@ -27,3 +27,17 @@ vip_dhcp_allocation: false
 # This index var corresponds to the index in hw_nic_name in labs.yml for which network to use as the impaired nic for
 # the hypervisor impairments playbook
 hypervisor_nic_interface_idx: 1
+
+# Bonding
+
+# Index of the ports for bond0. Bond0 is the intended private network bond name.
+# Typically the first two non-lab interfaces are bonded to bond0 (Private network)
+# Default behavior uses interfaces at indices 1 and 2 from hw_nic_name mapping
+# bond0_port1: 1
+# bond0_port2: 2
+
+# The assisted-installer doesn't need exact nic names for the private bond. These names are used
+# as representatives for the actual nic names, the actual nics are determined by the mac addresses
+# private_bond_interfaces:
+# - eth0
+# - eth1

--- a/ansible/roles/create-inventory/defaults/main/networks.yml
+++ b/ansible/roles/create-inventory/defaults/main/networks.yml
@@ -33,11 +33,11 @@ hypervisor_nic_interface_idx: 1
 # Index of the ports for bond0. Bond0 is the intended private network bond name.
 # Typically the first two non-lab interfaces are bonded to bond0 (Private network)
 # Default behavior uses interfaces at indices 1 and 2 from hw_nic_name mapping
-# bond0_port1: 1
-# bond0_port2: 2
+bond0_port1: 1
+bond0_port2: 2
 
 # The assisted-installer doesn't need exact nic names for the private bond. These names are used
 # as representatives for the actual nic names, the actual nics are determined by the mac addresses
-# private_bond_interfaces:
-# - eth0
-# - eth1
+private_bond_interfaces:
+- eth0
+- eth1

--- a/ansible/roles/create-inventory/tasks/main.yml
+++ b/ansible/roles/create-inventory/tasks/main.yml
@@ -202,20 +202,14 @@
     block:
     - name: MNO - Set controlplane0 bond mac addresses
       set_fact:
-        controlplane0_bond0_mac1: "{{ (controlplane0_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface1) | first).mac }}"
-        controlplane0_bond0_mac2: "{{ (controlplane0_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface2) | first).mac }}"
         controlplane0_bond0_macs: "{{ (controlplane0_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface1) | first).mac }},{{ (controlplane0_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface2) | first).mac }}"
 
     - name: MNO - Set controlplane1 bond mac addresses
       set_fact:
-        controlplane1_bond0_mac1: "{{ (controlplane1_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface1) | first).mac }}"
-        controlplane1_bond0_mac2: "{{ (controlplane1_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface2) | first).mac }}"
         controlplane1_bond0_macs: "{{ (controlplane1_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface1) | first).mac }},{{ (controlplane1_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface2) | first).mac }}"
 
     - name: MNO - Set controlplane2 bond mac addresses
       set_fact:
-        controlplane2_bond0_mac1: "{{ (controlplane2_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface1) | first).mac }}"
-        controlplane2_bond0_mac2: "{{ (controlplane2_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface2) | first).mac }}"
         controlplane2_bond0_macs: "{{ (controlplane2_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface1) | first).mac }},{{ (controlplane2_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface2) | first).mac }}"
 
   - name: MNO - Set max number of nodes

--- a/ansible/roles/create-inventory/tasks/main.yml
+++ b/ansible/roles/create-inventory/tasks/main.yml
@@ -116,6 +116,27 @@
     - lab in hw_nic_name
     - machine_type in hw_nic_name[lab]
 
+- name: Bond configuration for scale/performance labs
+  when: (lab in rh_labs) and enable_bond | default(false) and not (public_vlan | default(false))
+  block:
+  - name: Set default bond port indices (only when not explicitly set)
+    set_fact:
+      bond0_port1: "{{ bond0_port1 | default(1) }}"
+      bond0_port2: "{{ bond0_port2 | default(2) }}"
+
+  - name: Set default private bond interfaces (only when not explicitly set)
+    set_fact:
+      private_bond_interfaces: "{{ private_bond_interfaces | default(['eth0', 'eth1']) }}"
+
+  - name: Auto-configure bond interface names from hardware mapping
+    set_fact:
+      bond0_interface1: "{{ hw_nic_name[lab][machine_type][bond0_port1|int] }}"
+      bond0_interface2: "{{ hw_nic_name[lab][machine_type][bond0_port2|int] }}"
+    when:
+      - lab in hw_nic_name
+      - machine_type in hw_nic_name[lab]
+      - hw_nic_name[lab][machine_type] | length > (bond0_port2|int)
+
 - name: Multi node cluster type tasks
   when: cluster_type == "mno"
   block:
@@ -176,6 +197,27 @@
     with_items: "{{ controlplane2_foreman_data.json.interfaces }}"
     when: item.primary|bool
 
+  - name: MNO - Set bond MAC addresses for controlplane nodes (when bonding is enabled)
+    when: enable_bond | default(false) and not (public_vlan | default(false))
+    block:
+    - name: MNO - Set controlplane0 bond mac addresses
+      set_fact:
+        controlplane0_bond0_mac1: "{{ (controlplane0_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface1) | first).mac }}"
+        controlplane0_bond0_mac2: "{{ (controlplane0_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface2) | first).mac }}"
+        controlplane0_bond0_macs: "{{ (controlplane0_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface1) | first).mac }},{{ (controlplane0_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface2) | first).mac }}"
+
+    - name: MNO - Set controlplane1 bond mac addresses
+      set_fact:
+        controlplane1_bond0_mac1: "{{ (controlplane1_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface1) | first).mac }}"
+        controlplane1_bond0_mac2: "{{ (controlplane1_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface2) | first).mac }}"
+        controlplane1_bond0_macs: "{{ (controlplane1_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface1) | first).mac }},{{ (controlplane1_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface2) | first).mac }}"
+
+    - name: MNO - Set controlplane2 bond mac addresses
+      set_fact:
+        controlplane2_bond0_mac1: "{{ (controlplane2_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface1) | first).mac }}"
+        controlplane2_bond0_mac2: "{{ (controlplane2_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface2) | first).mac }}"
+        controlplane2_bond0_macs: "{{ (controlplane2_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface1) | first).mac }},{{ (controlplane2_foreman_data.json.interfaces | selectattr('name', 'eq', bond0_interface2) | first).mac }}"
+
   - name: MNO - Set max number of nodes
     set_fact:
       max_nodes: "{{ ocpinventory.json.nodes|length }}"
@@ -206,6 +248,22 @@
   when: cluster_type == "mno"
   register: mno_foreman_data
 
+- name: MNO - Add bond MAC addresses to worker nodes (when bonding is enabled)
+  when: cluster_type == "mno" and enable_bond | default(false) and not (public_vlan | default(false))
+  set_fact:
+    ocpinventory_worker_nodes: >-
+      {{
+        ocpinventory_worker_nodes | zip(mno_foreman_data.results) |
+        map('combine') |
+        map('combine', {
+          'bond0_macs': ((item.1.json.interfaces | selectattr('name', 'eq', bond0_interface1) | first).mac + ',' + (item.1.json.interfaces | selectattr('name', 'eq', bond0_interface2) | first).mac)
+        }) |
+        list
+      }}
+  loop: "{{ ocpinventory_worker_nodes | zip(mno_foreman_data.results) | list }}"
+  loop_control:
+    loop_var: item
+
 - name: Single Node OpenShift cluster type tasks
   when: cluster_type == "sno"
   block:
@@ -223,6 +281,22 @@
       validate_certs: false
     register: sno_foreman_data
     loop: "{{ ocpinventory_sno_nodes }}"
+
+  - name: SNO - Add bond MAC addresses to SNO nodes (when bonding is enabled)
+    when: enable_bond | default(false) and not (public_vlan | default(false))
+    set_fact:
+      ocpinventory_sno_nodes: >-
+        {{
+          ocpinventory_sno_nodes | zip(sno_foreman_data.results) |
+          map('combine') |
+          map('combine', {
+            'bond0_macs': ((item.1.json.interfaces | selectattr('name', 'eq', bond0_interface1) | first).mac + ',' + (item.1.json.interfaces | selectattr('name', 'eq', bond0_interface2) | first).mac)
+          }) |
+          list
+        }}
+    loop: "{{ ocpinventory_sno_nodes | zip(sno_foreman_data.results) | list }}"
+    loop_control:
+      loop_var: item
 
   - name: set json query fact
     set_fact:

--- a/ansible/roles/create-inventory/tasks/main.yml
+++ b/ansible/roles/create-inventory/tasks/main.yml
@@ -119,14 +119,6 @@
 - name: Bond configuration for scale/performance labs
   when: (lab in rh_labs) and enable_bond | default(false) and not (public_vlan | default(false))
   block:
-  - name: Set default bond port indices (only when not explicitly set)
-    set_fact:
-      bond0_port1: "{{ bond0_port1 | default(1) }}"
-      bond0_port2: "{{ bond0_port2 | default(2) }}"
-
-  - name: Set default private bond interfaces (only when not explicitly set)
-    set_fact:
-      private_bond_interfaces: "{{ private_bond_interfaces | default(['eth0', 'eth1']) }}"
 
   - name: Auto-configure bond interface names from hardware mapping
     set_fact:

--- a/ansible/roles/create-inventory/templates/inventory-mno.j2
+++ b/ansible/roles/create-inventory/templates/inventory-mno.j2
@@ -22,9 +22,15 @@ bmc_user={{ bmc_user }}
 bmc_password={{ bmc_password }}
 
 [controlplane]
+{% if enable_bond | default(false) and not (public_vlan | default(false)) %}
+{{ controlplane0.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane0 }} bond0_macs={{ controlplane0_bond0_macs }} lab_mac={{ controlplane0_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(5) }} vendor={{ controlplane0_vendor }} install_disk={{ control_plane_install_disk }}
+{{ controlplane1.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane1 }} bond0_macs={{ controlplane1_bond0_macs }} lab_mac={{ controlplane1_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(6) }} vendor={{ controlplane1_vendor }} install_disk={{ control_plane_install_disk }}
+{{ controlplane2.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane2 }} bond0_macs={{ controlplane2_bond0_macs }} lab_mac={{ controlplane2_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(7) }} vendor={{ controlplane2_vendor }} install_disk={{ control_plane_install_disk }}
+{% else %}
 {{ controlplane0.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane0 }} mac_address={{ controlplane0_mac_address }} lab_mac={{ controlplane0_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(5) }} vendor={{ controlplane0_vendor }} install_disk={{ control_plane_install_disk }}
 {{ controlplane1.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane1 }} mac_address={{ controlplane1_mac_address }} lab_mac={{ controlplane1_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(6) }} vendor={{ controlplane1_vendor }} install_disk={{ control_plane_install_disk }}
 {{ controlplane2.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane2 }} mac_address={{ controlplane2_mac_address }} lab_mac={{ controlplane2_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(7) }} vendor={{ controlplane2_vendor }} install_disk={{ control_plane_install_disk }}
+{% endif %}
 
 [controlplane:vars]
 role=master
@@ -32,7 +38,11 @@ boot_iso=discovery.iso
 bmc_user={{ bmc_user }}
 bmc_password={{ bmc_password }}
 lab_interface={{ controlplane_lab_interface }}
+{% if enable_bond | default(false) and not (public_vlan | default(false)) %}
+bond0_interfaces={{ private_bond_interfaces }}
+{% else %}
 network_interface={{ controlplane_network_interface }}
+{% endif %}
 network_prefix={{ controlplane_network_prefix }}
 gateway={{ controlplane_network_gateway }}
 {% if controlplane_bastion_as_dns %}
@@ -44,7 +54,11 @@ dns2={{ labs[lab]['dns'][1] | default('') }}
 
 [worker]
 {% for worker in ocpinventory_worker_nodes %}
+{% if enable_bond | default(false) and not (public_vlan | default(false)) %}
+{{ worker.pm_addr.split('.')[0] | replace('mgmt-','') }} bmc_address={{ worker.pm_addr }} bond0_macs={{ worker.bond0_macs }} lab_mac={{ ( (mno_foreman_data.results| selectattr('json.name', 'eq', worker.pm_addr | replace('mgmt-',''))|first).json.interfaces | selectattr('primary', 'eq', True)|first).mac }} ip={{ controlplane_network | ansible.utils.nthhost(loop.index + mno_worker_node_offset) }} vendor={{ hw_vendor[(worker.pm_addr.split('.')[0]).split('-')[-1]] }} install_disk={{ worker_install_disk }}
+{% else %}
 {{ worker.pm_addr.split('.')[0] | replace('mgmt-','') }} bmc_address={{ worker.pm_addr }} mac_address={{ worker.mac[controlplane_network_interface_idx|int] }} lab_mac={{ ( (mno_foreman_data.results| selectattr('json.name', 'eq', worker.pm_addr | replace('mgmt-',''))|first).json.interfaces | selectattr('primary', 'eq', True)|first).mac }} ip={{ controlplane_network | ansible.utils.nthhost(loop.index + mno_worker_node_offset) }} vendor={{ hw_vendor[(worker.pm_addr.split('.')[0]).split('-')[-1]] }} install_disk={{ worker_install_disk }}
+{% endif %}
 {% endfor %}
 {% if hybrid_worker_count > 0 %}
 {%   set ctr = namespace(vm=1) %}
@@ -73,7 +87,11 @@ boot_iso=discovery.iso
 bmc_user={{ bmc_user }}
 bmc_password={{ bmc_password }}
 lab_interface={{ controlplane_lab_interface }}
+{% if enable_bond | default(false) and not (public_vlan | default(false)) %}
+bond0_interfaces={{ private_bond_interfaces }}
+{% else %}
 network_interface={{ controlplane_network_interface }}
+{% endif %}
 network_prefix={{ controlplane_network_prefix }}
 gateway={{ controlplane_network_gateway }}
 {% if controlplane_bastion_as_dns %}

--- a/ansible/roles/create-inventory/templates/inventory-mno.j2
+++ b/ansible/roles/create-inventory/templates/inventory-mno.j2
@@ -22,7 +22,7 @@ bmc_user={{ bmc_user }}
 bmc_password={{ bmc_password }}
 
 [controlplane]
-{% if enable_bond | default(false) and not (public_vlan | default(false)) %}
+{% if enable_bond | default(false) %}
 {{ controlplane0.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane0 }} bond0_macs={{ controlplane0_bond0_macs }} lab_mac={{ controlplane0_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(5) }} vendor={{ controlplane0_vendor }} install_disk={{ control_plane_install_disk }}
 {{ controlplane1.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane1 }} bond0_macs={{ controlplane1_bond0_macs }} lab_mac={{ controlplane1_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(6) }} vendor={{ controlplane1_vendor }} install_disk={{ control_plane_install_disk }}
 {{ controlplane2.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane2 }} bond0_macs={{ controlplane2_bond0_macs }} lab_mac={{ controlplane2_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(7) }} vendor={{ controlplane2_vendor }} install_disk={{ control_plane_install_disk }}
@@ -38,7 +38,7 @@ boot_iso=discovery.iso
 bmc_user={{ bmc_user }}
 bmc_password={{ bmc_password }}
 lab_interface={{ controlplane_lab_interface }}
-{% if enable_bond | default(false) and not (public_vlan | default(false)) %}
+{% if enable_bond | default(false) %}
 bond0_interfaces={{ private_bond_interfaces }}
 {% else %}
 network_interface={{ controlplane_network_interface }}
@@ -54,7 +54,7 @@ dns2={{ labs[lab]['dns'][1] | default('') }}
 
 [worker]
 {% for worker in ocpinventory_worker_nodes %}
-{% if enable_bond | default(false) and not (public_vlan | default(false)) %}
+{% if enable_bond | default(false) %}
 {{ worker.pm_addr.split('.')[0] | replace('mgmt-','') }} bmc_address={{ worker.pm_addr }} bond0_macs={{ worker.bond0_macs }} lab_mac={{ ( (mno_foreman_data.results| selectattr('json.name', 'eq', worker.pm_addr | replace('mgmt-',''))|first).json.interfaces | selectattr('primary', 'eq', True)|first).mac }} ip={{ controlplane_network | ansible.utils.nthhost(loop.index + mno_worker_node_offset) }} vendor={{ hw_vendor[(worker.pm_addr.split('.')[0]).split('-')[-1]] }} install_disk={{ worker_install_disk }}
 {% else %}
 {{ worker.pm_addr.split('.')[0] | replace('mgmt-','') }} bmc_address={{ worker.pm_addr }} mac_address={{ worker.mac[controlplane_network_interface_idx|int] }} lab_mac={{ ( (mno_foreman_data.results| selectattr('json.name', 'eq', worker.pm_addr | replace('mgmt-',''))|first).json.interfaces | selectattr('primary', 'eq', True)|first).mac }} ip={{ controlplane_network | ansible.utils.nthhost(loop.index + mno_worker_node_offset) }} vendor={{ hw_vendor[(worker.pm_addr.split('.')[0]).split('-')[-1]] }} install_disk={{ worker_install_disk }}
@@ -87,7 +87,7 @@ boot_iso=discovery.iso
 bmc_user={{ bmc_user }}
 bmc_password={{ bmc_password }}
 lab_interface={{ controlplane_lab_interface }}
-{% if enable_bond | default(false) and not (public_vlan | default(false)) %}
+{% if enable_bond | default(false) %}
 bond0_interfaces={{ private_bond_interfaces }}
 {% else %}
 network_interface={{ controlplane_network_interface }}

--- a/ansible/roles/create-inventory/templates/inventory-sno.j2
+++ b/ansible/roles/create-inventory/templates/inventory-sno.j2
@@ -55,7 +55,11 @@ bmc_password={{ bmc_password }}
 {%   else %}
 {%     set ip=controlplane_network | ansible.utils.nthhost(loop.index0 + sno_controlplane_ip_offset) %}
 {%   endif %}
-{%   if not loop.first %}# {% endif %}{{ sno_short_hostname }} bmc_address={{ sno.pm_addr }} mac_address={{ sno.mac[controlplane_network_interface_idx|int] }} lab_mac={{ lab_mac }} ip={{ ip }} vendor={{ hw_vendor[(sno.pm_addr.split('.')[0]).split('-')[-1]] }} install_disk={{ sno_install_disk }} boot_iso={{ sno_short_hostname }}.iso
+{%   if enable_bond | default(false) and not (public_vlan | default(false)) and not sno_use_lab_dhcp %}
+{%     if not loop.first %}# {% endif %}{{ sno_short_hostname }} bmc_address={{ sno.pm_addr }} bond0_macs={{ sno.bond0_macs }} lab_mac={{ lab_mac }} ip={{ ip }} vendor={{ hw_vendor[(sno.pm_addr.split('.')[0]).split('-')[-1]] }} install_disk={{ sno_install_disk }} boot_iso={{ sno_short_hostname }}.iso
+{%   else %}
+{%     if not loop.first %}# {% endif %}{{ sno_short_hostname }} bmc_address={{ sno.pm_addr }} mac_address={{ sno.mac[controlplane_network_interface_idx|int] }} lab_mac={{ lab_mac }} ip={{ ip }} vendor={{ hw_vendor[(sno.pm_addr.split('.')[0]).split('-')[-1]] }} install_disk={{ sno_install_disk }} boot_iso={{ sno_short_hostname }}.iso
+{%   endif %}
 {% endfor %}
 
 [sno:vars]
@@ -76,7 +80,11 @@ bmc_password={{ bmc_password }}
 {%   endif %}
 {% else %}
 lab_interface={{ controlplane_lab_interface }}
+{% if enable_bond | default(false) and not (public_vlan | default(false)) %}
+bond0_interfaces={{ private_bond_interfaces }}
+{% else %}
 network_interface={{ controlplane_network_interface }}
+{% endif %}
 network_prefix={{ controlplane_network_prefix }}
 gateway={{ controlplane_network_gateway }}
 {%   if controlplane_bastion_as_dns %}

--- a/ansible/roles/create-inventory/templates/inventory-sno.j2
+++ b/ansible/roles/create-inventory/templates/inventory-sno.j2
@@ -55,7 +55,7 @@ bmc_password={{ bmc_password }}
 {%   else %}
 {%     set ip=controlplane_network | ansible.utils.nthhost(loop.index0 + sno_controlplane_ip_offset) %}
 {%   endif %}
-{%   if enable_bond | default(false) and not (public_vlan | default(false)) and not sno_use_lab_dhcp %}
+{%   if enable_bond | default(false) %}
 {%     if not loop.first %}# {% endif %}{{ sno_short_hostname }} bmc_address={{ sno.pm_addr }} bond0_macs={{ sno.bond0_macs }} lab_mac={{ lab_mac }} ip={{ ip }} vendor={{ hw_vendor[(sno.pm_addr.split('.')[0]).split('-')[-1]] }} install_disk={{ sno_install_disk }} boot_iso={{ sno_short_hostname }}.iso
 {%   else %}
 {%     if not loop.first %}# {% endif %}{{ sno_short_hostname }} bmc_address={{ sno.pm_addr }} mac_address={{ sno.mac[controlplane_network_interface_idx|int] }} lab_mac={{ lab_mac }} ip={{ ip }} vendor={{ hw_vendor[(sno.pm_addr.split('.')[0]).split('-')[-1]] }} install_disk={{ sno_install_disk }} boot_iso={{ sno_short_hostname }}.iso

--- a/ansible/roles/validate-vars/tasks/main.yml
+++ b/ansible/roles/validate-vars/tasks/main.yml
@@ -45,6 +45,13 @@
   - public_vlan | default(false)
   - enable_bond | default(false)
 
+- name: Validate enable_bond and sno_use_lab_dhcp
+  fail:
+    msg: "enable_bond and sno_use_lab_dhcp can not both be true, only enable one or the other"
+  when:
+  - enable_bond | default(false)
+  - sno_use_lab_dhcp | default(false)
+
 - name: Check for RHEL/Centos (Bastion Validation)
   fail:
     msg: "Expecting RHEL or Centos for a Bastion OS"

--- a/ansible/roles/validate-vars/tasks/main.yml
+++ b/ansible/roles/validate-vars/tasks/main.yml
@@ -38,6 +38,13 @@
   - public_vlan | default(false)
   - sno_use_lab_dhcp | default(false)
 
+- name: Validate public_vlan and enable_bond
+  fail:
+    msg: "public_vlan and enable_bond can not both be true, only enable one or the other"
+  when:
+  - public_vlan | default(false)
+  - enable_bond | default(false)
+
 - name: Check for RHEL/Centos (Bastion Validation)
   fail:
     msg: "Expecting RHEL or Centos for a Bastion OS"

--- a/ansible/vars/all.sample.yml
+++ b/ansible/vars/all.sample.yml
@@ -79,7 +79,7 @@ use_bastion_registry: false
 # Bond configuration for private network (optional for scale/performance labs)
 # Enable bonding for bastion, controlplane, and worker nodes using 802.3ad mode
 # When enabled, uses the first two network interfaces by default (indices 1 & 2)
-# Only works with private VLANs (public_vlan: false)
+# Only works with private VLANs (public_vlan: false) and homogeneous hardware 
 # enable_bond: false
 
 # Index of the ports for bond0. Bond0 is the intended private network bond name.

--- a/ansible/vars/all.sample.yml
+++ b/ansible/vars/all.sample.yml
@@ -79,20 +79,8 @@ use_bastion_registry: false
 # Bond configuration for private network (optional for scale/performance labs)
 # Enable bonding for bastion, controlplane, and worker nodes using 802.3ad mode
 # When enabled, uses the first two network interfaces by default (indices 1 & 2)
-# Only works with private VLANs (public_vlan: false) and homogeneous hardware 
-# enable_bond: false
-
-# Index of the ports for bond0. Bond0 is the intended private network bond name.
-# Typically the first two non-lab interfaces are bonded to bond0 (Private network)
-# Default behavior uses interfaces at indices 1 and 2 from hw_nic_name mapping
-# bond0_port1: 1
-# bond0_port2: 2
-
-# The assisted-installer doesn't need exact nic names for our private bond. These names are used
-# as representatives for the actual nic names, the actual nics are determined by the mac addresses
-# private_bond_interfaces:
-# - eth0
-# - eth1
+# Only works with private VLANs (public_vlan: false) and homogeneous hardware
+enable_bond: false
 
 ################################################################################
 # Extra vars

--- a/ansible/vars/all.sample.yml
+++ b/ansible/vars/all.sample.yml
@@ -76,6 +76,24 @@ use_bastion_registry: false
 # To override auto-configuration, uncomment and set value:
 # controlplane_lab_interface: eno1np0
 
+# Bond configuration for private network (optional for scale/performance labs)
+# Enable bonding for bastion, controlplane, and worker nodes using 802.3ad mode
+# When enabled, uses the first two network interfaces by default (indices 1 & 2)
+# Only works with private VLANs (public_vlan: false)
+# enable_bond: false
+
+# Index of the ports for bond0. Bond0 is the intended private network bond name.
+# Typically the first two non-lab interfaces are bonded to bond0 (Private network)
+# Default behavior uses interfaces at indices 1 and 2 from hw_nic_name mapping
+# bond0_port1: 1
+# bond0_port2: 2
+
+# The assisted-installer doesn't need exact nic names for our private bond. These names are used
+# as representatives for the actual nic names, the actual nics are determined by the mac addresses
+# private_bond_interfaces:
+# - eth0
+# - eth1
+
 ################################################################################
 # Extra vars
 ################################################################################

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -222,7 +222,7 @@ In case you are bringing your own lab, set `controlplane_network_interface` to t
 ### Bonding in the scale/perf labs
 To support some particular use cases jetlag implements the option for LACP bonding through the var `enable_bond`.
 When enabled, uses the first two network interfaces by default (indices 1 & 2).
-Only works with private VLANs (`public_vlan: false`) and homogeneous hardware.
+Only works with private networks (`public_vlan: false`) and homogeneous hardware.
 At the moment QUADS does not expose any APIs for this kind of networking setup in the labs, so unless you have discussed your particular use case with the DevOps team and the network setup of your cloud allocation is ready to accommodate this config, please disconsider this option.
 
 ## Configuring NVMe install and etcd disks

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -2,15 +2,22 @@
 
 _**Table of Contents**_
 <!-- TOC -->
-- [Network interface to vars table](#network-interface-to-vars-table)
-- [Install disk by-path vars](#install-disk-by-path-vars)
-- [Updating the OCP version](#updating-the-ocp-version)
-- [Override lab ocpinventory json file](#override-lab-ocpinventory-json-file)
-- [Using other network interfaces](#using-other-network-interfaces)
-- [Configuring NVMe install and etcd disks](#configuring-nvme-install-and-etcd-disks)
-- [DU Profile for SNOs](#du-profile-for-snos)
-- [Post Deployment Tasks](#post-deployment-tasks)
-- [Add/delete contents to the bastion registry](#adddelete-contents-to-the-bastion-registry)
+- [Jetlag Tips and additional Vars](#jetlag-tips-and-additional-vars)
+  - [Network interface to vars table](#network-interface-to-vars-table)
+  - [Install disk by-path vars](#install-disk-by-path-vars)
+  - [Updating the OCP version](#updating-the-ocp-version)
+  - [Override lab ocpinventory json file](#override-lab-ocpinventory-json-file)
+  - [Using other network interfaces](#using-other-network-interfaces)
+    - [Alternative method](#alternative-method)
+    - [Bonding in the scale/perf labs](#bonding-in-the-scaleperf-labs)
+  - [Configuring NVMe install and etcd disks](#configuring-nvme-install-and-etcd-disks)
+  - [DU Profile for SNOs](#du-profile-for-snos)
+  - [Post Deployment Tasks](#post-deployment-tasks)
+    - [SNO DU Profile](#sno-du-profile)
+      - [Performance Profile](#performance-profile)
+      - [Tuned Performance Patch](#tuned-performance-patch)
+      - [Installing Performance Addon Operator on OCP 4.9 or OCP 4.10](#installing-performance-addon-operator-on-ocp-49-or-ocp-410)
+  - [Add/delete contents to the bastion registry](#adddelete-contents-to-the-bastion-registry)
 <!-- /TOC -->
 
 
@@ -21,27 +28,27 @@ Note that if these variables are not explicitely set then Jetlag auto configures
 
 **Scale Lab**
 
-| Hardware           | bastion_lab_interface | bastion_controlplane_interface | controlplane_lab_interface |
-| - | - | - | - |
-| Dell r660          | eno12399np0           | ens1f0                         | eno12399np0                |
-| Dell r650          | eno12399np0           | ens1f0                         | eno12399np0                |
-| Dell r640          | eno1np0               | ens1f0                         | eno1np0                    |
-| Dell r630          | enp129s0f0            | eno1                           | enp129s0f0                 |
-| Dell fc640         | eno1                  | eno2                           | eno1                       |
-| Supermicro 1029p   | eno1                  | ens2f0                         | eno1                       |
-| Supermicro 5039ms  | enp2s0f0              | enp1s0f0                       | enp2s0f0                   |
+| Hardware          | bastion_lab_interface | bastion_controlplane_interface | controlplane_lab_interface |
+| ----------------- | --------------------- | ------------------------------ | -------------------------- |
+| Dell r660         | eno12399np0           | ens1f0                         | eno12399np0                |
+| Dell r650         | eno12399np0           | ens1f0                         | eno12399np0                |
+| Dell r640         | eno1np0               | ens1f0                         | eno1np0                    |
+| Dell r630         | enp129s0f0            | eno1                           | enp129s0f0                 |
+| Dell fc640        | eno1                  | eno2                           | eno1                       |
+| Supermicro 1029p  | eno1                  | ens2f0                         | eno1                       |
+| Supermicro 5039ms | enp2s0f0              | enp1s0f0                       | enp2s0f0                   |
 
 Scale lab network table is available on the scale lab wiki.
 
 **Performance Lab**
 
-| Hardware           | bastion_lab_interface | bastion_controlplane_interface | controlplane_lab_interface |
-| - | - | - | - |
-| Dell r740xd        | eno3                  | eno1                           | eno3                       |
-| Dell r7425         | eno3                  | eno1                           | eno3                       |
-| Dell r7525         | eno1                  | enp33np0                       | eno1                       |
-| Dell r750          | eno8303               | ens3f0                         | eno8303                    |
-| Supermicro 6029p   | eno1                  | enp95s0f0                      | eno1                       |
+| Hardware         | bastion_lab_interface | bastion_controlplane_interface | controlplane_lab_interface |
+| ---------------- | --------------------- | ------------------------------ | -------------------------- |
+| Dell r740xd      | eno3                  | eno1                           | eno3                       |
+| Dell r7425       | eno3                  | eno1                           | eno3                       |
+| Dell r7525       | eno1                  | enp33np0                       | eno1                       |
+| Dell r750        | eno8303               | ens3f0                         | eno8303                    |
+| Supermicro 6029p | eno1                  | enp95s0f0                      | eno1                       |
 
 Performance lab network table is available on the performance lab wiki.
 
@@ -72,25 +79,25 @@ edit the inventory file to set appropriate install paths for each machine.
 
 **Scale Lab**
 
-| Hardware  | Install disk path |
-| - | - |
-| Dell r750 | /dev/disk/by-path/pci-0000:05:00.0-ata-1.0 |
+| Hardware  | Install disk path                               |
+| --------- | ----------------------------------------------- |
+| Dell r750 | /dev/disk/by-path/pci-0000:05:00.0-ata-1.0      |
 | Dell r660 | /dev/disk/by-path/pci-0000:4a:00.0-scsi-0:0:1:0 |
 | Dell r650 | /dev/disk/by-path/pci-0000:67:00.0-scsi-0:2:0:0 |
 | Dell r640 | /dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:0:0 |
 
 **Performance Lab**
 
-| Hardware | Install disk path |
-| - | - |
+| Hardware                                             | Install disk path                               |
+| ---------------------------------------------------- | ----------------------------------------------- |
 | Dell r740xd (SL-N, SL-G, SL-U, CL-N, CL-U-2, CL-G-2) | /dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:0:0 |
-| Dell r740xd (CL-U-1, CL-G-1) | /dev/disk/by-path/pci-0000:86:00.0-scsi-0:2:0:0 |
-| Dell r750 | /dev/disk/by-path/pci-0000:05:00.0-ata-1 |
-| Dell r7425 | /dev/disk/by-path/pci-0000:e2:00.0-scsi-0:2:0:0 |
-| Dell r7525 | /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0 |
-| SuperMicro 6029p | /dev/disk/by-path/pci-0000:00:11.5-ata-5 |
-| Dell xe8640  | /dev/disk/by-path/pci-0000:01:00.0-nvme-1 |
-| Dell xe9680  | /dev/disk/by-path/pci-0000:01:00.0-nvme-1 |
+| Dell r740xd (CL-U-1, CL-G-1)                         | /dev/disk/by-path/pci-0000:86:00.0-scsi-0:2:0:0 |
+| Dell r750                                            | /dev/disk/by-path/pci-0000:05:00.0-ata-1        |
+| Dell r7425                                           | /dev/disk/by-path/pci-0000:e2:00.0-scsi-0:2:0:0 |
+| Dell r7525                                           | /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0 |
+| SuperMicro 6029p                                     | /dev/disk/by-path/pci-0000:00:11.5-ata-5        |
+| Dell xe8640                                          | /dev/disk/by-path/pci-0000:01:00.0-nvme-1       |
+| Dell xe9680                                          | /dev/disk/by-path/pci-0000:01:00.0-nvme-1       |
 
 To find your machine's by-path reference:
 
@@ -190,8 +197,8 @@ In this example using nic `ens2f0` in a cluster of r650 nodes is shown.
 1. Select which NIC you want to use instead of the default, in this example, `ens2f0`.
 2. Look for your server model number in your lab's network table/chart then select the network you want configured as your primary network using the following mapping:
 
-| Network | YAML variable |
-| ------- | ------------- |
+| Network   | YAML variable                           |
+| --------- | --------------------------------------- |
 | Network 1 | `controlplane_network_interface_idx: 0` |
 | Network 2 | `controlplane_network_interface_idx: 1` |
 | Network 3 | `controlplane_network_interface_idx: 2` |
@@ -211,6 +218,12 @@ controlplane_network_interface_idx: 2
 
 ### Alternative method
 In case you are bringing your own lab, set `controlplane_network_interface` to the desired name, eg. `controlplane_network_interface: ens2f0`.
+
+### Bonding in the scale/perf labs
+To support some particular use cases jetlag implements the option for LACP bonding through the var `enable_bond`.
+When enabled, uses the first two network interfaces by default (indices 1 & 2).
+Only works with private VLANs (`public_vlan: false`) and homogeneous hardware.
+At the moment QUADS does not expose any APIs for this kind of networking setup in the labs, so unless you have discussed your particular use case with the DevOps team and the network setup of your cloud allocation is ready to accommodate this config, please disconsider this option.
 
 ## Configuring NVMe install and etcd disks
 


### PR DESCRIPTION
- Changes the bastion networking configuration as well
- Uses LACP mode (switch configuration required)
- Bonds first two interfaces (ports 0 & 1) for private network
- Reuses IBM Cloud terminology and structure for consistency
- Only applies to private VLAN scenarios in scale/perf labs

Assisted-by: Claude 🤖