### PR TITLE
Force replace old RHEL opm file

### DIFF
--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -248,6 +248,7 @@
     src: /usr/local/bin/opm-rhel8
     dest: /usr/local/bin/opm
     state: link
+    force: yes
   when: ansible_facts['distribution_major_version'] is version('8', '==')
 
 - name: Symlink RHEL9 opm
@@ -255,6 +256,7 @@
     src: /usr/local/bin/opm-rhel9
     dest: /usr/local/bin/opm
     state: link
+    force: yes
   when: ansible_facts['distribution_major_version'] is version('9', '==')
 
 - name: Untar yq tool


### PR DESCRIPTION
The current Ansible task for creating a symlink to the opm binary fails on RHEL with the error:

`TASK [bastion-install : Symlink RHEL9 opm] *************************************************************************************************************** Sunday 05 October 2025 03:28:31 -0400 (0:00:00.021) 0:00:31.244 ******** fatal: [10.26.8.107]: FAILED! => {"changed": false, "gid": 1000, "group": "jenkins", "mode": "0700", "msg": "refusing to convert from file to symlink for /usr/local/bin/opm", "owner": "jenkins", "path": "/usr/local/bin/opm", "secontext": "unconfined_u:object_r:bin_t:s0", "size": 81544080, "state": "file", "uid": 1000}`

This happens because a regular opm file already exists, and Ansible will not overwrite it unless explicitly instructed.
Added force: yes to the ansible.builtin.file task to allow replacing the existing opm binary with a symlink.