### PR TITLE
Add hw_install_disk mapping for auto disk by path configuration

### DIFF
--- a/ansible/roles/create-inventory/defaults/main/storage.yml
+++ b/ansible/roles/create-inventory/defaults/main/storage.yml
@@ -9,9 +9,8 @@
 # Edit and adjust each machine's install_disk= to have the by-path/by-id reference instead of the symbolic reference
 # See https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/managing_file_systems/index#device-identifiers_assembly_overview-of-persistent-naming-attributes
 
-# Default install disks for mno
-control_plane_install_disk: /dev/sda
-worker_install_disk: /dev/sda
-
-# Default install disk for sno
-sno_install_disk: /dev/sda
+# Default install disks are now set dynamically in tasks/main.yml based on hardware mappings
+# You can override these in vars/all.yml:
+#   control_plane_install_disk: /dev/nvme0n1
+#   worker_install_disk: /dev/nvme0n1
+#   sno_install_disk: /dev/nvme0n1

--- a/ansible/roles/create-inventory/templates/inventory-mno.j2
+++ b/ansible/roles/create-inventory/templates/inventory-mno.j2
@@ -22,14 +22,19 @@ bmc_user={{ bmc_user }}
 bmc_password={{ bmc_password }}
 
 [controlplane]
+{% set cp_hw = (controlplane0.split('.')[0]).split('-')[-1] %}
+{% set cp_parts = (controlplane0.split('.')[0]).replace('mgmt-','').split('-') %}
+{% set cp_rack = cp_parts[0] %}
+{% set cp_unit = cp_parts[1] if cp_parts|length > 1 else '' %}
+{% set cp_disk = control_plane_install_disk | default(hw_install_disk[lab][cp_rack ~ '-' ~ cp_unit ~ '-' ~ cp_hw]) | default(hw_install_disk[lab][cp_rack ~ '-' ~ cp_hw]) | default(hw_install_disk[lab][cp_hw]) | default('/dev/sda') %}
 {% if enable_bond | default(false) %}
-{{ controlplane0.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane0 }} bond0_macs={{ controlplane0_bond0_macs }} lab_mac={{ controlplane0_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(5) }} vendor={{ controlplane0_vendor }} install_disk={{ control_plane_install_disk }}
-{{ controlplane1.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane1 }} bond0_macs={{ controlplane1_bond0_macs }} lab_mac={{ controlplane1_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(6) }} vendor={{ controlplane1_vendor }} install_disk={{ control_plane_install_disk }}
-{{ controlplane2.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane2 }} bond0_macs={{ controlplane2_bond0_macs }} lab_mac={{ controlplane2_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(7) }} vendor={{ controlplane2_vendor }} install_disk={{ control_plane_install_disk }}
+{{ controlplane0.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane0 }} bond0_macs={{ controlplane0_bond0_macs }} lab_mac={{ controlplane0_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(5) }} vendor={{ controlplane0_vendor }} install_disk={{ cp_disk }}
+{{ controlplane1.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane1 }} bond0_macs={{ controlplane1_bond0_macs }} lab_mac={{ controlplane1_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(6) }} vendor={{ controlplane1_vendor }} install_disk={{ cp_disk }}
+{{ controlplane2.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane2 }} bond0_macs={{ controlplane2_bond0_macs }} lab_mac={{ controlplane2_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(7) }} vendor={{ controlplane2_vendor }} install_disk={{ cp_disk }}
 {% else %}
-{{ controlplane0.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane0 }} mac_address={{ controlplane0_mac_address }} lab_mac={{ controlplane0_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(5) }} vendor={{ controlplane0_vendor }} install_disk={{ control_plane_install_disk }}
-{{ controlplane1.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane1 }} mac_address={{ controlplane1_mac_address }} lab_mac={{ controlplane1_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(6) }} vendor={{ controlplane1_vendor }} install_disk={{ control_plane_install_disk }}
-{{ controlplane2.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane2 }} mac_address={{ controlplane2_mac_address }} lab_mac={{ controlplane2_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(7) }} vendor={{ controlplane2_vendor }} install_disk={{ control_plane_install_disk }}
+{{ controlplane0.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane0 }} mac_address={{ controlplane0_mac_address }} lab_mac={{ controlplane0_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(5) }} vendor={{ controlplane0_vendor }} install_disk={{ cp_disk }}
+{{ controlplane1.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane1 }} mac_address={{ controlplane1_mac_address }} lab_mac={{ controlplane1_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(6) }} vendor={{ controlplane1_vendor }} install_disk={{ cp_disk }}
+{{ controlplane2.split('.')[0] | replace('mgmt-','') }} bmc_address={{ controlplane2 }} mac_address={{ controlplane2_mac_address }} lab_mac={{ controlplane2_lab_mac }} ip={{ controlplane_network | ansible.utils.nthhost(7) }} vendor={{ controlplane2_vendor }} install_disk={{ cp_disk }}
 {% endif %}
 
 [controlplane:vars]
@@ -54,10 +59,15 @@ dns2={{ labs[lab]['dns'][1] | default('') }}
 
 [worker]
 {% for worker in ocpinventory_worker_nodes %}
+{%   set worker_hw = (worker.pm_addr.split('.')[0]).split('-')[-1] %}
+{%   set worker_parts = (worker.pm_addr.split('.')[0]).replace('mgmt-','').split('-') %}
+{%   set worker_rack = worker_parts[0] %}
+{%   set worker_unit = worker_parts[1] if worker_parts|length > 1 else '' %}
+{%   set worker_disk = worker_install_disk | default(hw_install_disk[lab][worker_rack ~ '-' ~ worker_unit ~ '-' ~ worker_hw]) | default(hw_install_disk[lab][worker_rack ~ '-' ~ worker_hw]) | default(hw_install_disk[lab][worker_hw]) | default('/dev/sda') %}
 {% if enable_bond | default(false) %}
-{{ worker.pm_addr.split('.')[0] | replace('mgmt-','') }} bmc_address={{ worker.pm_addr }} bond0_macs={{ worker.bond0_macs }} lab_mac={{ ( (mno_foreman_data.results| selectattr('json.name', 'eq', worker.pm_addr | replace('mgmt-',''))|first).json.interfaces | selectattr('primary', 'eq', True)|first).mac }} ip={{ controlplane_network | ansible.utils.nthhost(loop.index + mno_worker_node_offset) }} vendor={{ hw_vendor[(worker.pm_addr.split('.')[0]).split('-')[-1]] }} install_disk={{ worker_install_disk }}
+{{ worker.pm_addr.split('.')[0] | replace('mgmt-','') }} bmc_address={{ worker.pm_addr }} bond0_macs={{ worker.bond0_macs }} lab_mac={{ ( (mno_foreman_data.results| selectattr('json.name', 'eq', worker.pm_addr | replace('mgmt-',''))|first).json.interfaces | selectattr('primary', 'eq', True)|first).mac }} ip={{ controlplane_network | ansible.utils.nthhost(loop.index + mno_worker_node_offset) }} vendor={{ hw_vendor[worker_hw] }} install_disk={{ worker_disk }}
 {% else %}
-{{ worker.pm_addr.split('.')[0] | replace('mgmt-','') }} bmc_address={{ worker.pm_addr }} mac_address={{ worker.mac[controlplane_network_interface_idx|int] }} lab_mac={{ ( (mno_foreman_data.results| selectattr('json.name', 'eq', worker.pm_addr | replace('mgmt-',''))|first).json.interfaces | selectattr('primary', 'eq', True)|first).mac }} ip={{ controlplane_network | ansible.utils.nthhost(loop.index + mno_worker_node_offset) }} vendor={{ hw_vendor[(worker.pm_addr.split('.')[0]).split('-')[-1]] }} install_disk={{ worker_install_disk }}
+{{ worker.pm_addr.split('.')[0] | replace('mgmt-','') }} bmc_address={{ worker.pm_addr }} mac_address={{ worker.mac[controlplane_network_interface_idx|int] }} lab_mac={{ ( (mno_foreman_data.results| selectattr('json.name', 'eq', worker.pm_addr | replace('mgmt-',''))|first).json.interfaces | selectattr('primary', 'eq', True)|first).mac }} ip={{ controlplane_network | ansible.utils.nthhost(loop.index + mno_worker_node_offset) }} vendor={{ hw_vendor[worker_hw] }} install_disk={{ worker_disk }}
 {% endif %}
 {% endfor %}
 {% if hybrid_worker_count > 0 %}

--- a/ansible/roles/create-inventory/templates/inventory-sno.j2
+++ b/ansible/roles/create-inventory/templates/inventory-sno.j2
@@ -55,10 +55,15 @@ bmc_password={{ bmc_password }}
 {%   else %}
 {%     set ip=controlplane_network | ansible.utils.nthhost(loop.index0 + sno_controlplane_ip_offset) %}
 {%   endif %}
+{%   set sno_hw = (sno.pm_addr.split('.')[0]).split('-')[-1] %}
+{%   set sno_parts = (sno.pm_addr.split('.')[0]).replace('mgmt-','').split('-') %}
+{%   set sno_rack = sno_parts[0] %}
+{%   set sno_unit = sno_parts[1] if sno_parts|length > 1 else '' %}
+{%   set sno_disk = sno_install_disk | default(hw_install_disk[lab][sno_rack ~ '-' ~ sno_unit ~ '-' ~ sno_hw]) | default(hw_install_disk[lab][sno_rack ~ '-' ~ sno_hw]) | default(hw_install_disk[lab][sno_hw]) | default('/dev/sda') %}
 {%   if enable_bond | default(false) %}
-{%     if not loop.first %}# {% endif %}{{ sno_short_hostname }} bmc_address={{ sno.pm_addr }} bond0_macs={{ sno.bond0_macs }} lab_mac={{ lab_mac }} ip={{ ip }} vendor={{ hw_vendor[(sno.pm_addr.split('.')[0]).split('-')[-1]] }} install_disk={{ sno_install_disk }} boot_iso={{ sno_short_hostname }}.iso
+{%     if not loop.first %}# {% endif %}{{ sno_short_hostname }} bmc_address={{ sno.pm_addr }} bond0_macs={{ sno.bond0_macs }} lab_mac={{ lab_mac }} ip={{ ip }} vendor={{ hw_vendor[sno_hw] }} install_disk={{ sno_disk }} boot_iso={{ sno_short_hostname }}.iso
 {%   else %}
-{%     if not loop.first %}# {% endif %}{{ sno_short_hostname }} bmc_address={{ sno.pm_addr }} mac_address={{ sno.mac[controlplane_network_interface_idx|int] }} lab_mac={{ lab_mac }} ip={{ ip }} vendor={{ hw_vendor[(sno.pm_addr.split('.')[0]).split('-')[-1]] }} install_disk={{ sno_install_disk }} boot_iso={{ sno_short_hostname }}.iso
+{%     if not loop.first %}# {% endif %}{{ sno_short_hostname }} bmc_address={{ sno.pm_addr }} mac_address={{ sno.mac[controlplane_network_interface_idx|int] }} lab_mac={{ lab_mac }} ip={{ ip }} vendor={{ hw_vendor[sno_hw] }} install_disk={{ sno_disk }} boot_iso={{ sno_short_hostname }}.iso
 {%   endif %}
 {% endfor %}
 

--- a/ansible/vars/lab.yml
+++ b/ansible/vars/lab.yml
@@ -47,6 +47,8 @@ hw_vendor:
   r7425: Dell
   r7525: Dell
   r7625: Dell
+  xe8640: Dell
+  xe9680: Dell
   1029u: Supermicro
   1029p: Supermicro
   5039ms: Supermicro
@@ -57,6 +59,36 @@ hw_vendor:
   6048p: Supermicro
   6049p: Supermicro
   dl360: Hp
+
+# Hardware install disk by-path mappings
+# Based on docs/tips-and-vars.md
+# Format: hw_model or rack-hw_model or rack-unit-hw_model for overrides
+# Examples:
+#   1029p                - hardware default
+#   f05-1029p            - rack-specific override
+#   f05-h03-1029p        - rack-unit-specific override
+hw_install_disk:
+  scalelab:
+    r750: /dev/disk/by-path/pci-0000:05:00.0-ata-1.0
+    r660: /dev/disk/by-path/pci-0000:4a:00.0-scsi-0:0:1:0
+    r650: /dev/disk/by-path/pci-0000:67:00.0-scsi-0:2:0:0
+    r640: /dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:0:0
+    r630: /dev/disk/by-path/pci-0000:02:00.0-scsi-0:2:0:0
+  performancelab:
+    r740xd: /dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:0:0
+    y37-r740xd: /dev/disk/by-path/pci-0000:86:00.0-scsi-0:2:0:0
+    y37-h01-r740xd: /dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:0:0
+    y37-h03-r740xd: /dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:0:0
+    y37-h05-r740xd: /dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:0:0
+    y37-h07-r740xd: /dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:0:0
+    y37-h09-r740xd: /dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:0:0
+    r750: /dev/disk/by-path/pci-0000:05:00.0-ata-1
+    r7425: /dev/disk/by-path/pci-0000:e2:00.0-scsi-0:2:0:0
+    r7525: /dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0
+    r760: /dev/disk/by-path/pci-0000:3f:00.0-scsi-0:0:1:0
+    6029p: /dev/disk/by-path/pci-0000:00:11.5-ata-5
+    xe8640: /dev/disk/by-path/pci-0000:01:00.0-nvme-1
+    xe9680: /dev/disk/by-path/pci-0000:01:00.0-nvme-1
 
 # This dictionary contains the expected nic names for networks in the scale/performance lab. This determines the name of the
 # nic for hypervisors.


### PR DESCRIPTION
- Add hw_install_disk mapping table to ansible/vars/lab.yml with support for:
  * Hardware defaults (e.g., r740xd)
  * Rack-level overrides (e.g., y37-r740xd)
  * Rack-unit-level overrides (e.g., y37-h01-r740xd)

- Update inventory templates to parse rack and rack-unit from hostnames and perform fallback lookup

- Remove hardcoded defaults from defaults/main/storage.yml

- Add support for user overrides via vars/all.yml that take precedence over hardware mappings