### PR TITLE
Add retries to Extract/Download the openshift-install binary task

### DIFF
--- a/ansible/roles/bastion-ocp-version/tasks/main.yml
+++ b/ansible/roles/bastion-ocp-version/tasks/main.yml
@@ -65,6 +65,10 @@
     tar -xvf openshift-install-linux-*.tar.gz openshift-install
   args:
     chdir: "{{ ocp_version_path }}"
+  register: extract_installer
+  retries: 3
+  delay: 5
+  until: extract_installer is not failed
 
 # We need to unarchive the clients here to align their versions cluster version
 


### PR DESCRIPTION
Retry pulling the release image for cases like below:

```
TASK [bastion-ocp-version : Extract/Download the openshift-install binary for the specific release] ***
Friday 10 October 2025  00:44:38 +0000 (0:00:00.019)       0:01:03.335 ******** 
fatal: [XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX]: FAILED! => {"changed": true, "cmd": "oc adm release extract --tools registry.build11.ci.openshift.org/ci-op-wh1lqlgs/release@sha256:b16000f457ca4bc4276ca420cb3ad4fb861f2fc3ceffe4199dd32c3637a045c0 --to /opt/ocp-version --registry-config /root/.docker/config.json\ntar -xvf openshift-install-linux-*.tar.gz openshift-install\n", "delta": "0:00:11.561672", "end": "2025-10-10 00:44:50.256647", "msg": "non-zero return code", "rc": 2, "start": "2025-10-10 00:44:38.694975", "stderr": "error: unable to parse image quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:16292bbb30a9c203c19e66b7ffa3c42851431a47cfdc22a90283aa91e658bf28: cannot retrieve image configuration for manifest sha256:16292bbb30a9c203c19e66b7ffa3c42851431a47cfdc22a90283aa91e658bf28: Get \"https://cdn01.quay.io/quayio-production-s3/sha256/75/7515410c313e0ad65d847073c36f4f9a7070059980eb5cb61dd2c3a5f67b82ee?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIATAAF2YHTGR23ZTE6%2F20251010%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20251010T004440Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Signature=caa957131603a368dda8883365820fe9297d666f1e190fc409f4d8fc0e73f054&region=us-east-1&namespace=openshift-release-dev&username=openshift-release-dev+ocm_access_13dbbef7366e4c60bb0529d6dd0b4f1a&repo_name=ocp-v4.0-art-dev&akamai_signature=exp=1760057980~hmac=a65a445d3694af4a72b1871ffbc4027e88601585cbcd415a35daaee35a430549\": net/http: TLS handshake timeout\ntar: openshift-install-linux-*.tar.gz: Cannot open: No such file or directory\ntar: Error is not recoverable: exiting now", "stderr_lines": ["error: unable to parse image quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:16292bbb30a9c203c19e66b7ffa3c42851431a47cfdc22a90283aa91e658bf28: cannot retrieve image configuration for manifest sha256:16292bbb30a9c203c19e66b7ffa3c42851431a47cfdc22a90283aa91e658bf28: Get \"https://cdn01.quay.io/quayio-production-s3/sha256/75/7515410c313e0ad65d847073c36f4f9a7070059980eb5cb61dd2c3a5f67b82ee?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIATAAF2YHTGR23ZTE6%2F20251010%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20251010T004440Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Signature=caa957131603a368dda8883365820fe9297d666f1e190fc409f4d8fc0e73f054&region=us-east-1&namespace=openshift-release-dev&username=openshift-release-dev+ocm_access_13dbbef7366e4c60bb0529d6dd0b4f1a&repo_name=ocp-v4.0-art-dev&akamai_signature=exp=1760057980~hmac=a65a445d3694af4a72b1871ffbc4027e88601585cbcd415a35daaee35a430549\": net/http: TLS handshake timeout", "tar: openshift-install-linux-*.tar.gz: Cannot open: No such file or directory", "tar: Error is not recoverable: exiting now"], "stdout": "", "stdout_lines": []}
```