### PR TITLE
Change bond xmit mode to 3+4

### DIFF
--- a/ansible/roles/create-ai-cluster/templates/rhlab_bond_nmstate.yml.j2
+++ b/ansible/roles/create-ai-cluster/templates/rhlab_bond_nmstate.yml.j2
@@ -16,6 +16,7 @@ interfaces:
     mode: 802.3ad
     options:
       miimon: '100'
+      xmit_hash_policy: layer3+4
     port:
 {% for interface in hostvars[item]['bond0_interfaces'] %}
     - {{ interface }}


### PR DESCRIPTION
We need this to increase the throughput on OCP envs.
Before this PR:
```
cat /sys/class/net/bond0/bonding/xmit_hash_policy
layer2 0
```