### PR TITLE
Update pull_secret to pull-secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 pull_secret.*
+pull-secret.*
 kubeconfig
 .ansible
 .vscode

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can also [manually create a "Bring Your Own Lab"](docs/deploy-mno-byol.md) i
 | - | - |
 | `ansible/vars/all.yml` | An Ansible vars file used for Red Hat performance labs (sample provided at `ansible/vars/all.sample.yml`)
 | `ansible/vars/ibmcloud.yml` | An Ansible vars file used for IBM Cloud (sample provided at `ansible/vars/ibmcloud.sample.yml`)
-| `pull_secret.txt` | Your OCP pull secret, download from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads)
+| `pull-secret.txt` | Your OCP pull secret, download from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads)
 | `ansible/inventory/$CLOUDNAME.local` | The generated inventory file (Samples provided in `ansible/inventory`)
 
 Start by editing the vars
@@ -126,10 +126,10 @@ Make sure to set/review the following vars:
 
 More customization such as `cluster_network` and `service_network` are available as extra vars, check each ansible role default vars file for variable names and options. For network interface configuration details, see [tips-and-vars.md](docs/tips-and-vars.md).
 
-Save your pull-secret from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) in `pull_secret.txt` in the Jetlag repo base directory, for example by using the "Copy" button on the web page, and then pasting the clipboard text into a `cat > pull_secret.txt` command like this:
+Save your pull-secret from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) in `pull-secret.txt` in the Jetlag repo base directory, for example by using the "Copy" button on the web page, and then pasting the clipboard text into a `cat > pull-secret.txt` command like this:
 
 ```console
-(.ansible) [root@<bastion> jetlag]# cat >pull_secret.txt
+(.ansible) [root@<bastion> jetlag]# cat >pull-secret.txt
 {
   "auths": {
     "quay.io": {

--- a/ansible/vars/all.sample.yml
+++ b/ansible/vars/all.sample.yml
@@ -43,9 +43,9 @@ enable_cnv_install: false
 
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
-# Place your pull_secret.txt in the base directory of the cloned jetlag repo, Example:
-# [root@<bastion> jetlag]# ls pull_secret.txt
-pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
+# Place your pull-secret.txt in the base directory of the cloned jetlag repo, Example:
+# [root@<bastion> jetlag]# ls pull-secret.txt
+pull_secret: "{{ lookup('file', '../pull-secret.txt') }}"
 
 ################################################################################
 # Bastion node vars

--- a/ansible/vars/hv.sample.yml
+++ b/ansible/vars/hv.sample.yml
@@ -47,4 +47,4 @@ hv_vm_manifest_acm_cr: true
 # Retrieves the bastion pull-secret instead of below pull-secret
 use_bastion_registry: false
 # Provide pull-secret for connected manifests
-pull_secret: "{{ lookup('file', '../pull_secret.txt') | b64encode }}"
+pull_secret: "{{ lookup('file', '../pull-secret.txt') | b64encode }}"

--- a/ansible/vars/ibmcloud.sample.yml
+++ b/ansible/vars/ibmcloud.sample.yml
@@ -25,9 +25,9 @@ enable_cnv_install: false
 
 ssh_private_key_file: ~/.ssh/ibmcloud_id_rsa
 ssh_public_key_file: ~/.ssh/ibmcloud_id_rsa.pub
-# Place your pull_secret.txt in the base directory of the cloned jetlag repo, Example:
-# [root@<bastion> jetlag]# ls pull_secret.txt
-pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
+# Place your pull-secret.txt in the base directory of the cloned jetlag repo, Example:
+# [root@<bastion> jetlag]# ls pull-secret.txt
+pull_secret: "{{ lookup('file', '../pull-secret.txt') }}"
 
 ################################################################################
 # Bastion node vars

--- a/ansible/vars/sync-ocp-release.sample.yml
+++ b/ansible/vars/sync-ocp-release.sample.yml
@@ -8,4 +8,4 @@ ocp_build: "ga"
 # For "ci" builds, an example is "4.19.0-0.nightly-2025-02-25-035256"
 ocp_version: "latest-4.20"
 
-pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
+pull_secret: "{{ lookup('file', '../pull-secret.txt') }}"

--- a/docs/deploy-mno-byol.md
+++ b/docs/deploy-mno-byol.md
@@ -134,14 +134,13 @@ for subsequent steps:
 [root@<bastion> jetlag]#
 ```
 
-6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
+6. Download your `pull-secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
 the long downloads page, in the section labeled "Tokens". You can either click the "Download" button, and then copy the
-downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
-file will download with a hyphen (`-`)); *or* click on the "Copy" button, and then paste the clipboard into the terminal
-after typing `cat >pull_secret.txt` on the bastion to create the expected filename:
+downloaded file to `~/jetlag/pull-secret.txt` on the bastion; *or* click on the "Copy" button, and then paste the clipboard into the terminal
+after typing `cat >pull-secret.txt` on the bastion to create the expected filename:
 
 ```console
-[root@<bastion> jetlag]# cat >pull_secret.txt
+[root@<bastion> jetlag]# cat >pull-secret.txt
 {
   "auths": {
     "quay.io": {
@@ -218,7 +217,7 @@ for a list of `dev` releases. Nightly `ci` builds are tricky and require determi
 exact builds you can use, an example of `ocp_version` with `ocp_build: ci` is
 `4.19.0-0.nightly-2025-02-25-035256`.
 
-Note: user has to add registry.ci.openshift.org token in pull_secret.txt for `ci` builds.
+Note: user has to add registry.ci.openshift.org token in pull-secret.txt for `ci` builds.
 
 ### Bastion node vars
 
@@ -309,9 +308,9 @@ enable_cnv_install: false
 
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
-# Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
-# [root@<bastion> jetlag]# ls pull_secret.txt
-pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
+# Place your pull-secret.txt in the base directory of the cloned Jetlag repo, Example:
+# [root@<bastion> jetlag]# ls pull-secret.txt
+pull_secret: "{{ lookup('file', '../pull-secret.txt') }}"
 
 ################################################################################
 # Bastion node vars

--- a/docs/deploy-mno-ibmcloud.md
+++ b/docs/deploy-mno-ibmcloud.md
@@ -127,14 +127,13 @@ for subsequent steps:
 [root@<bastion> jetlag]#
 ```
 
-6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
+6. Download your `pull-secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
 the long downloads page, in the section labeled "Tokens". You can either click the "Download" button, and then copy the
-downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
-file will download with a hyphen (`-`)); *or* click on the "Copy" button, and then paste the clipboard into the terminal
-after typing `cat >pull_secret.txt` on the bastion to create the expected filename:
+downloaded file to `~/jetlag/pull-secret.txt` on the bastion; *or* click on the "Copy" button, and then paste the clipboard into the terminal
+after typing `cat >pull-secret.txt` on the bastion to create the expected filename:
 
 ```console
-[root@<bastion> jetlag]# cat >pull_secret.txt
+[root@<bastion> jetlag]# cat >pull-secret.txt
 {
   "auths": {
     "quay.io": {
@@ -209,7 +208,7 @@ for a list of `dev` releases. Nightly `ci` builds are tricky and require determi
 exact builds you can use, an example of `ocp_version` with `ocp_build: ci` is
 `4.19.0-0.nightly-2025-02-25-035256`.
 
-Note: user has to add registry.ci.openshift.org token in pull_secret.txt for `ci` builds.
+Note: user has to add registry.ci.openshift.org token in pull-secret.txt for `ci` builds.
 
 Set `ssh_private_key_file` and `ssh_public_key_file` to the file location of the ssh key files to access your ibmcloud bare metal servers.
 
@@ -271,9 +270,9 @@ enable_cnv_install: false
 
 ssh_private_key_file: ~/.ssh/ibmcloud_id_rsa
 ssh_public_key_file: ~/.ssh/ibmcloud_id_rsa.pub
-# Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
-# [root@<bastion> jetlag]# ls pull_secret.txt
-pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
+# Place your pull-secret.txt in the base directory of the cloned Jetlag repo, Example:
+# [root@<bastion> jetlag]# ls pull-secret.txt
+pull_secret: "{{ lookup('file', '../pull-secret.txt') }}"
 
 ################################################################################
 # Bastion node vars

--- a/docs/deploy-mno-performancelab.md
+++ b/docs/deploy-mno-performancelab.md
@@ -120,14 +120,13 @@ for subsequent steps:
 [root@<bastion> jetlag]#
 ```
 
-6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
+6. Download your `pull-secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
 the long downloads page, in the section labeled "Tokens". You can either click the "Download" button, and then copy the
-downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
-file will download with a hyphen (`-`)); *or* click on the "Copy" button, and then paste the clipboard into the terminal
-after typing `cat >pull_secret.txt` on the bastion to create the expected filename:
+downloaded file to `~/jetlag/pull-secret.txt` on the bastion; *or* click on the "Copy" button, and then paste the clipboard into the terminal
+after typing `cat >pull-secret.txt` on the bastion to create the expected filename:
 
 ```console
-[root@<bastion> jetlag]# cat >pull_secret.txt
+[root@<bastion> jetlag]# cat >pull-secret.txt
 {
   "auths": {
     "quay.io": {
@@ -204,7 +203,7 @@ for a list of `dev` releases. Nightly `ci` builds are tricky and require determi
 exact builds you can use, an example of `ocp_version` with `ocp_build: ci` is
 `4.19.0-0.nightly-2025-02-25-035256`.
 
-Note: user has to add registry.ci.openshift.org token in pull_secret.txt for `ci` builds.
+Note: user has to add registry.ci.openshift.org token in pull-secret.txt for `ci` builds.
 
 ### Bastion node vars
 
@@ -325,9 +324,9 @@ enable_cnv_install: false
 
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
-# Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
-# [root@<bastion> jetlag]# ls pull_secret.txt
-pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
+# Place your pull-secret.txt in the base directory of the cloned Jetlag repo, Example:
+# [root@<bastion> jetlag]# ls pull-secret.txt
+pull_secret: "{{ lookup('file', '../pull-secret.txt') }}"
 
 ################################################################################
 # Bastion node vars

--- a/docs/deploy-mno-scalelab.md
+++ b/docs/deploy-mno-scalelab.md
@@ -121,14 +121,13 @@ for subsequent steps:
 [root@<bastion> jetlag]#
 ```
 
-6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
+6. Download your `pull-secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
 the long downloads page, in the section labeled "Tokens". You can either click the "Download" button, and then copy the
-downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
-file will download with a hyphen (`-`)); *or* click on the "Copy" button, and then paste the clipboard into the terminal
-after typing `cat >pull_secret.txt` on the bastion to create the expected filename:
+downloaded file to `~/jetlag/pull-secret.txt` on the bastion; *or* click on the "Copy" button, and then paste the clipboard into the terminal
+after typing `cat >pull-secret.txt` on the bastion to create the expected filename:
 
 ```console
-[root@<bastion> jetlag]# cat >pull_secret.txt
+[root@<bastion> jetlag]# cat >pull-secret.txt
 {
   "auths": {
     "quay.io": {
@@ -205,7 +204,7 @@ for a list of `dev` releases. Nightly `ci` builds are tricky and require determi
 exact builds you can use, an example of `ocp_version` with `ocp_build: ci` is
 `4.19.0-0.nightly-2025-02-25-035256`.
 
-Note: user has to add registry.ci.openshift.org token in pull_secret.txt for `ci` builds.
+Note: user has to add registry.ci.openshift.org token in pull-secret.txt for `ci` builds.
 
 ### Prow integration
 
@@ -331,9 +330,9 @@ enable_cnv_install: false
 
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
-# Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
-# [root@<bastion> jetlag]# ls pull_secret.txt
-pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
+# Place your pull-secret.txt in the base directory of the cloned Jetlag repo, Example:
+# [root@<bastion> jetlag]# ls pull-secret.txt
+pull_secret: "{{ lookup('file', '../pull-secret.txt') }}"
 
 ################################################################################
 # Bastion node vars

--- a/docs/deploy-sno-ibmcloud.md
+++ b/docs/deploy-sno-ibmcloud.md
@@ -116,14 +116,13 @@ for subsequent steps:
 [root@<bastion> jetlag]#
 ```
 
-6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
+6. Download your `pull-secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
 the long downloads page, in the section labeled "Tokens". You can either click the "Download" button, and then copy the
-downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
-file will download with a hyphen (`-`)); *or* click on the "Copy" button, and then paste the clipboard into the terminal
-after typing `cat >pull_secret.txt` on the bastion to create the expected filename:
+downloaded file to `~/jetlag/pull-secret.txt` on the bastion; *or* click on the "Copy" button, and then paste the clipboard into the terminal
+after typing `cat >pull-secret.txt` on the bastion to create the expected filename:
 
 ```console
-[root@<bastion> jetlag]# cat >pull_secret.txt
+[root@<bastion> jetlag]# cat >pull-secret.txt
 {
   "auths": {
     "quay.io": {
@@ -214,9 +213,9 @@ enable_cnv_install: false
 
 ssh_private_key_file: ~/.ssh/ibmcloud_id_rsa
 ssh_public_key_file: ~/.ssh/ibmcloud_id_rsa.pub
-# Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
-# [root@<bastion> jetlag]# ls pull_secret.txt
-pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
+# Place your pull-secret.txt in the base directory of the cloned Jetlag repo, Example:
+# [root@<bastion> jetlag]# ls pull-secret.txt
+pull_secret: "{{ lookup('file', '../pull-secret.txt') }}"
 
 ################################################################################
 # Bastion node vars

--- a/docs/deploy-sno-performancelab.md
+++ b/docs/deploy-sno-performancelab.md
@@ -122,14 +122,13 @@ for subsequent steps:
 [root@<bastion> jetlag]#
 ```
 
-6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
+6. Download your `pull-secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
 the long downloads page, in the section labeled "Tokens". You can either click the "Download" button, and then copy the
-downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
-file will download with a hyphen (`-`)); *or* click on the "Copy" button, and then paste the clipboard into the terminal
-after typing `cat >pull_secret.txt` on the bastion to create the expected filename:
+downloaded file to `~/jetlag/pull-secret.txt` on the bastion; *or* click on the "Copy" button, and then paste the clipboard into the terminal
+after typing `cat >pull-secret.txt` on the bastion to create the expected filename:
 
 ```console
-[root@<bastion> jetlag]# cat >pull_secret.txt
+[root@<bastion> jetlag]# cat >pull-secret.txt
 {
   "auths": {
     "quay.io": {
@@ -204,7 +203,7 @@ for a list of `dev` releases. Nightly `ci` builds are tricky and require determi
 exact builds you can use, an example of `ocp_version` with `ocp_build: ci` is
 `4.19.0-0.nightly-2025-02-25-035256`.
 
-Note: user has to add registry.ci.openshift.org token in pull_secret.txt for `ci` builds.
+Note: user has to add registry.ci.openshift.org token in pull-secret.txt for `ci` builds.
 
 For the ssh keys we have a chicken before the egg problem in that our bastion machine won't be defined or ensure that keys are created until after we run `create-inventory.yml` and `setup-bastion.yml` playbooks. We will revisit that a little bit later.
 
@@ -299,9 +298,9 @@ enable_cnv_install: false
 
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
-# Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
-# [root@<bastion> jetlag]# ls pull_secret.txt
-pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
+# Place your pull-secret.txt in the base directory of the cloned Jetlag repo, Example:
+# [root@<bastion> jetlag]# ls pull-secret.txt
+pull_secret: "{{ lookup('file', '../pull-secret.txt') }}"
 
 ################################################################################
 # Bastion node vars

--- a/docs/deploy-sno-scalelab.md
+++ b/docs/deploy-sno-scalelab.md
@@ -116,14 +116,13 @@ for subsequent steps:
 [root@<bastion> jetlag]#
 ```
 
-6. Download your `pull_secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
+6. Download your `pull-secret.txt` from [console.redhat.com/openshift/downloads](https://console.redhat.com/openshift/downloads) into the root directory of your Jetlag repo on the bastion. You'll find the Pull Secret near the end of
 the long downloads page, in the section labeled "Tokens". You can either click the "Download" button, and then copy the
-downloaded file to `~/jetlag/pull_secret.txt` on the bastion (notice that Jetlag expects an underscore (`_`) while the
-file will download with a hyphen (`-`)); *or* click on the "Copy" button, and then paste the clipboard into the terminal
-after typing `cat >pull_secret.txt` on the bastion to create the expected filename:
+downloaded file to `~/jetlag/pull-secret.txt` on the bastion; *or* click on the "Copy" button, and then paste the clipboard into the terminal
+after typing `cat >pull-secret.txt` on the bastion to create the expected filename:
 
 ```console
-[root@<bastion> jetlag]# cat >pull_secret.txt
+[root@<bastion> jetlag]# cat >pull-secret.txt
 {
   "auths": {
     "quay.io": {
@@ -198,7 +197,7 @@ for a list of `dev` releases. Nightly `ci` builds are tricky and require determi
 exact builds you can use, an example of `ocp_version` with `ocp_build: ci` is
 `4.19.0-0.nightly-2025-02-25-035256`.
 
-Note: user has to add registry.ci.openshift.org token in pull_secret.txt for `ci` builds.
+Note: user has to add registry.ci.openshift.org token in pull-secret.txt for `ci` builds.
 
 For the ssh keys we have a chicken before the egg problem in that our bastion machine won't be defined or ensure that keys are created until after we run `create-inventory.yml` and `setup-bastion.yml` playbooks. We will revisit that a little bit later.
 
@@ -291,9 +290,9 @@ enable_cnv_install: false
 
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
-# Place your pull_secret.txt in the base directory of the cloned Jetlag repo, Example:
-# [root@<bastion> jetlag]# ls pull_secret.txt
-pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
+# Place your pull-secret.txt in the base directory of the cloned Jetlag repo, Example:
+# [root@<bastion> jetlag]# ls pull-secret.txt
+pull_secret: "{{ lookup('file', '../pull-secret.txt') }}"
 
 ################################################################################
 # Bastion node vars

--- a/docs/deploy-vmno.md
+++ b/docs/deploy-vmno.md
@@ -30,7 +30,7 @@ _**Table of Contents**_
 
 # Deploy a VMNO
 
-This quickstart assumes you already have selected a bastion, setup ssh, downloaded your pull_secret.txt and cloned the jetlag repo. An example cloud consisting of Dell r740xds called `cloud99` in the performancelab is used for the example.
+This quickstart assumes you already have selected a bastion, setup ssh, downloaded your pull-secret.txt and cloned the jetlag repo. An example cloud consisting of Dell r740xds called `cloud99` in the performancelab is used for the example.
 
 The main steps to deploy a VMNO are as follows
 
@@ -77,7 +77,7 @@ for a list of `dev` releases. Nightly `ci` builds are tricky and require determi
 exact builds you can use, an example of `ocp_version` with `ocp_build: ci` is
 `4.19.0-0.nightly-2025-02-25-035256`.
 
-Note: user has to add registry.ci.openshift.org token in pull_secret.txt for `ci` builds.
+Note: user has to add registry.ci.openshift.org token in pull-secret.txt for `ci` builds.
 
 ### Bastion node vars
 
@@ -189,9 +189,9 @@ enable_cnv_install: false
 
 ssh_private_key_file: ~/.ssh/id_rsa
 ssh_public_key_file: ~/.ssh/id_rsa.pub
-# Place your pull_secret.txt in the base directory of the cloned jetlag repo, Example:
-# [root@<bastion> jetlag]# ls pull_secret.txt
-pull_secret: "{{ lookup('file', '../pull_secret.txt') }}"
+# Place your pull-secret.txt in the base directory of the cloned jetlag repo, Example:
+# [root@<bastion> jetlag]# ls pull-secret.txt
+pull_secret: "{{ lookup('file', '../pull-secret.txt') }}"
 
 ################################################################################
 # Bastion node vars
@@ -284,7 +284,7 @@ hv_vm_manifest_acm_cr: true
 # Retrieves the bastion pull-secret instead of below pull-secret
 use_bastion_registry: false
 # Provide pull-secret for connected manifests
-pull_secret: "{{ lookup('file', '../pull_secret.txt') | b64encode }}"
+pull_secret: "{{ lookup('file', '../pull-secret.txt') | b64encode }}"
 ```
 
 ## Run playbooks

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -201,7 +201,7 @@ Saved credentials for registry.ci.openshift.org into ci_ps.json
 	}
 }
 ```
-* Append or update the pull secret retrieved from above under pull_secret.txt in repo base directory.
+* Append or update the pull secret retrieved from above under pull-secret.txt in repo base directory.
 
 You must stop and remove all assisted-installer containers on the bastion with [clean the pods and containers off the bastion](troubleshooting.md#cleaning-all-podscontainers-off-the-bastion-machines) and then rerun the setup-bastion step in order to setup your bastion's assisted-installer to the version you specified before deploying a fresh cluster with that version.
 


### PR DESCRIPTION
Am always encountering this on a new cloud. It seems cloud.redhat.com changed to download the pull secret with a hyphen, and jetlag is written assuming an underscore. There are even notes acknowledging this difference, but let's change it to what is downloaded to simplify our lives.