### PR TITLE
Allow setting the amount of hypervisors for VMNO

### DIFF
--- a/ansible/roles/create-inventory/defaults/main/main.yml
+++ b/ansible/roles/create-inventory/defaults/main/main.yml
@@ -42,3 +42,7 @@ disk2_mount_path: /mnt/disk2
 # If HV is setup, how many workers are VMs
 # This adds vm workers to the workers section of the inventory
 hybrid_worker_count: 0
+
+# For VMNO cluster type, specify how many hypervisors to include in the inventory
+# Default (None) uses all available nodes (minus bastion)
+hv_count:

--- a/ansible/roles/create-inventory/tasks/main.yml
+++ b/ansible/roles/create-inventory/tasks/main.yml
@@ -93,7 +93,7 @@
 
   - name: Public VLAN - Set hypervisor_nic_interface_idx to -1 for the last interface
     set_fact:
-      hypervisor_nic_interface_idx: "-1"
+      hypervisor_nic_interface_idx: -1
 
 - name: Auto-configure bastion lab interface (only when not explicitly set)
   set_fact:
@@ -361,7 +361,9 @@
   block:
   - name: VMNO - Set ocpinventory hv nodes
     set_fact:
-      ocpinventory_hv_nodes: "{{ ocpinventory.json.nodes[1:] }}"
+      ocpinventory_hv_nodes: "{{ ocpinventory.json.nodes[1:max_hv_nodes|int] }}"
+    vars:
+      max_hv_nodes: "{{ (hv_count|int + 1) if hv_count != None else ocpinventory.json.nodes|length }}"
 
 - name: Hypervisor tasks to determine if there is a 2nd disk available
   when: hv_inventory or cluster_type == "vmno"


### PR DESCRIPTION
Introduce a variable for VMNO inventory which allows the user to pass how many nodes in the inventory should
be used as hypervisors. This is useful when we don't need all the nodes in the allocation to be used as hypervisors.