### PR TITLE
Better failure message for disk by-path not existing

### DIFF
--- a/ansible/roles/wait-hosts-discovered/tasks/set_node_install_disk.yml
+++ b/ansible/roles/wait-hosts-discovered/tasks/set_node_install_disk.yml
@@ -33,10 +33,24 @@
 
 - name: Get by-path disk id
   set_fact:
-    new_disk_id: "{{ (node.inventory | from_json | json_query(query) | first).id }}"
+    matching_disks: "{{ node.inventory | from_json | json_query(query) }}"
   vars:
     query: "disks[?by_path=='{{ hostvars[node.requested_hostname].install_disk }}']"
   when: '"by-path" in hostvars[node.requested_hostname].install_disk'
+
+- name: Set new_disk_id from matching disk
+  set_fact:
+    new_disk_id: "{{ (matching_disks | first).id }}"
+  when:
+  - '"by-path" in hostvars[node.requested_hostname].install_disk'
+  - matching_disks | length > 0
+
+- name: Fail if no matching disk found
+  fail:
+    msg: "No disk found with by_path matching '{{ hostvars[node.requested_hostname].install_disk }}' for host {{ node.requested_hostname }}. Available disks: {{ node.inventory | from_json | json_query('disks[*].by_path') | list }}"
+  when:
+  - '"by-path" in hostvars[node.requested_hostname].install_disk'
+  - matching_disks | length == 0
 
 - name: Adjust by-path selected install disk
   uri:


### PR DESCRIPTION
Previously, this section could fail if the disk by-path didn't exist but the error was obscure:

```
TASK [wait-hosts-discovered : Get by-path disk id] *****************************************************************************************************************************************************************************
Saturday 10 January 2026  13:59:10 +0000 (0:00:00.028)       0:08:56.592 ******
fatal: [f27-h32-000-r630.rdu2.scalelab.redhat.com]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: No first item, sequence was empty.. No first item, sequence was empty.\n\nThe error appears to be in '/root/jetlag/ansible/roles/wait-hosts-discovered/tasks/set_node_install_disk.yml': line 34, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Get by-path disk id\n  ^ here\n"}
```

Now it will fail with a better error message:

```
TASK [wait-hosts-discovered : Fail if no matching disk found] ******************************************************************************************************************************************************************
Saturday 10 January 2026  14:14:59 +0000 (0:00:00.037)       0:09:05.274 ******
fatal: [f27-h32-000-r630.rdu2.scalelab.redhat.com]: FAILED! => {"changed": false, "msg": "No disk found with by_path matching '/dev/disk/by-path/pci-0000:02:00.0-scsi-0:2:0:0' for host f35-h18-000-r640. Available disks: ['/dev/disk/by-path/pci-0000:d8:00.0-nvme-1', '/dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:2:0', '/dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:0:0', '/dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:1:0', '/dev/disk/by-path/pci-0000:00:14.0-usb-0:14.4.2:1.0-scsi-0:0:0:0']"}
```