### PR TITLE
Quote the channel name when syncing an operator index.

### DIFF
--- a/ansible/roles/sync-operator-index/templates/imagesetconf.yml.j2
+++ b/ansible/roles/sync-operator-index/templates/imagesetconf.yml.j2
@@ -14,7 +14,7 @@ mirror:
 {%   endif %}
       channels:
 {% for channel in package.channels %}
-      - name: {{ channel.name }}
+      - name: "{{ channel.name }}"
         minVersion: {{ channel.minVersion }}
         maxVersion: {{ channel.maxVersion }}
 {%   endfor %}


### PR DESCRIPTION
Some operators have a number for channel name such as 4.20 which will be interpreted as 4.2 and thus requires quotes.

Assisted-by: Cursor (Claude)