### PR TITLE
Use mac address as node-config conditions

### DIFF
--- a/ansible/roles/ocp-scale-out/templates/nodes-config.yml.j2
+++ b/ansible/roles/ocp-scale-out/templates/nodes-config.yml.j2
@@ -5,11 +5,11 @@ hosts:
   rootDeviceHints:
    deviceName: {{ hostvars[worker].install_disk }}
   interfaces:
-{% if hostvars[worker].network_interface | default(False) %}
+{% if hostvars[worker].mac_address | default(False) %}
    - macAddress: {{ hostvars[worker].mac_address }}
      name: {{ hostvars[worker].network_interface }}
 {% endif %}
-{% if hostvars[worker].lab_interface | default(False) %}
+{% if hostvars[worker].lab_mac | default(False) %}
    - macAddress: {{ hostvars[worker].lab_mac }}
      name: {{ hostvars[worker].lab_interface }}
 {% endif %}
@@ -30,7 +30,7 @@ hosts:
      config:
        server:
        - {{ hostvars[groups['sno'][0]].ip }}
-{% elif hostvars[worker].lab_interface | default(False) %}
+{% elif hostvars[worker].lab_mac | default(False) %}
      - name: {{ hostvars[worker].lab_interface }}
        type: ethernet
        state: up
@@ -39,7 +39,7 @@ hosts:
          enabled: false
          auto-dns: false
 {% endif %}
-{% if hostvars[worker].network_interface | default(False) %}
+{% if hostvars[worker].mac_address | default(False) %}
      - name: {{ hostvars[worker].network_interface }}
        type: ethernet
        state: up


### PR DESCRIPTION
After running a hybrid install, I got an error from this template where the VM host did not contain lab_mac. Looking closer at the inventory, I saw that `lab_interface` and `network_interface` are worker host group variables, and are thus always defined, but the the MAC address variables are individual host variables.

Also, the bare metal workers have `lab_mac` and the VM workers have `mac_address` and these appear to be mutually exclusive.

Thus, I think it makes more sense to use the mac variables as the conditionals for these sections of the templates.


Example:
```
[worker]
a22-b11-000-r650 bmc_address=mgmt-a22-b11-000-r650.lab.redhat.com mac_address=aa:ee:bb:cc lab_mac=ee:ff:dd:bb:cc:e0 ip=198.18.0.8 vendor=Dell install_disk=/dev/disk/by-path/pci-0000:67:00.0-scsi-0:2:0:0
a22-b13-000-r650 bmc_address=mgmt-a22-b13-000-r650.lab.redhat.com mac_address=aa:ee:bb:cc lab_mac=ee:ff:dd:bb:cc:60 ip=198.18.0.9 vendor=Dell install_disk=/dev/disk/by-path/pci-0000:67:00.0-scsi-0:2:0:0
a22-b14-000-r650 bmc_address=mgmt-a22-b14-000-r650.lab.redhat.com mac_address=aa:ee:bb:cc lab_mac=ee:ff:dd:bb:cc:10 ip=198.18.0.10 vendor=Dell install_disk=/dev/disk/by-path/pci-0000:67:00.0-scsi-0:2:0:0
vm00001 bmc_address=a22-b15-000-r650.lab.redhat.com ip=198.18.1.1 mac_address=52:54:00:00:00:01 domain_uuid=4a223905-a9fa-5aaa-974a-01d8f03aebf2 vendor=Libvirt install_disk=/dev/sda

[worker:vars]
...
lab_interface=eno12399np0
network_interface=eth0
...
```