### PR TITLE
Remove kube-burner download and re-try download tasks

### DIFF
--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -195,10 +195,13 @@
 - name: Get CoreDNS, OpenShift clients, opm, kube-burner, kube-burner-ocp, grpcurl, minio client, and yq
   get_url:
     validate_certs: false
-    force: true
     url: "{{ item.url }}"
     dest: "{{ item.dest }}"
     mode: "{{ item.mode | default('0644') }}"
+  retries: 3
+  delay: 10
+  register: download_result
+  until: download_result is not failed
   with_items:
   - url: "{{ coredns_url }}"
     dest: "{{ bastion_cluster_config_dir }}/coredns_linux_amd64.tgz"
@@ -220,6 +223,10 @@
     force: true
     url: "{{ item.url }}"
     dest: "{{ item.dest }}"
+  retries: 3
+  delay: 10
+  register: download_rhel8_result
+  until: download_rhel8_result is not failed
   with_items:
   - url: "{{ release_urls['ga'] }}/latest/opm-linux.tar.gz"
     dest: "{{ bastion_cluster_config_dir }}/opm-linux.tar.gz"
@@ -233,6 +240,10 @@
     force: true
     url: "{{ item.url }}"
     dest: "{{ item.dest }}"
+  retries: 3
+  delay: 10
+  register: download_rhel9_result
+  until: download_rhel9_result is not failed
   with_items:
   - url: "{{ release_urls['ga'] }}/latest/opm-linux-rhel9.tar.gz"
     dest: "{{ bastion_cluster_config_dir }}/opm-linux.tar.gz"


### PR DESCRIPTION
In CI we hit an issue while downloading kube-burner release. This PR is removing the kube-burner release download since this is covered outside jetlag and adds retries to the tasks which download pakages.

```
TASK [bastion-install : Get CoreDNS, OpenShift clients, opm, kube-burner, grpcurl, minio client, and yq] ***
Tuesday 24 February 2026 08:21:03 +0000 (0:00:00.033) 0:00:20.133 ****** 
ok: [XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX] => (item={'url': 'https://github.com/coredns/coredns/releases/download/v1.10.1/coredns_1.10.1_linux_amd64.tgz', 'dest': '/root/mno/coredns_linux_amd64.tgz'})
failed: [XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX] (item={'url': 'https://github.com/kube-burner/kube-burner/releases/download/v1.15.0/kube-burner-V1.15.0-linux-x86_64.tar.gz', 'dest': '/root/mno/kube-burner-linux.tar.gz'}) => {"ansible_loop_var": "item", "changed": false, "dest": "/root/mno/kube-burner-linux.tar.gz", "elapsed": 0, "gid": 0, "group": "root", "item": {"dest": "/root/mno/kube-burner-linux.tar.gz", "url": "https://github.com/kube-burner/kube-burner/releases/download/v1.15.0/kube-burner-V1.15.0-linux-x86_64.tar.gz"}, "mode": "0644", "msg": "Request failed", "owner": "root", "response": "HTTP Error 502: Bad Gateway or Proxy Error", "secontext": "system_u:object_r:admin_home_t:s0", "size": 36486634, "state": "file", "status_code": 502, "uid": 0, "url": "https://github.com/kube-burner/kube-burner/releases/download/v1.15.0/kube-burner-V1.15.0-linux-x86_64.tar.gz"}
ok: [XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX] => (item={'url': 'https://github.com/fullstorydev/grpcurl/releases/download/v1.8.1/grpcurl_1.8.1_linux_x86_64.tar.gz', 'dest': '/root/mno/grpcurl-linux.tar.gz'})
ok: [XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX] => (item={'url': 'https://dl.min.io/client/mc/release/linux-amd64/mc', 'dest': '/usr/local/bin/mc', 'mode': '0700'})
ok: [XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX] => (item={'url': 'https://github.com/mikefarah/yq/releases/download/v4.40.3/yq_linux_amd64.tar.gz', 'dest': '/root/mno/yq_linux_amd64.tar.gz'})
```