### PR TITLE
Skip calculating checksum on VM disk files, which takes an eternity.

### DIFF
--- a/ansible/roles/hv-vm-create/tasks/main.yml
+++ b/ansible/roles/hv-vm-create/tasks/main.yml
@@ -4,6 +4,7 @@
 - name: Check if vm disk file exists
   stat:
     path: "{{ hostvars[inventory_hostname]['disk_location'] }}/{{ inventory_hostname }}.qcow2"
+    get_checksum: false
   register: vm_disk_stat
 
 - name: Create vm disk


### PR DESCRIPTION
If all we want to do is verify whether the file exists, we can skip the checksum.
