### PR TITLE
Increase racreset retries to handle iDRAC instability after clear-jobs

### DIFF
--- a/ansible/roles/boot-iso/tasks/dell.yml
+++ b/ansible/roles/boot-iso/tasks/dell.yml
@@ -38,6 +38,8 @@
     badfish_password: "{{ hostvars[item]['bmc_password'] }}"
     badfish_args:
       - "--racreset"
+    retries: 15
+    delay: 10
     ignore_errors: true
   when: reset_idrac | bool
 


### PR DESCRIPTION
After --clear-jobs --force, the iDRAC can take up to ~2 minutes before its Redfish Systems endpoint responds again, causing --racreset to fail with "ComputerSystem's Members array is either empty or missing". Add retries (15) and delay (10s) to allow the iDRAC time to stabilize.


```
- WARNING  - Passing secrets via command line arguments can be unsafe. Consider using environment variables (BADFISH_USERNAME, BADFISH_PASSWORD).
- INFO     - Job queue for iDRAC mgmt-f19-h02-000-r640.rdu2.scalelab.redhat.com successfully cleared.
- WARNING  - Passing secrets via command line arguments can be unsafe. Consider using environment variables (BADFISH_USERNAME, BADFISH_PASSWORD).
- ERROR    - ComputerSystem's Members array is either empty or missing
Tue Mar  3 10:45:33 AM UTC 2026
Waiting for iDRAC to stabilize...
- WARNING  - Passing secrets via command line arguments can be unsafe. Consider using environment variables (BADFISH_USERNAME, BADFISH_PASSWORD).
- ERROR    - ComputerSystem's Members array is either empty or missing
Tue Mar  3 10:45:47 AM UTC 2026
Waiting for iDRAC to stabilize...
- WARNING  - Passing secrets via command line arguments can be unsafe. Consider using environment variables (BADFISH_USERNAME, BADFISH_PASSWORD).
- ERROR    - ComputerSystem's Members array is either empty or missing
Tue Mar  3 10:46:00 AM UTC 2026
Waiting for iDRAC to stabilize...
- WARNING  - Passing secrets via command line arguments can be unsafe. Consider using environment variables (BADFISH_USERNAME, BADFISH_PASSWORD).
- ERROR    - ComputerSystem's Members array is either empty or missing
Tue Mar  3 10:46:14 AM UTC 2026
Waiting for iDRAC to stabilize...
- WARNING  - Passing secrets via command line arguments can be unsafe. Consider using environment variables (BADFISH_USERNAME, BADFISH_PASSWORD).
- ERROR    - ComputerSystem's Members array is either empty or missing
Tue Mar  3 10:46:27 AM UTC 2026
Waiting for iDRAC to stabilize...
- WARNING  - Passing secrets via command line arguments can be unsafe. Consider using environment variables (BADFISH_USERNAME, BADFISH_PASSWORD).
- ERROR    - ComputerSystem's Members array is either empty or missing
Tue Mar  3 10:46:42 AM UTC 2026
Waiting for iDRAC to stabilize...
- WARNING  - Passing secrets via command line arguments can be unsafe. Consider using environment variables (BADFISH_USERNAME, BADFISH_PASSWORD).
- INFO     - Status code 204 returned for POST command to reset iDRAC.
- INFO     - iDRAC will now reset and be back online within a few minutes.
```