### PR TITLE
Decouple iDRAC clear-jobs and racreset into separate phases with proper waits

### DIFF
--- a/ansible/roles/boot-iso/tasks/dell-clear-jobs.yml
+++ b/ansible/roles/boot-iso/tasks/dell-clear-jobs.yml
@@ -1,0 +1,26 @@
+---
+# Dell tasks for clearing iDRAC job queue (fire for all hosts, then wait separately)
+
+  # ignore_errors: closessn is only available starting with iDRAC 9
+- name: "Dell - Close all existing iDRAC sessions for {{ item }}"
+  ansible.builtin.raw: >-
+    racadm closessn -a
+  delegate_to: "{{ hostvars[item]['bmc_address'] }}"
+  vars:
+    ansible_user: "{{ hostvars[item]['bmc_user'] }}"
+    ansible_password: "{{ hostvars[item]['bmc_password'] }}"
+    ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+  ignore_errors: true
+
+- name: "Dell - Clear iDRAC job queue for {{ item }} (badfish)"
+  ansible.builtin.include_role:
+    name: badfish
+    tasks_from: call
+  vars:
+    badfish_host: "{{ hostvars[item]['bmc_address'] }}"
+    badfish_user: "{{ hostvars[item]['bmc_user'] }}"
+    badfish_password: "{{ hostvars[item]['bmc_password'] }}"
+    badfish_args:
+      - "--clear-jobs"
+      - "--force"
+    ignore_errors: true

--- a/ansible/roles/boot-iso/tasks/dell-reset-idrac.yml
+++ b/ansible/roles/boot-iso/tasks/dell-reset-idrac.yml
@@ -1,0 +1,14 @@
+---
+# Dell tasks for resetting iDRAC (fire resets for all hosts, then wait separately)
+
+- name: "Dell - Reset iDRAC for {{ item }} (badfish)"
+  ansible.builtin.include_role:
+    name: badfish
+    tasks_from: call
+  vars:
+    badfish_host: "{{ hostvars[item]['bmc_address'] }}"
+    badfish_user: "{{ hostvars[item]['bmc_user'] }}"
+    badfish_password: "{{ hostvars[item]['bmc_password'] }}"
+    badfish_args:
+      - "--racreset"
+    ignore_errors: true

--- a/ansible/roles/boot-iso/tasks/dell-wait-clear-jobs.yml
+++ b/ansible/roles/boot-iso/tasks/dell-wait-clear-jobs.yml
@@ -1,0 +1,23 @@
+---
+# Dell tasks for waiting on iDRAC after clear-jobs
+# Clear-jobs triggers an LC reinit that temporarily empties the ComputerSystem
+# Members array (~10s to start, ~70s to recover). Poll until recovered.
+
+- name: "Dell - Wait for ComputerSystem ready after clear-jobs for {{ item }}"
+  ansible.builtin.uri:
+    url: "https://{{ hostvars[item]['bmc_address'] }}/redfish/v1/Systems"
+    user: "{{ hostvars[item]['bmc_user'] }}"
+    password: "{{ hostvars[item]['bmc_password'] }}"
+    method: GET
+    headers:
+      content-type: application/json
+      Accept: application/json
+    validate_certs: false
+    return_content: true
+  register: systems_ready
+  until: >-
+    systems_ready.status == 200 and
+    (systems_ready.json['Members@odata.count'] | default(0) | int) >= 1
+  retries: 40
+  delay: 15
+  failed_when: false

--- a/ansible/roles/boot-iso/tasks/dell-wait-idrac.yml
+++ b/ansible/roles/boot-iso/tasks/dell-wait-idrac.yml
@@ -1,0 +1,20 @@
+---
+# Dell tasks for waiting on iDRAC availability after racreset
+# Poll until Redfish API is responding.
+
+- name: "Dell - Wait for iDRAC Redfish ready after racreset for {{ item }}"
+  ansible.builtin.uri:
+    url: "https://{{ hostvars[item]['bmc_address'] }}/redfish/v1"
+    user: "{{ hostvars[item]['bmc_user'] }}"
+    password: "{{ hostvars[item]['bmc_password'] }}"
+    method: GET
+    headers:
+      content-type: application/json
+      Accept: application/json
+    validate_certs: false
+    status_code: [200, 201, 301, 302]
+  register: redfish_result
+  until: redfish_result.status in [200, 201, 301, 302]
+  retries: 40
+  delay: 15
+  failed_when: false

--- a/ansible/roles/boot-iso/tasks/dell.yml
+++ b/ansible/roles/boot-iso/tasks/dell.yml
@@ -5,20 +5,6 @@
   ansible.builtin.set_fact:
     _virtual_media_iso: "{{ virtual_media_iso | default(hostvars[item]['boot_iso']) }}"
 
-- name: "Dell - Clear iDrac job queue for {{ item }} (badfish)"
-  ansible.builtin.include_role:
-    name: badfish
-    tasks_from: call
-  vars:
-    badfish_host: "{{ hostvars[item]['bmc_address'] }}"
-    badfish_user: "{{ hostvars[item]['bmc_user'] }}"
-    badfish_password: "{{ hostvars[item]['bmc_password'] }}"
-    badfish_args:
-      - "--clear-jobs"
-      - "--force"
-    ignore_errors: true
-  when: reset_idrac | bool
-
 - name: "Dell - Power down machine prior to booting iso for {{ item }}"
   ansible.builtin.command:
     cmd: >-
@@ -28,21 +14,6 @@
   ignore_errors: true
   register: ipmi_poweroff
 
-- name: "Dell - Reset iDRAC for {{ item }} (badfish)"
-  ansible.builtin.include_role:
-    name: badfish
-    tasks_from: call
-  vars:
-    badfish_host: "{{ hostvars[item]['bmc_address'] }}"
-    badfish_user: "{{ hostvars[item]['bmc_user'] }}"
-    badfish_password: "{{ hostvars[item]['bmc_password'] }}"
-    badfish_args:
-      - "--racreset"
-    retries: 15
-    delay: 10
-    ignore_errors: true
-  when: reset_idrac | bool
-
 - name: "Dell - Wait for power down for {{ item }}"
   ansible.builtin.wait_for:
     port: 22
@@ -51,29 +22,6 @@
     host: "{{ hostvars[item]['ansible_host'] | default(hostvars[item]['inventory_hostname']) }}"
     timeout: 60
   when: not ipmi_poweroff.failed
-
-- name: "Ensure iDRAC reset order is passed for {{ item }}"
-  when: reset_idrac | bool
-  ansible.builtin.pause:
-    seconds: 30
-
-- name: "Dell - Wait for iDRAC to be available for {{ item }}"
-  ansible.builtin.uri:
-    url: "https://{{ hostvars[item]['bmc_address'] }}/redfish/v1"
-    user: "{{ hostvars[item]['bmc_user'] }}"
-    password: "{{ hostvars[item]['bmc_password'] }}"
-    method: GET
-    headers:
-      content-type: application/json
-      Accept: application/json
-    validate_certs: false
-    status_code: [200, 201, 301, 302]
-  register: racreset_result
-  until: racreset_result.status in [200, 201, 301, 302]
-  retries: 60
-  delay: 5
-  failed_when: false
-  when: reset_idrac | bool  
 
 - name: "Dell - Check for Virtual Media for {{ item }}"
   ansible.builtin.uri:

--- a/ansible/roles/boot-iso/tasks/main.yml
+++ b/ansible/roles/boot-iso/tasks/main.yml
@@ -1,6 +1,43 @@
 ---
 # boot-iso tasks
 
+- name: Dell iDRAC clear-jobs and reset
+  when: reset_idrac | bool
+  block:
+    - name: Dell - Clear iDRAC job queue
+      include_tasks: dell-clear-jobs.yml
+      with_items:
+        - "{{ groups[inventory_group][offset|int:index|int] }}"
+      when: hostvars[item]['vendor'] == 'Dell'
+
+    - name: Dell - Pause for LC reinit to start after clear-jobs
+      ansible.builtin.pause:
+        seconds: 30
+      when: groups[inventory_group][offset|int:index|int] | map('extract', hostvars, 'vendor') | select('equalto', 'Dell') | list | length > 0
+
+    - name: Dell - Wait for iDRAC after clear-jobs
+      include_tasks: dell-wait-clear-jobs.yml
+      with_items:
+        - "{{ groups[inventory_group][offset|int:index|int] }}"
+      when: hostvars[item]['vendor'] == 'Dell'
+
+    - name: Dell - Reset iDRAC
+      include_tasks: dell-reset-idrac.yml
+      with_items:
+        - "{{ groups[inventory_group][offset|int:index|int] }}"
+      when: hostvars[item]['vendor'] == 'Dell'
+
+    - name: Dell - Pause for iDRAC to start resetting
+      ansible.builtin.pause:
+        seconds: 30
+      when: groups[inventory_group][offset|int:index|int] | map('extract', hostvars, 'vendor') | select('equalto', 'Dell') | list | length > 0
+
+    - name: Dell - Wait for iDRAC after reset
+      include_tasks: dell-wait-idrac.yml
+      with_items:
+        - "{{ groups[inventory_group][offset|int:index|int] }}"
+      when: hostvars[item]['vendor'] == 'Dell'
+
 - name: Boot iso on dell hardware
   include_tasks: dell.yml
   with_items:


### PR DESCRIPTION
Decouples iDRAC clear-jobs and racreset out of dell.yml (which ran per-host sequentially) into separate task files with a phased model in main.yml. Each phase fires across all hosts before moving to the next, avoiding the previous pattern where each host waited through the full clear-jobs → pause → racreset → wait cycle before the next host could start.