### PR TITLE
Remove assisted-service pod before recreation to pick up config changes

### DIFF
--- a/ansible/roles/bastion-assisted-installer/tasks/main.yml
+++ b/ansible/roles/bastion-assisted-installer/tasks/main.yml
@@ -74,18 +74,16 @@
   - src: nginx-ui.conf
     dest: /opt/assisted-service/nginx-ui.conf
 
+- name: Remove existing assisted-service pod to pick up configuration changes
+  containers.podman.podman_pod:
+    name: assisted-service
+    state: absent
+
 - name: Create assisted-service pod
   containers.podman.podman_pod:
     name: assisted-service
     network: host
     state: started
-
-# On a reboot "started" state does not start an exited pod (why..idk)
-- name: Ensure assisted-service pod is up
-  containers.podman.podman_pod:
-    name: assisted-service
-    network: host
-    state: restarted
 
 - name: Create database container in assisted-service pod
   containers.podman.podman_container:


### PR DESCRIPTION
## Summary

When re-running `setup-bastion.yml` with different network configuration (e.g., switching from IPv4 to IPv6), the assisted-service containers kept the old environment. The pod restart + container `state: started` pattern did not force container recreation with the updated `onprem-environment` file.

This replaces the create+restart pattern with an explicit remove+create cycle, ensuring containers are always created fresh with the current configuration.

Fixes #765

## Test Plan
- [ ] `deploy-sno` — standard IPv4 deployment (regression test)
- [ ] `deploy-sno-reconfig-ipv6` — IPv4 deploy followed by IPv6 redeploy on same bastion (requires openshift/release companion PR)

## Changes
- Remove the `state: started` + `state: restarted` two-step pod creation
- Add `state: absent` task before pod creation to ensure old containers are fully removed
- New pod and containers are created fresh with the current `onprem-environment` config

## Cross-Repo
This PR requires a companion PR in `openshift/release` to add the `deploy-sno-reconfig-ipv6` test job with a `REDEPLOY_IPV6` env var that exercises the IPv4→IPv6 reconfiguration path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pod lifecycle now always removes the existing service instance before recreating it during deployment, ensuring a clean start so configuration changes are reliably applied and stale state doesn't persist across reboots or restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->