### PR TITLE
Add agentic skills for fixing Jetlag GH issues and testing them in Prow jobs

### DIFF
--- a/.claude/commands/jetlag-issue-fix.md
+++ b/.claude/commands/jetlag-issue-fix.md
@@ -7,6 +7,13 @@ You are the orchestrator for the Jetlag issue-to-fix-to-test workflow. You drive
 
 **IMPORTANT**: This workflow has mandatory human gates. NEVER proceed past a gate without explicit user confirmation.
 
+## Related Skills
+
+This orchestrator delegates to three companion skills via the Skill tool:
+- **`/jetlag-test-map`** — Maps changed files to Prow test jobs (used in Phase 2)
+- **`/jetlag-prow-trigger`** — Triggers tests and polls for results (used in Phase 4)
+- **`/jetlag-prow-analyze`** — Analyzes failed Prow job logs (used in Phase 5)
+
 ## Input
 
 - `$ARGUMENTS` — GitHub issue number or URL from `redhat-performance/jetlag`
@@ -49,10 +56,11 @@ You are the orchestrator for the Jetlag issue-to-fix-to-test workflow. You drive
 ## Phase 2: PLAN
 
 1. Identify the files to change and what changes are needed
-2. Determine which Prow test jobs cover the change (apply test-map logic):
-   - Map changed files to test jobs using the mapping from `/jetlag-test-map`
-   - Check for feature modifiers (bond, public_vlan, hybrid, vmno)
-   - Check for cross-repo needs (new variables)
+2. Determine which Prow test jobs cover the change by invoking `/jetlag-test-map`:
+   - Use the Skill tool to run `/jetlag-test-map` with the list of files you plan to change
+   - This returns: minimum tests, extra coverage, feature-specific tests, and cross-repo flags
+   - Review its output for feature modifiers (bond, public_vlan, hybrid, vmno)
+   - Review its output for cross-repo needs (new variables requiring openshift/release changes)
 
 3. **HUMAN GATE 2**: Present the fix plan:
    ```
@@ -131,16 +139,11 @@ Trigger `deploy-sno` now? (bare-metal CI, ~1-2 hours)
 WAIT for user confirmation.
 
 ### Standard Flow (existing test covers the change)
-1. Trigger the test:
-   ```
-   gh pr comment <PR#> --repo redhat-performance/jetlag --body "/test <job-name>"
-   ```
-2. Poll for results (every 5 minutes, 3-hour timeout):
-   ```
-   gh api repos/redhat-performance/jetlag/commits/<SHA>/statuses \
-     --jq '[.[] | select(.context | contains("<job>"))] | first | {state, target_url, description}'
-   ```
-3. Report progress inline to the user
+Use the Skill tool to invoke `/jetlag-prow-trigger <PR#> <job-name>` which handles:
+1. Triggering the test via `/test <job-name>` PR comment
+2. Polling commit statuses every 5 minutes (3-hour timeout)
+3. Reporting progress inline
+4. Returning the final result with Prow URL and log excerpts on failure
 
 ### Cross-Repo Flow (new feature needs test job changes)
 If the test-map flagged cross-repo needs:
@@ -203,12 +206,14 @@ Recommend: `/retest <job>`
 Do NOT count infra errors toward the 3-iteration limit.
 
 ### Code Failure
+Use the Skill tool to invoke `/jetlag-prow-analyze <prow-url>` with the Prow URL from the trigger result. This returns a structured report with root cause classification, failed task/role, log excerpts, and correlation with PR changes.
+
 **HUMAN GATE 4**: Present failure analysis and proposed revision:
 ```
 ## Test Failed: <job>
 
 ### Root Cause
-<analysis from log examination>
+<analysis from /jetlag-prow-analyze output>
 
 ### Failed Task
 <role>/<task> on <host>: <error>

--- a/.claude/commands/jetlag-issue-fix.md
+++ b/.claude/commands/jetlag-issue-fix.md
@@ -1,0 +1,243 @@
+---
+description: Full issue-to-fix-to-test loop for Jetlag
+argument-hint: "<issue#>"
+---
+
+You are the orchestrator for the Jetlag issue-to-fix-to-test workflow. You drive the full loop from reading an issue to implementing a fix, creating a PR, triggering CI tests, and iterating on failures.
+
+**IMPORTANT**: This workflow has mandatory human gates. NEVER proceed past a gate without explicit user confirmation.
+
+## Input
+
+- `$ARGUMENTS` — GitHub issue number or URL from `redhat-performance/jetlag`
+
+## Phase 1: UNDERSTAND
+
+1. Fetch the issue:
+   ```
+   gh issue view <number> --repo redhat-performance/jetlag --json title,body,labels,comments
+   ```
+
+2. Extract key information:
+   - Error messages or tracebacks
+   - Cluster type affected (MNO, SNO, VMNO, hybrid)
+   - Lab environment (scalelab, performancelab, ibmcloud)
+   - Hardware type (r750, r660, r650, r640, etc.)
+   - File or role references
+   - OCP version or build type
+   - Any reproduction steps
+
+3. Explore referenced code paths in the repo:
+   - Read the files/roles mentioned in the issue
+   - Understand the current behavior and what's expected
+   - Check git blame for recent changes that may have caused the issue
+
+4. **HUMAN GATE 1**: Present your analysis to the user:
+   ```
+   ## Issue #<N> Analysis
+
+   **Title**: <title>
+   **Problem**: <one-line summary>
+   **Affected**: <cluster type, lab, hardware>
+   **Root Cause**: <your assessment>
+   **Affected Files**: <list>
+
+   Shall I proceed with planning a fix?
+   ```
+   WAIT for user confirmation before proceeding.
+
+## Phase 2: PLAN
+
+1. Identify the files to change and what changes are needed
+2. Determine which Prow test jobs cover the change (apply test-map logic):
+   - Map changed files to test jobs using the mapping from `/jetlag-test-map`
+   - Check for feature modifiers (bond, public_vlan, hybrid, vmno)
+   - Check for cross-repo needs (new variables)
+
+3. **HUMAN GATE 2**: Present the fix plan:
+   ```
+   ## Fix Plan for Issue #<N>
+
+   ### Code Changes
+   1. `<file>`: <description of change>
+   2. `<file>`: <description of change>
+
+   ### Test Plan
+   - Minimum: `deploy-sno`
+   - Extra: `deploy-mno`
+   - Cross-repo: <yes/no>
+
+   ### Branch
+   fix/issue-<N>-<short-desc>
+
+   Shall I implement this fix?
+   ```
+   WAIT for user confirmation before proceeding.
+
+## Phase 3: IMPLEMENT
+
+1. Create a branch:
+   ```
+   git checkout -b fix/issue-<N>-<short-desc> main
+   ```
+
+2. Make the code changes as planned
+
+3. Commit:
+   ```
+   git add <specific files>
+   git commit -m "<description>
+
+   Fixes #<N>
+
+   Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+   ```
+
+4. Push:
+   ```
+   git push -u origin fix/issue-<N>-<short-desc>
+   ```
+
+5. Create PR:
+   ```
+   gh pr create --repo redhat-performance/jetlag \
+     --title "<concise title>" \
+     --body "## Summary
+   <description of the fix>
+
+   Fixes #<N>
+
+   ## Test Plan
+   - [ ] `<job1>` — <why this test>
+   - [ ] `<job2>` — <why this test>
+
+   ## Changes
+   <bullet list of changes>
+   "
+   ```
+
+## Phase 4: TEST
+
+**HUMAN GATE 3**: Before triggering any test, confirm with the user:
+```
+PR #<PR#> created. Ready to trigger tests.
+
+Recommended test order:
+1. `deploy-sno` (fastest, covers core changes)
+2. `deploy-mno` (if applicable)
+
+Trigger `deploy-sno` now? (bare-metal CI, ~1-2 hours)
+```
+WAIT for user confirmation.
+
+### Standard Flow (existing test covers the change)
+1. Trigger the test:
+   ```
+   gh pr comment <PR#> --repo redhat-performance/jetlag --body "/test <job-name>"
+   ```
+2. Poll for results (every 5 minutes, 3-hour timeout):
+   ```
+   gh api repos/redhat-performance/jetlag/commits/<SHA>/statuses \
+     --jq '[.[] | select(.context | contains("<job>"))] | first | {state, target_url, description}'
+   ```
+3. Report progress inline to the user
+
+### Cross-Repo Flow (new feature needs test job changes)
+If the test-map flagged cross-repo needs:
+1. Create the Jetlag PR first (Phase 3 above)
+2. Inform the user about the cross-repo requirement:
+   ```
+   This change requires a companion PR in openshift/release to add/modify a test job.
+
+   Key files to modify:
+   - ci-operator/config/redhat-performance/jetlag/redhat-performance-jetlag-main.yaml
+   - ci-operator/step-registry/openshift-qe/installer/bm/deploy/openshift-qe-installer-bm-deploy-ref.yaml
+   - ci-operator/step-registry/openshift-qe/installer/bm/deploy/openshift-qe-installer-bm-deploy-commands.sh
+
+   The companion PR should set:
+     JETLAG_PR: "<jetlag-PR-number>"
+     JETLAG_LATEST: "true"
+
+   Shall I draft the openshift/release changes?
+   ```
+3. If user confirms, provide the YAML/script snippets for the openshift/release PR
+4. The user creates and triggers tests from the openshift/release PR
+5. After the Jetlag PR merges, remind the user to update the openshift/release PR to remove `JETLAG_PR`
+
+## Phase 5: EVALUATE
+
+On test completion:
+
+### Pass
+- Update the PR body to check off the passed test
+- If more tests are recommended, ask user about triggering the next one
+- When all tests pass:
+  ```
+  All tests passed for PR #<PR#>!
+
+  Results:
+  - deploy-sno: PASSED
+  - deploy-mno: PASSED
+
+  The PR is ready for review. A maintainer can /lgtm and /approve.
+  (I will NOT merge — that's for humans.)
+  ```
+
+### Infra Error
+If the failure is in infrastructure steps (ping, poweroff, BMC):
+```
+Infra error detected in `<step>`. This is a hardware/network flake, not a code issue.
+Recommend: `/retest <job>`
+```
+Do NOT count infra errors toward the 3-iteration limit.
+
+### Code Failure
+**HUMAN GATE 4**: Present failure analysis and proposed revision:
+```
+## Test Failed: <job>
+
+### Root Cause
+<analysis from log examination>
+
+### Failed Task
+<role>/<task> on <host>: <error>
+
+### Proposed Fix
+<description of what to change>
+
+### Iteration
+This is attempt <N>/3.
+
+Shall I push a fix and re-test?
+```
+WAIT for user confirmation.
+
+If confirmed:
+1. Make the fix
+2. Add a new commit (NEVER force-push or amend)
+3. Push
+4. Re-trigger the test
+5. Resume polling
+
+### Escalation
+After 3 failed iterations:
+```
+3 attempts have failed. Escalating to human review.
+
+Iteration history:
+1. <what was tried> → <what failed>
+2. <what was tried> → <what failed>
+3. <what was tried> → <what failed>
+
+The PR remains open for manual investigation.
+```
+
+## Safety Rails
+
+- **Max 3 fix iterations** before escalating to human
+- **Max 3-hour timeout** per test job
+- **Never trigger >1 test simultaneously** (bare-metal hardware constraint)
+- **Always add new commits** — never force-push, never amend published commits
+- **Always reference issue number** in commits and PR body
+- **NEVER merge** — present results and let humans /lgtm + /approve
+- **NEVER skip human gates** — always wait for explicit confirmation

--- a/.claude/commands/jetlag-issue-fix.md
+++ b/.claude/commands/jetlag-issue-fix.md
@@ -160,8 +160,19 @@ If the test-map flagged cross-repo needs:
 
    Shall I draft the openshift/release changes?
    ```
-3. If user confirms, provide the YAML/script snippets for the openshift/release PR
-4. The user creates and triggers tests from the openshift/release PR
+3. If user confirms, create the companion PR in openshift/release:
+   - Clone upstream: `git clone --depth=1 --branch=main https://github.com/openshift/release.git`
+   - Add user's fork as remote: `git remote add fork git@github.com:<user>/release.git`
+   - Make changes on a new branch
+   - **CRITICAL**: Before committing, run the required generators from the repo root:
+     ```
+     make ci-operator-config    # determinizes ci-operator config YAML (sorts keys, normalizes)
+     make jobs                  # regenerates prow job configs from ci-operator configs
+     ```
+     These generate/update files in `ci-operator/jobs/` and normalize `ci-operator/config/`.
+     The PR will fail `ci-operator-config-metadata` and `generated-config` checks without this.
+   - Commit all changes (including generated files), push to fork, create PR against openshift/release
+4. Trigger tests from the openshift/release PR
 5. After the Jetlag PR merges, remind the user to update the openshift/release PR to remove `JETLAG_PR`
 
 ## Phase 5: EVALUATE

--- a/.claude/commands/jetlag-prow-analyze.md
+++ b/.claude/commands/jetlag-prow-analyze.md
@@ -1,0 +1,139 @@
+---
+description: Analyze failed Prow job logs for Jetlag
+argument-hint: "<prow-url>"
+---
+
+You analyze failed Prow CI job logs for Jetlag deployments, identifying root causes and suggesting fixes.
+
+## Input
+
+- `$ARGUMENTS` — Prow job URL
+- Example: `https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/redhat-performance_jetlag/123/pull-ci-redhat-performance-jetlag-main-deploy-sno/1234567890`
+
+## Step 1: Parse the URL
+
+Extract from the Prow URL:
+- PR number (from path)
+- Job name (e.g., `deploy-sno`, `deploy-mno`)
+- Run ID (build number)
+- GCS base path
+
+Construct the GCS web URL:
+```
+https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/
+pr-logs/pull/redhat-performance_jetlag/<PR>/
+pull-ci-redhat-performance-jetlag-main-<job>/<run-id>/
+```
+
+## Step 2: Fetch Artifacts
+
+Use WebFetch to download key artifacts from GCS:
+
+1. **`finished.json`** — overall result and timestamp
+2. **`build-log.txt`** — full build log (may be large; fetch and scan for failures)
+3. **Step-level logs** — check `artifacts/<step-name>/build-log.txt` for individual steps:
+   - `openshift-qe-installer-bm-deploy` — the main deployment step
+   - Other steps as indicated by `finished.json`
+
+If the URL is for a periodic/batch job (not a PR), adjust the GCS path accordingly (use `logs/` instead of `pr-logs/pull/`).
+
+## Step 3: Identify Failure Point
+
+Scan `build-log.txt` for these Ansible failure patterns (in priority order):
+
+1. **`fatal: [hostname]: FAILED!`** → Extract:
+   - The task name (from `TASK [role : task name]` line above)
+   - The error `msg:` field
+   - The host that failed
+
+2. **`PLAY RECAP`** with `failed>0` → Which host(s) failed and at which play
+
+3. **`MODULE FAILURE`** → Module-level crash with traceback
+
+4. **`ERROR!`** → Ansible-level errors (syntax, undefined variable, unreachable host)
+
+5. **Non-Ansible failures**:
+   - `error: `  or `Error:` lines
+   - Python tracebacks
+   - Shell command failures (exit code != 0)
+
+## Step 4: Correlate with PR Changes
+
+If this is a PR job:
+1. Get the PR's changed files: `gh pr diff <PR#> --name-only --repo redhat-performance/jetlag`
+2. Compare the failed task/role against the changed files
+3. Classify:
+   - **Changed code failure**: The failed task/role is in files modified by the PR → likely our bug
+   - **Unrelated failure**: The failed task/role is NOT in files modified by the PR → pre-existing issue or infra
+   - **Infra failure**: Failure in hardware/network operations (ping, poweroff, BMC reset, IPMI) → infra flake
+
+## Step 5: Classify and Recommend
+
+### Classification Categories
+
+**Code Bug** (failure in changed code):
+- Identify the exact task and error
+- Show the relevant code from the PR diff
+- Suggest a specific fix
+- Recommend: push fix commit, re-test
+
+**Pre-existing Bug** (failure in unchanged code):
+- Note that this failure is NOT caused by the PR
+- Check if there's a known issue for this failure
+- Recommend: file separate issue, `/retest` to confirm it's unrelated
+
+**Infra Flake** (hardware/network):
+Indicators:
+- Failed task involves: `ping`, `poweroff`, `ipmitool`, `racadm`, `badfish`, BMC operations
+- Error messages: `unreachable`, `timed out`, `connection refused`, `No route to host`
+- Failure in `boot-iso` role during virtual media attachment
+Recommend: `/retest <job>` — don't count as code failure
+
+**Timeout**:
+- Cluster install exceeded time limit
+- Hosts not discovered within timeout
+- Recommend: check if PR introduces slower operations, or `/retest`
+
+**Configuration Error**:
+- Undefined variable, missing file, bad YAML syntax
+- Usually a code bug in the PR
+- Recommend: fix the syntax/variable issue
+
+## Step 6: Leverage Existing Prow Skills
+
+For deeper analysis, delegate to existing prow-job skills where applicable:
+- Use `/prow-job:analyze-test-failure` patterns for structured test failure analysis
+- Use `/prow-job:extract-must-gather` patterns if must-gather artifacts are available
+- Use `/prow-job:analyze-resource` patterns for resource lifecycle issues
+
+## Output Format
+
+Present the analysis as:
+
+```
+## Prow Job Failure Analysis
+
+**Job**: <job-name>
+**PR**: #<PR#>
+**Run**: <run-id>
+**Result**: FAILED
+
+### Root Cause
+<Classification>: <one-line summary>
+
+### Failed Task
+- **Role**: <role-name>
+- **Task**: <task-name>
+- **Host**: <hostname>
+- **Error**: <error message>
+
+### Log Excerpt
+(relevant 20-30 lines around the failure)
+
+### Correlation with PR
+<Whether the failure is in changed code, unrelated code, or infra>
+
+### Recommendation
+<Specific action: fix code, retest, file issue, etc.>
+<If code fix: show the suggested change>
+```

--- a/.claude/commands/jetlag-prow-analyze.md
+++ b/.claude/commands/jetlag-prow-analyze.md
@@ -101,10 +101,15 @@ Recommend: `/retest <job>` — don't count as code failure
 
 ## Step 6: Leverage Existing Prow Skills
 
-For deeper analysis, delegate to existing prow-job skills where applicable:
-- Use `/prow-job:analyze-test-failure` patterns for structured test failure analysis
-- Use `/prow-job:extract-must-gather` patterns if must-gather artifacts are available
-- Use `/prow-job:analyze-resource` patterns for resource lifecycle issues
+For deeper OCP-level analysis beyond Ansible failures, delegate to the `prow-job:*` skills
+from [openshift-eng/ai-helpers](https://github.com/openshift-eng/ai-helpers) (if installed):
+- `/prow-job:analyze-test-failure` — structured test failure analysis from JUnit and console logs
+- `/prow-job:extract-must-gather` — extract and browse must-gather archives from job artifacts
+- `/prow-job:analyze-resource` — Kubernetes resource lifecycle analysis from audit/pod logs
+
+These are generic OpenShift CI tools, not Ansible-aware. Use them when the failure is in
+OCP cluster operations (operator failures, resource issues) rather than in Jetlag's Ansible
+playbooks. This skill's own Ansible-focused parsing (Steps 3-5) handles the common case.
 
 ## Output Format
 

--- a/.claude/commands/jetlag-prow-trigger.md
+++ b/.claude/commands/jetlag-prow-trigger.md
@@ -1,0 +1,118 @@
+---
+description: Trigger Prow tests on a PR and monitor results
+argument-hint: "<PR#> [job-name]"
+---
+
+You trigger and monitor Prow CI test jobs on Jetlag PRs.
+
+## Input
+
+- `$ARGUMENTS` — PR number, optionally followed by job name(s)
+- Formats:
+  - `123 deploy-sno` — trigger `deploy-sno` on jetlag PR #123
+  - `123` — auto-detect jobs via test-map logic, then trigger
+  - `--release-pr 456 deploy-foo` — trigger on an openshift/release PR
+
+## Parse Arguments
+
+1. Check if `$ARGUMENTS` starts with `--release-pr`:
+   - If yes: target repo is `openshift/release`, PR number and job follow
+   - If no: target repo is `redhat-performance/jetlag`
+2. Extract PR number and optional job name(s)
+3. If no job name provided, get the changed files from the PR and apply the test-map logic (from `/jetlag-test-map`) to determine which jobs to run. Present the list and ask the user to confirm which job to trigger first.
+
+## Pre-flight Checks
+
+1. Get HEAD SHA:
+   ```
+   gh pr view <PR#> --repo <target-repo> --json headRefOid --jq '.headRefOid'
+   ```
+
+2. Check for `ok-to-test` label (required for non-org members):
+   ```
+   gh pr view <PR#> --repo <target-repo> --json labels --jq '.labels[].name'
+   ```
+   If missing and needed, inform the user that an org member must add `/ok-to-test`.
+
+3. Check current status — a test may already be running or completed:
+   ```
+   gh api repos/<target-repo>/commits/<SHA>/statuses \
+     --jq '[.[] | select(.context | contains("<job>"))] | first | {state, target_url, description}'
+   ```
+   If a test is already running, ask the user if they want to wait for it or trigger a new one.
+
+## Trigger
+
+**IMPORTANT**: Ask the user for confirmation before triggering. Bare-metal CI jobs are expensive and take 1-2 hours.
+
+Comment on the PR to trigger:
+```
+gh pr comment <PR#> --repo <target-repo> --body "/test <job-name>"
+```
+
+Only trigger ONE job at a time (bare-metal hardware constraint — only one test can run simultaneously).
+
+## Monitor
+
+After triggering, poll for results interactively. Stay active and report progress inline.
+
+**Poll loop**:
+1. Wait 2 minutes for the initial status to appear
+2. Then poll every 5 minutes:
+   ```
+   gh api repos/<owner>/<repo>/commits/<SHA>/statuses \
+     --jq '[.[] | select(.context | contains("<job>"))] | first | {state, target_url, description, updated_at}'
+   ```
+3. Report each poll result to the user:
+   - `pending` → "Test still running... (elapsed: Xm)"
+   - `success` → "Test PASSED"
+   - `failure` → "Test FAILED — analyzing..."
+   - `error` → "Test ERROR (infra issue)"
+4. Timeout after 3 hours — inform user and stop polling
+
+## On Completion
+
+### Success
+Report: "Test `<job>` passed on PR #<PR#>."
+If there are additional recommended tests from the test-map, ask the user if they want to trigger the next one.
+
+### Failure
+1. Extract the Prow URL from the status `target_url`
+2. Derive the GCS artifacts path:
+   ```
+   https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/
+   pr-logs/pull/redhat-performance_jetlag/<PR>/
+   pull-ci-redhat-performance-jetlag-main-<job>/<run-id>/
+   ```
+3. Fetch `finished.json` to confirm the failure
+4. Fetch `build-log.txt` of the failed step
+5. Present a summary:
+   ```
+   ## Test Failed: <job> on PR #<PR#>
+
+   **Prow URL**: <url>
+   **Failed Step**: <step-name>
+   **Log excerpt**: (last 50 relevant lines)
+
+   Run `/jetlag-prow-analyze <prow-url>` for detailed analysis.
+   ```
+
+### Error (infra)
+If the failure is in infrastructure steps (ping, poweroff, BMC access), classify it as an infra flake:
+```
+Infra error detected (failed in <step>). This is likely a hardware/network flake, not a code issue.
+Suggest: `/retest <job>` or wait and retry.
+```
+
+## Output
+
+Return a structured result:
+```
+Job: <job-name>
+PR: #<PR#>
+Result: success | failure | error | timeout
+Prow URL: <url>
+Failed Step: <step-name> (if applicable)
+Log Excerpt: (if applicable)
+Elapsed: <duration>
+```

--- a/.claude/commands/jetlag-prow-trigger.md
+++ b/.claude/commands/jetlag-prow-trigger.md
@@ -13,6 +13,11 @@ You trigger and monitor Prow CI test jobs on Jetlag PRs.
   - `123` — auto-detect jobs via test-map logic, then trigger
   - `--release-pr 456 deploy-foo` — trigger on an openshift/release PR
 
+**Note on openshift/release PRs**: When creating companion PRs in openshift/release,
+you must run `make ci-operator-config` and `make jobs` before pushing to regenerate
+config metadata and prow job files. Without this, `ci-operator-config-metadata` and
+`generated-config` checks will fail and the test job won't be triggerable.
+
 ## Parse Arguments
 
 1. Check if `$ARGUMENTS` starts with `--release-pr`:

--- a/.claude/commands/jetlag-test-map.md
+++ b/.claude/commands/jetlag-test-map.md
@@ -66,6 +66,13 @@ If a new variable is found that gates behavior and is NOT in the above list:
 - Provide a draft YAML snippet showing the new test entry for `ci-operator/config/redhat-performance/jetlag/redhat-performance-jetlag-main.yaml`
 - Provide a draft env var declaration for `openshift-qe-installer-bm-deploy-ref.yaml`
 - Provide the script modification needed in `openshift-qe-installer-bm-deploy-commands.sh`
+- **IMPORTANT**: Note that after making changes to openshift/release, these generators must be run from the repo root before pushing:
+  ```
+  make ci-operator-config    # determinizes config YAML (sorts keys, normalizes)
+  make jobs                  # regenerates prow job configs from ci-operator configs
+  ```
+  Without this, the PR will fail `ci-operator-config-metadata` and `generated-config` checks.
+  Both commands require `podman` (or `docker`) and pull CI tooling images.
 
 ## Output Format
 

--- a/.claude/commands/jetlag-test-map.md
+++ b/.claude/commands/jetlag-test-map.md
@@ -1,0 +1,95 @@
+---
+description: Map changed files to Prow test jobs
+argument-hint: "[PR#]"
+---
+
+You are a test selection engine for the Jetlag project. Given a set of changed files, you determine which Prow CI test jobs should be triggered.
+
+## Input
+
+- `$ARGUMENTS` — optional PR number or file list
+- If a PR number is given: run `gh pr diff $ARGUMENTS --name-only --repo redhat-performance/jetlag` to get the changed files
+- If no argument: run `git diff --name-only main` to get changed files from the current branch
+- If a comma-separated file list is given: use those files directly
+
+## Core Mapping Table
+
+Apply these rules to each changed file path. Collect all matching jobs (deduplicated).
+
+| Changed Path Pattern | Minimum Test | Extra Coverage |
+|---|---|---|
+| `ansible/roles/bastion-*/**` | `deploy-sno` | `deploy-mno` |
+| `ansible/roles/create-inventory/**` | `deploy-sno` | `deploy-mno` |
+| `ansible/roles/validate-vars/**` | `deploy-sno` | `deploy-mno` |
+| `ansible/roles/install-cluster/**` | `deploy-sno` | `deploy-mno` |
+| `ansible/roles/boot-iso/**` | `deploy-sno` | `deploy-mno` |
+| `ansible/roles/wait-hosts-discovered/**` | `deploy-sno` | `deploy-mno` |
+| `ansible/roles/create-ai-cluster/**` | `deploy-sno` | `deploy-mno` |
+| `ansible/roles/generate-discovery-iso/**` | `deploy-sno` | `deploy-mno` |
+| `ansible/roles/sno-post-cluster-install/**` | `deploy-sno` | — |
+| `ansible/roles/mno-post-cluster-install/**` | `deploy-mno` | `deploy-cmno` |
+| `ansible/roles/hv-*/**` | `deploy-vmno` | `deploy-hmno` |
+| `ansible/roles/ocp-scale-out*/**` | `deploy-mno-scaleout` | `deploy-sno-scaleout` |
+| `ansible/roles/badfish/**` | `deploy-sno` | `deploy-mno` |
+| `ansible/mno-deploy.yml` | `deploy-mno` | `deploy-cmno` |
+| `ansible/sno-deploy.yml` | `deploy-sno` | — |
+| `ansible/hv-setup.yml` or `ansible/hv-vm-create.yml` | `deploy-vmno` | `deploy-hmno` |
+| `ansible/ocp-scale-out.yml` | `deploy-mno-scaleout` | — |
+| `ansible/vars/lab.yml` | `deploy-sno` | `deploy-mno` |
+| `ansible/vars/all.sample.yml` | `deploy-sno` | `deploy-mno` |
+| `docs/**`, `*.md`, `CLAUDE.md` | No test needed | — |
+| `bootstrap.sh` | No test needed | — |
+
+## Feature Modifiers
+
+After applying the base mapping, scan the actual diff content (not just filenames) for these patterns and add additional jobs:
+
+- Code touches `enable_bond` or bond-related logic → add `*-private-bond` variants of matched jobs
+- Code touches `public_vlan` logic → add `*-private` variants of matched jobs
+- Code touches `hybrid_worker_count` → add `deploy-hmno`
+- Code touches `cluster_type == "vmno"` or vmno logic → add `deploy-vmno`
+- Code touches FIPS-related logic → add `*-fips` variants if they exist
+
+## Cross-Repo Detection
+
+Check if the change introduces a new variable that needs a new test job in `openshift/release`:
+
+1. Look for new variables added to `ansible/vars/all.sample.yml`
+2. Check if those variables are consumed in conditionals in changed code
+3. Compare against the known env vars already supported in deploy scripts:
+   - `TYPE`, `NUM_WORKER_NODES`, `NUM_HYBRID_WORKER_NODES`, `PUBLIC_VLAN`, `BOND`, `FIPS`
+   - `JETLAG_PR`, `JETLAG_LATEST`, `JETLAG_BRANCH`
+   - `OCP_BUILD`, `OCP_VERSION`, `DISCONNECTED`
+
+If a new variable is found that gates behavior and is NOT in the above list:
+- Flag: "**Cross-repo PR needed**: This change introduces `<var>` which is not covered by existing test jobs."
+- Provide a draft YAML snippet showing the new test entry for `ci-operator/config/redhat-performance/jetlag/redhat-performance-jetlag-main.yaml`
+- Provide a draft env var declaration for `openshift-qe-installer-bm-deploy-ref.yaml`
+- Provide the script modification needed in `openshift-qe-installer-bm-deploy-commands.sh`
+
+## Output Format
+
+Present results as:
+
+```
+## Test Recommendations for <PR# or branch>
+
+### Changed Files
+- file1.yml
+- file2.yml
+
+### Minimum Tests (must pass)
+1. `deploy-sno` — covers bastion, inventory, boot-iso changes
+2. `deploy-mno` — covers install-cluster changes
+
+### Extra Coverage (recommended)
+3. `deploy-cmno` — compact MNO variant for mno-deploy.yml change
+
+### Feature-Specific Tests
+4. `deploy-mno-private-bond` — bond logic was modified
+
+### Cross-Repo Notes
+(if applicable) New variable `enable_foo` requires openshift/release PR.
+```
+
+If no test is needed (docs-only change), say so explicitly.


### PR DESCRIPTION
Adding Claude skills that automate the full loop from reading GitHub issue, raising PRs with fixes and testing them in existing Prow jobs in the Jetlag PR **or** it can also create new Prow jobs for cases where the Jetlag change is not covered by existing jobs.

This is an example with the PRs created by Claude for addressing https://github.com/redhat-performance/jetlag/issues/765 : https://github.com/redhat-performance/jetlag/pull/787 and https://github.com/openshift/release/pull/76604

Below is a more detailed explanation of what each skill is doing:

## Architecture

```
/jetlag-issue-fix <issue#>          (orchestrator - drives the full loop)
    |
    +-- /jetlag-test-map             (maps changed files to Prow test jobs)
    +-- /jetlag-prow-trigger <PR#>   (triggers tests, monitors, fetches results)
    +-- /jetlag-prow-analyze <URL>   (analyzes failed Prow job logs)

Each skill works standalone:
  /jetlag-test-map                  -> give it a PR# or file list, get test recommendations
  /jetlag-prow-trigger 123          -> trigger + poll a test on PR #123
  /jetlag-prow-analyze <prow-url>   -> analyze any failed Prow job
```

---

## `/jetlag-issue-fix <issue#>` -- Orchestrator

**File**: `.claude/commands/jetlag-issue-fix.md`

The main driver skill that takes a GitHub issue number and walks through 5 phases with mandatory human confirmation gates at each step.

### Phase 1: UNDERSTAND

Fetches the issue from `redhat-performance/jetlag` via `gh issue view`, extracts error messages, affected cluster type (MNO/SNO/VMNO/hybrid), lab environment (scalelab/performancelab/ibmcloud), hardware type (r750/r660/r650/r640/etc.), and referenced files. Explores the code paths in the repo, checks `git blame` for recent changes, and presents an analysis for user review.

**Human Gate 1**: User must confirm before proceeding to planning.

### Phase 2: PLAN

Identifies files to change and applies the test-map logic to determine which Prow jobs cover the change. This includes:
- Mapping changed files to test jobs using the path-to-job table
- Checking for feature modifiers (bond, public_vlan, hybrid, vmno)
- Detecting cross-repo needs (new variables requiring `openshift/release` changes)

Presents a fix plan with code changes, test plan, and branch name.

**Human Gate 2**: User must confirm before implementation begins.

### Phase 3: IMPLEMENT

- Creates a branch from `main` (`fix/issue-<N>-<short-desc>`)
- Makes the code changes as planned
- Commits with `Fixes #<N>` reference and co-author attribution
- Pushes to origin
- Creates a PR against `redhat-performance/jetlag` with a test plan checklist in the body

### Phase 4: TEST

Two flows depending on whether existing tests cover the change:

**Standard Flow**:
- Triggers tests via `/test <job>` PR comment
- Polls `gh api` commit statuses every 5 minutes
- 3-hour timeout per job
- Reports progress inline

**Cross-Repo Flow** (when a new test job is needed in `openshift/release`):
- Creates the Jetlag PR first
- Clones `openshift/release` from upstream (not from a potentially stale fork)
- Makes changes to 3 files:
  - `ci-operator/config/redhat-performance/jetlag/redhat-performance-jetlag-main.yaml` (test entry)
  - `ci-operator/step-registry/openshift-qe/installer/bm/deploy/openshift-qe-installer-bm-deploy-ref.yaml` (env var declaration)
  - `ci-operator/step-registry/openshift-qe/installer/bm/deploy/openshift-qe-installer-bm-deploy-commands.sh` (script logic)
- Runs `make ci-operator-config` and `make jobs` to regenerate required config metadata and prow job files (these checks fail without this step)
- Creates a companion PR with `JETLAG_PR` set to test the jetlag branch
- Triggers tests from the `openshift/release` PR

**Human Gate 3**: User must confirm before any test is triggered (bare-metal CI is expensive, ~1-2 hours per job).

### Phase 5: EVALUATE

- **Pass**: Checks off tests in the PR body, asks about triggering additional recommended tests. When all pass, declares success but never merges -- leaves `/lgtm` + `/approve` for humans.
- **Infra Error**: Classifies failures in ping/poweroff/BMC steps as hardware flakes. Suggests `/retest`. Does NOT count toward the 3-iteration limit.
- **Code Failure**: Analyzes logs, proposes a fix, asks for user confirmation before pushing a new commit (always a new commit, never force-push or amend). Resumes polling after re-trigger.
- **Escalation**: After 3 failed iterations, presents the full iteration history and stops.

**Human Gate 4**: User must confirm before each fix iteration.

### Safety Rails

- Max 3 fix iterations before escalating to human
- Max 3-hour timeout per test job
- Never trigger >1 test simultaneously (bare-metal hardware constraint)
- Always add new commits (never force-push, never amend published commits)
- Always reference issue number in commits and PR body
- Never merges -- presents results for human `/lgtm` + `/approve`
- Never skips human gates

---

## `/jetlag-test-map [PR#]` -- Test Selection Engine

**File**: `.claude/commands/jetlag-test-map.md`

Maps changed files to the appropriate Prow CI test jobs. Can be used standalone or is called inline by the orchestrator.

### Input

- A PR number: fetches diff via `gh pr diff --name-only`
- No argument: uses `git diff --name-only main` from the current branch
- Comma-separated file list: uses those files directly

### Core Mapping Table

| Changed Path Pattern | Minimum Test | Extra Coverage |
|---|---|---|
| `ansible/roles/bastion-*/**` | `deploy-sno` | `deploy-mno` |
| `ansible/roles/create-inventory/**` | `deploy-sno` | `deploy-mno` |
| `ansible/roles/validate-vars/**` | `deploy-sno` | `deploy-mno` |
| `ansible/roles/install-cluster/**` | `deploy-sno` | `deploy-mno` |
| `ansible/roles/boot-iso/**` | `deploy-sno` | `deploy-mno` |
| `ansible/roles/wait-hosts-discovered/**` | `deploy-sno` | `deploy-mno` |
| `ansible/roles/create-ai-cluster/**` | `deploy-sno` | `deploy-mno` |
| `ansible/roles/generate-discovery-iso/**` | `deploy-sno` | `deploy-mno` |
| `ansible/roles/sno-post-cluster-install/**` | `deploy-sno` | -- |
| `ansible/roles/mno-post-cluster-install/**` | `deploy-mno` | `deploy-cmno` |
| `ansible/roles/hv-*/**` | `deploy-vmno` | `deploy-hmno` |
| `ansible/roles/ocp-scale-out*/**` | `deploy-mno-scaleout` | `deploy-sno-scaleout` |
| `ansible/roles/badfish/**` | `deploy-sno` | `deploy-mno` |
| `ansible/mno-deploy.yml` | `deploy-mno` | `deploy-cmno` |
| `ansible/sno-deploy.yml` | `deploy-sno` | -- |
| `ansible/hv-setup.yml` / `hv-vm-create.yml` | `deploy-vmno` | `deploy-hmno` |
| `ansible/ocp-scale-out.yml` | `deploy-mno-scaleout` | -- |
| `ansible/vars/lab.yml` | `deploy-sno` | `deploy-mno` |
| `ansible/vars/all.sample.yml` | `deploy-sno` | `deploy-mno` |
| `docs/**`, `*.md`, `CLAUDE.md` | No test needed | -- |
| `bootstrap.sh` | No test needed | -- |

### Feature Modifiers

Scans the actual diff content (not just filenames) for patterns and adds variant jobs:
- `enable_bond` or bond logic -> adds `*-private-bond` variants
- `public_vlan` logic -> adds `*-private` variants
- `hybrid_worker_count` -> adds `deploy-hmno`
- `cluster_type == "vmno"` or vmno logic -> adds `deploy-vmno`
- FIPS-related logic -> adds `*-fips` variants if they exist

### Cross-Repo Detection

Checks if new variables are added to `all.sample.yml` that aren't in the known set of CI env vars:
- Known: `TYPE`, `NUM_WORKER_NODES`, `NUM_HYBRID_WORKER_NODES`, `PUBLIC_VLAN`, `BOND`, `FIPS`, `JETLAG_PR`, `JETLAG_LATEST`, `JETLAG_BRANCH`, `OCP_BUILD`, `OCP_VERSION`, `DISCONNECTED`

If a new gating variable is found:
- Flags the need for an `openshift/release` companion PR
- Provides draft YAML snippets for the test entry, env var declaration, and script modification
- Notes that `make ci-operator-config` and `make jobs` must be run before pushing (requires `podman` or `docker`)

### Output

Structured recommendation with sections for minimum tests, extra coverage, feature-specific tests, and cross-repo notes.

---

## `/jetlag-prow-trigger <PR#> [job-name]` -- Test Trigger + Monitor

**File**: `.claude/commands/jetlag-prow-trigger.md`

Triggers Prow CI tests on PRs and polls until completion with inline progress reporting.

### Input Formats

- `123 deploy-sno` -- trigger a specific job on jetlag PR #123
- `123` -- auto-detect jobs via test-map logic, ask user to confirm
- `--release-pr 456 deploy-foo` -- trigger on an `openshift/release` PR

When targeting `openshift/release` PRs, the PR must have passed `ci-operator-config-metadata` and `generated-config` checks first (requires `make ci-operator-config` and `make jobs`).

### Pre-flight Checks

1. Gets the HEAD SHA via `gh pr view --json headRefOid`
2. Checks for `ok-to-test` label (required for non-org members)
3. Checks if a test is already running or completed on that SHA

### Trigger

Always asks for user confirmation first -- bare-metal CI is expensive and takes 1-2 hours per job. Comments `/test <job>` on the PR. Only triggers one job at a time due to hardware constraints (single bare-metal allocation shared across all jetlag CI).

### Monitor

1. Waits 2 minutes for initial status to appear
2. Polls every 5 minutes via `gh api repos/.../commits/<SHA>/statuses`
3. Reports each poll result inline:
   - `pending` -> "Test still running... (elapsed: Xm)"
   - `success` -> "Test PASSED"
   - `failure` -> "Test FAILED -- analyzing..."
   - `error` -> "Test ERROR (infra issue)"
4. Times out after 3 hours

### On Completion

**Success**: Reports pass, asks about triggering additional recommended tests from the test-map.

**Failure**:
1. Extracts Prow URL from the status `target_url`
2. Derives the GCS artifacts path:
   ```
   https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/
   pr-logs/pull/redhat-performance_jetlag/<PR>/
   pull-ci-redhat-performance-jetlag-main-<job>/<run-id>/
   ```
3. Fetches `finished.json` and `build-log.txt` of the failed step
4. Presents a summary with failed step, log excerpt, and pointer to `/jetlag-prow-analyze`

**Infra Error**: Classifies failures in ping/poweroff/BMC access steps as hardware flakes, suggests `/retest <job>`.

---

## `/jetlag-prow-analyze <prow-url>` -- Failure Analysis

**File**: `.claude/commands/jetlag-prow-analyze.md`

Analyzes failed Prow job logs to identify root causes and suggest fixes. Can be used standalone on any Prow job URL.

### Step 1: Parse URL

Extracts from the Prow URL:
- PR number (from path)
- Job name (e.g., `deploy-sno`, `deploy-mno`)
- Run ID (build number)
- GCS base path

Handles both PR jobs (`pr-logs/pull/`) and periodic/batch jobs (`logs/`).

### Step 2: Fetch Artifacts

Downloads via WebFetch from the GCS artifacts bucket:
1. `finished.json` -- overall result and timestamp
2. `build-log.txt` -- full build log
3. Step-level logs at `artifacts/<step-name>/build-log.txt` (e.g., `openshift-qe-installer-bm-deploy`)

### Step 3: Identify Failure Point

Scans for Ansible failure patterns in priority order:
1. `fatal: [hostname]: FAILED!` -- extracts task name (from `TASK [role : task name]` line), error `msg:` field, and failed host
2. `PLAY RECAP` with `failed>0` -- identifies which host(s) failed and at which play
3. `MODULE FAILURE` -- module-level crash with traceback
4. `ERROR!` -- Ansible-level errors (syntax, undefined variable, unreachable host)
5. Non-Ansible failures -- `error:`/`Error:` lines, Python tracebacks, shell command failures (exit code != 0)

### Step 4: Correlate with PR Changes

For PR jobs:
1. Gets the PR's changed files via `gh pr diff --name-only`
2. Compares the failed task/role against the changed files
3. Classifies:
   - **Changed code failure**: failed task/role is in PR's modified files -> likely our bug
   - **Unrelated failure**: failed task/role is NOT in modified files -> pre-existing issue or infra
   - **Infra failure**: failure in hardware/network operations -> flake

### Step 5: Classify and Recommend

Five classification categories:

| Category | Indicators | Recommendation |
|---|---|---|
| **Code Bug** | Failure in changed code | Show relevant diff, suggest specific fix, push fix commit |
| **Pre-existing Bug** | Failure in unchanged code | File separate issue, `/retest` to confirm unrelated |
| **Infra Flake** | ping/poweroff/ipmitool/racadm/badfish failures; `unreachable`/`timed out`/`connection refused` errors | `/retest <job>` -- don't count as code failure |
| **Timeout** | Cluster install or host discovery exceeded limits | Check if PR introduces slower operations, or `/retest` |
| **Configuration Error** | Undefined variable, missing file, bad YAML syntax | Fix the syntax/variable issue |

### Step 6: Leverage Existing Prow Skills

For deeper OCP-level analysis beyond Ansible failures, can delegate to the `prow-job:*` skills from [openshift-eng/ai-helpers](https://github.com/openshift-eng/ai-helpers) (if installed):
- `/prow-job:analyze-test-failure` -- structured test failure analysis from JUnit and console logs
- `/prow-job:extract-must-gather` -- extract and browse must-gather archives from job artifacts
- `/prow-job:analyze-resource` -- Kubernetes resource lifecycle analysis from audit/pod logs

These are generic OpenShift CI tools, not Ansible-aware. Use them when the failure is in OCP cluster operations (operator failures, resource issues) rather than in Jetlag's Ansible playbooks.

### Output

Structured report:
```
## Prow Job Failure Analysis

**Job**: <job-name>
**PR**: #<PR#>
**Run**: <run-id>
**Result**: FAILED

### Root Cause
<Classification>: <one-line summary>

### Failed Task
- **Role**: <role-name>
- **Task**: <task-name>
- **Host**: <hostname>
- **Error**: <error message>

### Log Excerpt
(relevant 20-30 lines around the failure)

### Correlation with PR
<Whether the failure is in changed code, unrelated code, or infra>

### Recommendation
<Specific action: fix code, retest, file issue, etc.>
<If code fix: show the suggested change>
```
