### PR TITLE
Add support for syncing and renaming extra images in sync-operator-index

### DIFF
--- a/ansible/roles/sync-operator-index/defaults/main.yml
+++ b/ansible/roles/sync-operator-index/defaults/main.yml
@@ -91,3 +91,4 @@ catalogs_to_sync:
       maxVersion: 4.19.0-202510010724
 
 additional_images: []
+extra_images: []

--- a/ansible/roles/sync-operator-index/tasks/main.yml
+++ b/ansible/roles/sync-operator-index/tasks/main.yml
@@ -19,3 +19,8 @@
   shell: |
     oc mirror --authfile {{ registry_path }}/pull-secret-bastion.txt -c {{ sync_path }}/operators/{{ operator_index_name }}/imagesetconf.yml --workspace file://{{ sync_path }}/operators/{{ operator_index_name }} docker://{{ registry_host }}:{{ registry_port }} --v2
 
+- name: Mirror extra images with renaming support
+  shell: |
+    oc image mirror -a {{ registry_path }}/pull-secret-bastion.txt {{ item.src }} {{ registry_host }}:{{ registry_port }}/{{ item.dest }} --keep-manifest-list --continue-on-error=true
+  loop: "{{ extra_images | default([]) }}"
+

--- a/ansible/vars/sync-operator-index.sample.yml
+++ b/ansible/vars/sync-operator-index.sample.yml
@@ -83,3 +83,10 @@ catalogs_to_sync:
 # - quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
 # - quay.io/namespace/image_name:example_tag
 
+# Sync extra container images directly with oc image mirror, allowing destination renaming.
+# extra_images:
+# - src: registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.21.0-2
+#   dest: openshift-kni/ztp-site-generator:v4.21.0-2
+# - src: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+#   dest: minio/minio:RELEASE.2025-09-07T16-13-09Z
+

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -465,6 +465,21 @@ additional_images:
 > [!NOTE]
 > The `additional_images` parameter mirrors the images exactly as they are named. It does not support renaming the target destination path or tag. Images requiring a rename must still be mirrored manually using `oc image mirror`.
 
+**Automating Image Mirroring with Renaming**
+
+Instead of manually running `oc image mirror` commands, you can automate mirroring generic container images into your bastion registry during the `sync-operator-index` playbook execution. This method uses a separate background task to process and mirror the images, ensuring it fully supports renaming the target destination path.
+
+Simply add the `extra_images` list to your `ansible/vars/sync-operator-index.yml` file:
+
+```yaml
+# Sync extra container images using oc image mirror, which allows renaming.
+extra_images:
+- src: registry.redhat.io/openshift4/ztp-site-generate-rhel8:v4.21.0-2
+  dest: openshift-kni/ztp-site-generator:v4.21.0-2
+- src: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+  dest: minio/minio:RELEASE.2025-09-07T16-13-09Z
+```
+
 For image deletion, use the Docker V2 REST API to delete the object. Note that the deletion operation argument has to be an image's digest not image's tag. So if you mirrored your image by tag in the previous step, on deletion you have to get its digest first. The following is a convenient script that deletes an image by tag.
 
 ```console


### PR DESCRIPTION
This enhancement addresses the limitation in oc-mirror v2 where target renaming is not supported. It adds a new extra_images list variable which iterates using 'oc image mirror', allowing users to map source images to distinct destinations on the mirror registry. Documentation and sample configurations have been provided.

Generated-by: Gemini