### PR TITLE
Force password auth for ssh-copy-id in self-sched-deploy

### DIFF
--- a/scripts/self-sched-deploy/Makefile
+++ b/scripts/self-sched-deploy/Makefile
@@ -242,7 +242,7 @@ inventory-run:
 			echo "Bastion host: $$BASTION_HOST"; \
 			ssh-keygen -R "$$BASTION_HOST" 2>/dev/null || true; \
 			ssh-keyscan "$$BASTION_HOST" >> ~/.ssh/known_hosts 2>/dev/null; \
-			sshpass -p "$$BASTION_ROOT_PASSWORD" ssh-copy-id -o StrictHostKeyChecking=no root@$$BASTION_HOST 2>/dev/null && \
+			sshpass -p "$$BASTION_ROOT_PASSWORD" ssh-copy-id -o StrictHostKeyChecking=no -o PubkeyAuthentication=no root@$$BASTION_HOST 2>/dev/null && \
 			echo -e "$(GREEN)SSH key copied to bastion successfully.$(NC)" || \
 			echo -e "$(YELLOW)Warning: Could not copy SSH key. You may need to do this manually.$(NC)"; \
 		else \


### PR DESCRIPTION
Users with many SSH keys loaded in their agent can exhaust the server's MaxAuthTries before password auth is attempted, causing ssh-copy-id to fail even when sshpass provides the correct password.