### PR TITLE
enhance error handling for self-sched-deploy script

### DIFF
--- a/scripts/self-sched-deploy/Makefile
+++ b/scripts/self-sched-deploy/Makefile
@@ -152,7 +152,7 @@ create-assignment-run:
 			echo "Waiting for assignment validation..."; \
 			QUADS_HOST="$$QUADS_API_SERVER"; \
 			while true; do \
-				STATUS=$$(curl -s "https://$$QUADS_HOST/api/v3/assignments/$$ASSIGNMENT_ID" | jq -r '.validated | tostring'); \
+				STATUS=$$(curl -sk "https://$$QUADS_HOST/api/v3/assignments/$$ASSIGNMENT_ID" | jq -r '.validated | tostring'); \
 				if [ "$$STATUS" = "true" ]; then \
 					echo -e "$(GREEN)Assignment validated and ready!$(NC)"; \
 					break; \
@@ -240,9 +240,9 @@ inventory-run:
 		else \
 			echo "Pull secret already in jetlag root."; \
 		fi; \
-		echo "Running jetlag create-inventory..."; \
+		echo "Running jetlag create-inventory..." && \
 		cd $(JETLAG_ROOT) && \
-		$(ACTIVATE_VENV) && ansible-playbook ansible/create-inventory.yml; \
+		$(ACTIVATE_VENV) && ansible-playbook ansible/create-inventory.yml && \
 		echo -e "$(GREEN)Inventory generated: $(JETLAG_ROOT)/ansible/inventory/$$CLOUD_NAME.local$(NC)"; \
 		echo ""; \
 		echo "Copying SSH key to bastion host..."; \
@@ -252,15 +252,24 @@ inventory-run:
 			ssh-keygen -R "$$BASTION_HOST" 2>/dev/null || true; \
 			ssh-keyscan "$$BASTION_HOST" >> ~/.ssh/known_hosts 2>/dev/null; \
 			if command -v sshpass &>/dev/null; then \
-				sshpass -p "$$BASTION_ROOT_PASSWORD" ssh-copy-id -o StrictHostKeyChecking=no -o PubkeyAuthentication=no root@$$BASTION_HOST 2>/dev/null && \
-				echo -e "$(GREEN)SSH key copied to bastion successfully.$(NC)" || \
-				echo -e "$(YELLOW)Warning: Could not copy SSH key. You may need to do this manually.$(NC)"; \
+				if sshpass -p "$$BASTION_ROOT_PASSWORD" ssh-copy-id -o StrictHostKeyChecking=no -o PubkeyAuthentication=no root@$$BASTION_HOST 2>/dev/null; then \
+					echo -e "$(GREEN)SSH key copied to bastion successfully.$(NC)"; \
+				else \
+					echo -e "$(RED)Error: Could not copy SSH key to bastion.$(NC)"; \
+					echo -e "$(RED)Please run the following command manually, then resume deployment:$(NC)"; \
+					echo "  ssh-copy-id root@$$BASTION_HOST"; \
+					echo "  make inventory-run bastion-run cluster-run"; \
+					exit 1; \
+				fi; \
 			else \
-				echo -e "$(YELLOW)Warning: sshpass not found. Please copy your SSH key manually:$(NC)"; \
+				echo -e "$(RED)Error: sshpass not found. Please copy your SSH key manually, then resume deployment:$(NC)"; \
 				echo "  ssh-copy-id root@$$BASTION_HOST"; \
+				echo "  make inventory-run bastion-run cluster-run"; \
+				exit 1; \
 			fi; \
 		else \
-			echo -e "$(YELLOW)Warning: Bastion host or password not available. SSH key not copied.$(NC)"; \
+			echo -e "$(RED)Error: Bastion host or password not available. SSH key not copied.$(NC)"; \
+			exit 1; \
 		fi
 
 #------------------------------------------------------------------------------
@@ -278,9 +287,9 @@ bastion-run:
 	@echo -e "$(BLUE)=============================================$(NC)"
 	@source $(CONFIG_FILE) && \
 	source $(STATE_FILE) && \
-	echo "Running jetlag setup-bastion..."; \
+	echo "Running jetlag setup-bastion..." && \
 	cd $(JETLAG_ROOT) && \
-	$(ACTIVATE_VENV) && ansible-playbook -i ansible/inventory/$$CLOUD_NAME.local ansible/setup-bastion.yml; \
+	$(ACTIVATE_VENV) && ansible-playbook -i ansible/inventory/$$CLOUD_NAME.local ansible/setup-bastion.yml && \
 	echo -e "$(GREEN)Bastion setup complete.$(NC)"
 
 #------------------------------------------------------------------------------
@@ -298,9 +307,9 @@ cluster-run:
 	@echo -e "$(BLUE)=============================================$(NC)"
 	@source $(CONFIG_FILE) && \
 	source $(STATE_FILE) && \
-	echo "Running jetlag $$DEPLOY_PLAYBOOK..."; \
+	echo "Running jetlag $$DEPLOY_PLAYBOOK..." && \
 	cd $(JETLAG_ROOT) && \
-	$(ACTIVATE_VENV) && ansible-playbook -i ansible/inventory/$$CLOUD_NAME.local ansible/$$DEPLOY_PLAYBOOK; \
+	$(ACTIVATE_VENV) && ansible-playbook -i ansible/inventory/$$CLOUD_NAME.local ansible/$$DEPLOY_PLAYBOOK && \
 	echo -e "$(GREEN)Cluster deployment complete!$(NC)"; \
 	echo ""; \
 	BASTION_HOST=$$(grep -v '^#' $(JETLAG_ROOT)/ansible/inventory/$$CLOUD_NAME.local | grep -A1 '^\[bastion\]' | tail -1 | awk '{print $$1}'); \
@@ -358,7 +367,7 @@ terminate-assignment:
 	fi; \
 	echo "Logging in to QUADS..."; \
 	QUADS_EMAIL="$$QUADS_USERNAME@$$QUADS_USER_DOMAIN"; \
-	TOKEN=$$(curl -s -X POST "https://$$QUADS_API_SERVER/api/v3/login/" \
+	TOKEN=$$(curl -sk -X POST "https://$$QUADS_API_SERVER/api/v3/login/" \
 		-u "$$QUADS_EMAIL:$$QUADS_PASSWORD" | jq -r '.auth_token // empty'); \
 	if [ -z "$$TOKEN" ]; then \
 		echo -e "$(RED)Error: Failed to authenticate with QUADS.$(NC)"; \

--- a/scripts/self-sched-deploy/check-r630.sh
+++ b/scripts/self-sched-deploy/check-r630.sh
@@ -51,14 +51,14 @@ MAX_RETRIES=90
 RETRY_INTERVAL=10
 
 # Get cloud_id
-CLOUD_ID=$(curl -s "$QUADS_API/clouds?name=$CLOUD_NAME" | jq -r '.[0].id')
+CLOUD_ID=$(curl -sk "$QUADS_API/clouds?name=$CLOUD_NAME" | jq -r '.[0].id')
 if [[ -z "$CLOUD_ID" || "$CLOUD_ID" == "null" ]]; then
     echo "Error: Could not find cloud_id for $CLOUD_NAME" >&2
     exit 2
 fi
 
 # Get pm_password from active assignment ticket
-TICKET=$(curl -s "$QUADS_API/assignments?active=true&cloud_id=$CLOUD_ID" | jq -r '.[0].ticket')
+TICKET=$(curl -sk "$QUADS_API/assignments?active=true&cloud_id=$CLOUD_ID" | jq -r '.[0].ticket')
 if [[ -z "$TICKET" || "$TICKET" == "null" ]]; then
     echo "Error: Could not find active assignment ticket for $CLOUD_NAME" >&2
     exit 2
@@ -67,7 +67,7 @@ PM_PASSWORD="rdu2@${TICKET}"
 
 # Get host list, retrying until hosts are assigned
 for ((i=1; i<=MAX_RETRIES; i++)); do
-    HOST_LIST=$(curl -s "$QUADS_API/hosts?cloud_id=$CLOUD_ID" | jq -r '.[].name')
+    HOST_LIST=$(curl -sk "$QUADS_API/hosts?cloud_id=$CLOUD_ID" | jq -r '.[].name')
     if [[ -n "$HOST_LIST" ]]; then
         break
     fi
@@ -83,7 +83,7 @@ done
 NODES="[]"
 for HOST in $HOST_LIST; do
     echo "Fetching MAC addresses for $HOST..." >&2
-    MACS=$(curl -s "$QUADS_API/hosts/$HOST" | jq '[.interfaces | sort_by(.name) | .[].mac_address]')
+    MACS=$(curl -sk "$QUADS_API/hosts/$HOST" | jq '[.interfaces | sort_by(.name) | .[].mac_address]')
     NODE=$(jq -n \
         --arg name "$HOST" \
         --arg pm_addr "mgmt-$HOST" \


### PR DESCRIPTION
Add -k flag to all curl calls to accept self-signed certificates from the QUADS API. Also fix error propagation so make stops on ansible failures instead of continuing and make SSH key copy failure a hard error with instructions to resume deployment.