### PR TITLE
fix: Add --insecure flag to badfish for self-signed BMC certs

### DIFF
--- a/ansible/roles/badfish/tasks/call.yml
+++ b/ansible/roles/badfish/tasks/call.yml
@@ -37,7 +37,7 @@
       }}
     _badfish_badfish_cmd: >-
       {{
-        ['-H', badfish_host, '-u', badfish_user, '-p', badfish_password] +
+        ['-H', badfish_host, '-u', badfish_user, '-p', badfish_password, '--insecure'] +
         (badfish_args | default([]))
       }}
     _badfish_full_cmd: "{{ _badfish_podman_cmd + ['quay.io/quads/badfish'] + _badfish_badfish_cmd }}"


### PR DESCRIPTION
## Summary
- Hardcode `--insecure` flag in the badfish call task to skip SSL certificate verification
- Lab BMCs/iDRACs universally use self-signed certificates, causing all badfish operations to fail with SSL verification errors

Fixes #811

## Test Plan
- [ ] `deploy-sno` — badfish is used during boot-iso for Dell iDRAC clear-jobs and racreset
- [ ] `deploy-mno` — validates the same badfish path for MNO deployments

## Changes
- `ansible/roles/badfish/tasks/call.yml`: Add `--insecure` to the hardcoded badfish command arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)