### PR TITLE
feat: Add bastion-minio role to run MinIO as a podman pod on the bastion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,12 @@ ansible-playbook ansible/hv-vm-replace.yml
 
 # Sync OpenShift releases
 ansible-playbook ansible/sync-ocp-release.yml
+
+# Deploy MinIO object storage on the bastion (set setup_bastion_minio: true in all.yml first)
+ansible-playbook -i ansible/inventory/cloud99.local ansible/bastion-minio.yml
+
+# Clean all MinIO data between cluster deployments (wipes data, recreates empty buckets)
+ansible-playbook -i ansible/inventory/cloud99.local ansible/bastion-minio-clean.yml
 ```
 
 ## Project Architecture
@@ -179,6 +185,12 @@ When encountering issues with Jetlag deployments, consult these comprehensive do
   - Bastion configuration and recovery procedures
   - BMC/iDRAC reset procedures
   - Virtual media and discovery issues
+
+- **[docs/bastion-minio.md](docs/bastion-minio.md)**: MinIO object storage setup and usage covering:
+  - Variables and configuration options
+  - Deploying MinIO via `setup-bastion.yml` or standalone `bastion-minio.yml`
+  - Accessing the S3 API (port 9000) and web console (port 9001)
+  - Cleaning MinIO data between cluster deployments with `bastion-minio-clean.yml`
 
 - **[docs/tips-and-vars.md](docs/tips-and-vars.md)**: Advanced configuration guidance including:
   - Network interface configuration and overrides

--- a/ansible/bastion-minio-clean.yml
+++ b/ansible/bastion-minio-clean.yml
@@ -1,0 +1,15 @@
+---
+# Cleans all data stored in MinIO on the bastion
+#
+# Example Usage:
+#
+# ansible-playbook -i ansible/inventory/cloud42.local ansible/bastion-minio-clean.yml
+#
+
+- name: Clean MinIO data on bastion
+  hosts: bastion
+  gather_facts: false
+  vars_files:
+  - vars/all.yml
+  roles:
+  - bastion-minio-clean

--- a/ansible/bastion-minio.yml
+++ b/ansible/bastion-minio.yml
@@ -1,0 +1,15 @@
+---
+# Setup MinIO on the bastion machine
+#
+# Example Usage:
+#
+# ansible-playbook -i ansible/inventory/cloud42.local ansible/bastion-minio.yml
+#
+
+- name: Setup MinIO on bastion
+  hosts: bastion
+  vars_files:
+  - vars/lab.yml
+  - vars/all.yml
+  roles:
+  - bastion-minio

--- a/ansible/roles/bastion-minio-clean/defaults/main.yml
+++ b/ansible/roles/bastion-minio-clean/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# bastion-minio-clean default vars
+
+minio_store_path: /opt/minio

--- a/ansible/roles/bastion-minio-clean/tasks/main.yml
+++ b/ansible/roles/bastion-minio-clean/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+# bastion-minio-clean tasks
+
+- name: Stop minio pod
+  containers.podman.podman_pod:
+    name: minio
+    state: stopped
+
+- name: Remove minio data directory
+  ansible.builtin.file:
+    path: "{{ minio_store_path }}/data"
+    state: absent
+
+- name: Recreate minio data directory
+  ansible.builtin.file:
+    path: "{{ minio_store_path }}/data"
+    state: directory
+
+- name: Start minio pod
+  containers.podman.podman_pod:
+    name: minio
+    network: host
+    state: started

--- a/ansible/roles/bastion-minio/defaults/main.yml
+++ b/ansible/roles/bastion-minio/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# bastion-minio default vars
+
+minio_store_path: /opt/minio
+minio_image: quay.io/minio/minio
+minio_image_tag: RELEASE.2025-09-07T16-13-09Z
+minio_access_key: minio
+minio_secret_key: minio123
+minio_port: 9000
+minio_console_port: 9001
+# Set to a full device path (e.g. /dev/sdb, /dev/nvme0n1,
+# /dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:1:0) to partition, format as XFS,
+# and mount it at minio_store_path/data. Empty string disables separate disk setup.
+minio_data_disk: ""

--- a/ansible/roles/bastion-minio/tasks/main.yml
+++ b/ansible/roles/bastion-minio/tasks/main.yml
@@ -1,0 +1,84 @@
+---
+# bastion-minio tasks
+
+- name: Create directory for bastion minio storage
+  ansible.builtin.file:
+    path: "{{ minio_store_path }}"
+    state: directory
+
+- name: Set minio data disk partition path
+  ansible.builtin.set_fact:
+    _minio_disk_partition: "{{ minio_data_disk }}1"
+  when: minio_data_disk != ""
+
+- name: Set minio data disk partition path for nvme
+  ansible.builtin.set_fact:
+    _minio_disk_partition: "{{ minio_data_disk }}p1"
+  when:
+  - minio_data_disk != ""
+  - '"nvme" in minio_data_disk'
+  - '"by-path" not in minio_data_disk'
+
+- name: Set minio data disk partition path for by-path
+  ansible.builtin.set_fact:
+    _minio_disk_partition: "{{ minio_data_disk }}-part1"
+  when:
+  - minio_data_disk != ""
+  - '"by-path" in minio_data_disk'
+
+- name: Create minio data disk primary partition
+  community.general.parted:
+    device: "{{ minio_data_disk }}"
+    number: 1
+    state: present
+    label: gpt
+  when: minio_data_disk != ""
+
+- name: Format minio data disk as XFS
+  community.general.filesystem:
+    fstype: xfs
+    dev: "{{ _minio_disk_partition }}"
+  when: minio_data_disk != ""
+
+- name: Mount minio data disk
+  ansible.posix.mount:
+    fstype: xfs
+    src: "{{ _minio_disk_partition }}"
+    path: "{{ minio_store_path }}"
+    state: mounted
+  when: minio_data_disk != ""
+
+- name: Create minio data directory
+  ansible.builtin.file:
+    path: "{{ minio_store_path }}/data"
+    state: directory
+
+- name: Create minio pod
+  containers.podman.podman_pod:
+    name: minio
+    network: host
+    state: started
+
+# On a reboot "started" state does not start an exited pod (why..idk)
+- name: Ensure minio pod is up
+  containers.podman.podman_pod:
+    name: minio
+    network: host
+    state: restarted
+
+- name: Create minio container in minio pod
+  containers.podman.podman_container:
+    pod: minio
+    network: host
+    name: minio
+    image: "{{ minio_image }}:{{ minio_image_tag }}"
+    entrypoint: /bin/sh
+    command:
+    - -c
+    - "mkdir -p /storage/thanos && mkdir -p /storage/dr4hub/velero && for i in $(seq -f \"%05g\" 1 4000); do mkdir -p \"/storage/vm$i-ibu\"; done && minio server /storage --console-address :{{ minio_console_port }}"
+    env:
+      MINIO_ACCESS_KEY: "{{ minio_access_key }}"
+      MINIO_SECRET_KEY: "{{ minio_secret_key }}"
+    volume:
+    - "{{ minio_store_path }}/data:/storage:Z"
+    state: started

--- a/ansible/setup-bastion.yml
+++ b/ansible/setup-bastion.yml
@@ -41,3 +41,5 @@
     when: use_bastion_registry or setup_bastion_proxy | default(false)
   - role: hv-metrics-server
     when: setup_hv_metrics | default(false) | bool
+  - role: bastion-minio
+    when: setup_bastion_minio | default(false)

--- a/docs/bastion-minio.md
+++ b/docs/bastion-minio.md
@@ -1,0 +1,93 @@
+# Bastion MinIO
+
+MinIO is an S3-compatible object storage service that Jetlag can deploy as a podman pod on the bastion machine. It is used to provide persistent object storage for workloads running on deployed clusters, such as Thanos metrics storage, Velero backup storage, and Image Based Upgrade (IBU) storage buckets.
+
+_**Table of Contents**_
+
+<!-- TOC -->
+- [Bastion MinIO](#bastion-minio)
+  - [Variables](#variables)
+  - [Setup MinIO via setup-bastion.yml](#setup-minio-via-setup-bastionyml)
+  - [Setup MinIO via bastion-minio.yml](#setup-minio-via-bastion-minioyml)
+  - [Accessing MinIO](#accessing-minio)
+  - [Clean MinIO data](#clean-minio-data)
+<!-- /TOC -->
+
+## Variables
+
+The following vars control the MinIO deployment and are defined in `ansible/roles/bastion-minio/defaults/main.yml`. Override them in the `Extra vars` section of `ansible/vars/all.yml`.
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `setup_bastion_minio` | `false` | Enable MinIO deployment on the bastion (set in `all.yml`) |
+| `minio_store_path` | `/opt/minio` | Base directory for MinIO storage on the bastion |
+| `minio_data_disk` | `""` | Full device path (e.g. `/dev/sdb`, `/dev/nvme0n1`, `/dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:1:0`) to partition, format as XFS, and mount at `minio_store_path/data`. Empty string uses the bastion root filesystem |
+| `minio_image` | `quay.io/minio/minio` | MinIO container image |
+| `minio_image_tag` | `RELEASE.2025-09-07T16-13-09Z` | MinIO container image tag |
+| `minio_access_key` | `minio` | MinIO S3 API access key |
+| `minio_secret_key` | `minio123` | MinIO S3 API secret key |
+| `minio_port` | `9000` | MinIO S3 API port |
+| `minio_console_port` | `9001` | MinIO web console port |
+
+## Setup MinIO via setup-bastion.yml
+
+MinIO can be deployed as part of the standard bastion setup by enabling it in `ansible/vars/all.yml` before running `setup-bastion.yml`.
+
+Set the following in the `Extra vars` section of `ansible/vars/all.yml`:
+
+```yaml
+################################################################################
+# Extra vars
+################################################################################
+setup_bastion_minio: true
+
+# Optional: use a dedicated disk for MinIO data storage
+# minio_data_disk: /dev/disk/by-path/pci-0000:18:00.0-scsi-0:2:1:0
+```
+
+Then run the bastion setup playbook:
+
+```console
+[root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/setup-bastion.yml
+```
+
+MinIO is deployed after the other bastion services and will be available at the completion of the playbook.
+
+## Setup MinIO via bastion-minio.yml
+
+If the bastion is already configured and you want to deploy MinIO independently without rerunning the full `setup-bastion.yml`, use the dedicated playbook. Set `setup_bastion_minio: true` in `ansible/vars/all.yml` as described above, then run:
+
+```console
+[root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/bastion-minio.yml
+```
+
+This runs only the `bastion-minio` role and is safe to run against an already-configured bastion without affecting other services.
+
+## Accessing MinIO
+
+Once deployed, MinIO exposes two endpoints on the bastion:
+
+| Endpoint | Port | Description |
+| -------- | ---- | ----------- |
+| S3 API | 9000 | Used by workloads to read and write objects |
+| Web console | 9001 | Browser-based management UI |
+
+Access the web console at `http://<bastion>:9001` and log in with `minio_access_key` and `minio_secret_key` (defaults: `minio` / `minio123`).
+
+The following buckets are created automatically on first start:
+
+| Bucket | Purpose |
+| ------ | ------- |
+| `thanos` | Thanos metrics long-term storage |
+| `dr4hub/velero` | Velero backup storage |
+| `vm00001-ibu` through `vm04000-ibu` | Image Based Upgrade storage per SNO |
+
+## Clean MinIO data
+
+When redeploying clusters you may need to clear all data stored in MinIO to start with empty buckets. Use the dedicated clean playbook:
+
+```console
+[root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/bastion-minio-clean.yml
+```
+
+This stops the MinIO pod, removes all data under `minio_store_path/data`, and restarts the pod. The buckets are recreated automatically on startup. The MinIO service itself (pod, container image, configuration) is not removed — only the stored data is wiped.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,6 +20,7 @@ _**Table of Contents**_
   - [Incorrect bastion controlplane interface](#incorrect-bastion-controlplane-interface)
   - [Changed controlplane network on bastion](#changed-controlplane-network-on-bastion)
   - [Root disk too small](#root-disk-too-small)
+  - [MinIO](#minio)
 - [Generic Hardware](#generic-hardware)
   - [Minimum Firmware Versions](#minimum-firmware-versions)
 - [Dell](#dell)
@@ -292,6 +293,8 @@ Several services are run on the bastion in order to automate the tasks that Jetl
 | Dnsmasq / Coredns                                       | 53                        |
 | Grafana instance for hypervisor monitoring              | 3000                      |
 | Prometheus server for hypervisor monitoring             | 9090                      |
+| MinIO S3 API (When `setup_bastion_minio=true`)          | 9000                      |
+| MinIO web console (When `setup_bastion_minio=true`)     | 9001                      |
 
 Example accessing the bastion registry and listing repositories:
 ```console
@@ -457,6 +460,54 @@ additional container images from its local disconnected registry. Some machines 
 lab have been found to have root disks which are on the order of only 70G and can fill
 with 1 or 2 OCP releases synced. If the bastion is one of those machines, relocate `/opt`
 to a separate larger disk so the machine does not run out of space on the root disk.
+
+
+## MinIO
+
+For full MinIO setup and usage documentation see [docs/bastion-minio.md](bastion-minio.md).
+
+**Check MinIO pod and container status:**
+
+```console
+[root@<bastion> ~]# podman pod ps
+[root@<bastion> ~]# podman ps --pod
+```
+
+**Check MinIO logs:**
+
+```console
+[root@<bastion> ~]# podman logs minio
+```
+
+**MinIO web console or S3 API unreachable:**
+
+Verify the MinIO pod is running and listening on the expected ports:
+
+```console
+[root@<bastion> ~]# podman pod ps
+[root@<bastion> ~]# ss -tlnp | grep -E '9000|9001'
+```
+
+If the pod is stopped, restart it:
+
+```console
+[root@<bastion> ~]# podman pod start minio
+```
+
+Or rerun the MinIO playbook to fully reconcile the pod and container state:
+
+```console
+[root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/bastion-minio.yml
+```
+
+**Clear MinIO data between cluster deployments:**
+
+Use the dedicated clean playbook to wipe all stored data and restart MinIO with empty buckets:
+
+```console
+[root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/bastion-minio-clean.yml
+```
+
 
 # Generic Hardware
 


### PR DESCRIPTION
Moves MinIO from the hub cluster to the bastion machine so it no longer skews per-node resource consumption measurements during capacity testing. Follows the same containers.podman pattern as bastion-http and bastion-assisted-installer. Supports an optional dedicated data disk (partitioned and formatted as XFS) to prevent minio from filling the OS disk.

Set setup_bastion_minio: true in all.yml to enable. Optionally set minio_data_disk to a block device name (e.g. sdb, nvme0n1) to use a dedicated disk for minio data storage.

AI-assisted: Claude Sonnet 4.6 (claude-sonnet-4-6)