### PR TITLE
fix: Make SNO public VLAN ingress IP configurable

### DIFF
--- a/ansible/roles/create-ai-cluster/defaults/main/main.yml
+++ b/ansible/roles/create-ai-cluster/defaults/main/main.yml
@@ -28,3 +28,6 @@ reserved_cpus: 0-1,32-33
 
 # SNO Only
 du_profile: false
+
+# SNO public VLAN ingress IP offset (set to 0 to disable secondary IP)
+sno_pub_vlan_ingress_ip_offset: 4

--- a/ansible/roles/create-ai-cluster/templates/rhlab_nmstate.yml.j2
+++ b/ansible/roles/create-ai-cluster/templates/rhlab_nmstate.yml.j2
@@ -7,8 +7,8 @@ interfaces:
     address:
     - ip: {{ hostvars[item]['ip'] }}
       prefix-length: {{ hostvars[item]['network_prefix'] }}
-{%   if cluster_type == "sno" and public_vlan and groups['sno'] | default([]) | length == 1  %}
-    - ip: {{ controlplane_network[0] | ansible.utils.nthhost(4) }}
+{%   if cluster_type == "sno" and public_vlan and groups['sno'] | default([]) | length == 1 and sno_pub_vlan_ingress_ip_offset | int > 0 %}
+    - ip: {{ controlplane_network[0] | ansible.utils.nthhost(sno_pub_vlan_ingress_ip_offset) }}
       prefix-length: {{ hostvars[item]['network_prefix'] }}
 {%   endif %}
     auto-dns: false
@@ -24,8 +24,8 @@ interfaces:
     - ip: {{ hostvars[item]['ip'] }}
       prefix-length: {{ hostvars[item]['network_prefix'] }}
 {%   endif %}
-{%   if cluster_type == "sno" and public_vlan and groups['sno'] | default([]) | length == 1 and controlplane_network | length > 1 %}
-    - ip: {{ controlplane_network[1] | ansible.utils.nthhost(4) }}
+{%   if cluster_type == "sno" and public_vlan and groups['sno'] | default([]) | length == 1 and controlplane_network | length > 1 and sno_pub_vlan_ingress_ip_offset | int > 0 %}
+    - ip: {{ controlplane_network[1] | ansible.utils.nthhost(sno_pub_vlan_ingress_ip_offset) }}
       prefix-length: {{ hostvars[item]['ipv6_prefix'] }}
 {%   endif %}
     auto-dns: false


### PR DESCRIPTION
## Summary
- Replace hardcoded `nthhost(4)` with configurable `sno_pub_vlan_ingress_ip_offset` variable (default: `4`) in `rhlab_nmstate.yml.j2`
- Setting the variable to `0` disables the secondary ingress IP entirely
- Enables ACM workflows where `.3`/`.4` addresses must be reserved for the target cluster

Fixes #813

## Changes
- `ansible/roles/create-ai-cluster/defaults/main/main.yml`: Add `sno_pub_vlan_ingress_ip_offset: 4` role default
- `ansible/roles/create-ai-cluster/templates/rhlab_nmstate.yml.j2`: Use variable instead of hardcoded offset, with `| int > 0` guard to allow disabling

## Test Plan
- [ ] `deploy-sno` — covers create-ai-cluster role (nmstate template)
- [ ] `deploy-mno` — extra coverage for create-ai-cluster role

🤖 Generated with [Claude Code](https://claude.com/claude-code)