### PR TITLE
fix: typo in url

### DIFF
--- a/ansible/roles/configure-local-storage/tasks/main.yml
+++ b/ansible/roles/configure-local-storage/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Apply worker host ignition config overrides
   uri:
-    url: "http://{{ assisted_installer_host }}:{{ assisted_installer_port }}/api/assisted-install/v2/infra-envs/{{ ai_infraenv_id }}/hosts//{{ item.id }}/ignition"
+    url: "http://{{ assisted_installer_host }}:{{ assisted_installer_port }}/api/assisted-install/v2/infra-envs/{{ ai_infraenv_id }}/hosts/{{ item.id }}/ignition"
     method: PATCH
     body_format: json
     status_code: [201]


### PR DESCRIPTION
While browsing the code base, I've noticed this typo.

While it probably doesn't break anything, opening a PR, just in case.