### PR TITLE
Bump default ocp_version to latest-4.21

### DIFF
--- a/ansible/vars/all.sample.yml
+++ b/ansible/vars/all.sample.yml
@@ -21,7 +21,7 @@ ocp_build: "ga"
 # For "ga" builds, examples are "latest-4.17", "latest-4.16", "4.17.17" or "4.16.35"
 # For "dev" builds, examples are "candidate-4.17", "candidate-4.16" or "latest"
 # For "ci" builds, an example is "4.19.0-0.nightly-2025-02-25-035256"
-ocp_version: "latest-4.20"
+ocp_version: "latest-4.21"
 
 # Set to true ONLY if you have a public routable vlan in your scalelab or performancelab cloud.
 # Autoconfigures cluster_name, base_dns_name, controlplane_network_interface_idx, controlplane_network,

--- a/ansible/vars/ibmcloud.sample.yml
+++ b/ansible/vars/ibmcloud.sample.yml
@@ -18,7 +18,7 @@ ocp_build: "ga"
 # For "ga" builds, examples are "latest-4.17", "latest-4.16", "4.17.17" or "4.16.35"
 # For "dev" builds, examples are "candidate-4.17", "candidate-4.16" or "latest"
 # For "ci" builds, an example is "4.19.0-0.nightly-2025-02-25-035256"
-ocp_version: "latest-4.20"
+ocp_version: "latest-4.21"
 
 # Enables Operators CNV and LSO install at deployment timeframe (GA releases only)
 enable_cnv_install: false

--- a/ansible/vars/sync-ocp-release.sample.yml
+++ b/ansible/vars/sync-ocp-release.sample.yml
@@ -6,6 +6,6 @@ ocp_build: "ga"
 # For "ga" builds, examples are "latest-4.17", "latest-4.16", "4.17.17" or "4.16.35"
 # For "dev" builds, examples are "candidate-4.17", "candidate-4.16" or "latest"
 # For "ci" builds, an example is "4.19.0-0.nightly-2025-02-25-035256"
-ocp_version: "latest-4.20"
+ocp_version: "latest-4.21"
 
 pull_secret: "{{ lookup('file', '../pull-secret.txt') }}"

--- a/docs/deploy-mno-byol.md
+++ b/docs/deploy-mno-byol.md
@@ -287,7 +287,7 @@ ocp_build: "ga"
 # For "ga" builds, examples are "latest-4.17", "latest-4.16", "4.17.17" or "4.16.35"
 # For "dev" builds, examples are "candidate-4.17", "candidate-4.16" or "latest"
 # For "ci" builds, an example is "4.19.0-0.nightly-2025-02-25-035256"
-ocp_version: "latest-4.20"
+ocp_version: "latest-4.21"
 
 # Set to true ONLY if you have a public routable vlan in your scalelab or performancelab cloud.
 # Autoconfigures cluster_name, base_dns_name, controlplane_network_interface_idx, controlplane_network,

--- a/docs/deploy-mno-ibmcloud.md
+++ b/docs/deploy-mno-ibmcloud.md
@@ -264,7 +264,7 @@ ocp_build: "ga"
 # For "ga" builds, examples are "latest-4.17", "latest-4.16", "4.17.17" or "4.16.35"
 # For "dev" builds, examples are "candidate-4.17", "candidate-4.16" or "latest"
 # For "ci" builds, an example is "4.19.0-0.nightly-2025-02-25-035256"
-ocp_version: "latest-4.20"
+ocp_version: "latest-4.21"
 
 # Enables Operators CNV and LSO install at deployment timeframe (GA releases only)
 enable_cnv_install: false

--- a/docs/deploy-mno-performancelab.md
+++ b/docs/deploy-mno-performancelab.md
@@ -304,7 +304,7 @@ ocp_build: "ga"
 # For "ga" builds, examples are "latest-4.17", "latest-4.16", "4.17.17" or "4.16.35"
 # For "dev" builds, examples are "candidate-4.17", "candidate-4.16" or "latest"
 # For "ci" builds, an example is "4.19.0-0.nightly-2025-02-25-035256"
-ocp_version: "latest-4.20"
+ocp_version: "latest-4.21"
 
 # Set to true ONLY if you have a public routable vlan in your scalelab or performancelab cloud.
 # Autoconfigures cluster_name, base_dns_name, controlplane_network_interface_idx, controlplane_network,

--- a/docs/deploy-mno-scalelab.md
+++ b/docs/deploy-mno-scalelab.md
@@ -309,7 +309,7 @@ ocp_build: "ga"
 # For "ga" builds, examples are "latest-4.17", "latest-4.16", "4.17.17" or "4.16.35"
 # For "dev" builds, examples are "candidate-4.17", "candidate-4.16" or "latest"
 # For "ci" builds, an example is "4.19.0-0.nightly-2025-02-25-035256"
-ocp_version: "latest-4.20"
+ocp_version: "latest-4.21"
 
 # Set to true ONLY if you have a public routable vlan in your scalelab or performancelab cloud.
 # Autoconfigures cluster_name, base_dns_name, controlplane_network_interface_idx, controlplane_network,

--- a/docs/deploy-sno-ibmcloud.md
+++ b/docs/deploy-sno-ibmcloud.md
@@ -206,7 +206,7 @@ ocp_build: "ga"
 # For "ga" builds, examples are "latest-4.17", "latest-4.16", "4.17.17" or "4.16.35"
 # For "dev" builds, examples are "candidate-4.17", "candidate-4.16" or "latest"
 # For "ci" builds, an example is "4.19.0-0.nightly-2025-02-25-035256"
-ocp_version: "latest-4.20"
+ocp_version: "latest-4.21"
 
 # Enables Operators CNV and LSO install at deployment timeframe (GA releases only)
 enable_cnv_install: false

--- a/docs/deploy-sno-performancelab.md
+++ b/docs/deploy-sno-performancelab.md
@@ -278,7 +278,7 @@ ocp_build: "ga"
 # For "ga" builds, examples are "latest-4.17", "latest-4.16", "4.17.17" or "4.16.35"
 # For "dev" builds, examples are "candidate-4.17", "candidate-4.16" or "latest"
 # For "ci" builds, an example is "4.19.0-0.nightly-2025-02-25-035256"
-ocp_version: "latest-4.20"
+ocp_version: "latest-4.21"
 
 # Set to true ONLY if you have a public routable vlan in your scalelab or performancelab cloud.
 # Autoconfigures cluster_name, base_dns_name, controlplane_network_interface_idx, controlplane_network,

--- a/docs/deploy-sno-scalelab.md
+++ b/docs/deploy-sno-scalelab.md
@@ -270,7 +270,7 @@ ocp_build: "ga"
 # For "ga" builds, examples are "latest-4.17", "latest-4.16", "4.17.17" or "4.16.35"
 # For "dev" builds, examples are "candidate-4.17", "candidate-4.16" or "latest"
 # For "ci" builds, an example is "4.19.0-0.nightly-2025-02-25-035256"
-ocp_version: "latest-4.20"
+ocp_version: "latest-4.21"
 
 # Set to true ONLY if you have a public routable vlan in your scalelab or performancelab cloud.
 # Autoconfigures cluster_name, base_dns_name, controlplane_network_interface_idx, controlplane_network,

--- a/docs/deploy-vmno.md
+++ b/docs/deploy-vmno.md
@@ -194,7 +194,7 @@ ocp_build: ga
 # For "ga" builds, examples are "latest-4.17", "latest-4.16", "4.17.17" or "4.16.35"
 # For "dev" builds, examples are "candidate-4.17", "candidate-4.16" or "latest"
 # For "ci" builds, an example is "4.19.0-0.nightly-2025-02-25-035256"
-ocp_version: "latest-4.20"
+ocp_version: "latest-4.21"
 
 # Set to true ONLY if you have a public routable vlan in your scalelab or performancelab cloud.
 # Autoconfigures cluster_name, base_dns_name, controlplane_network_interface_idx, controlplane_network,


### PR DESCRIPTION
Update the default ocp_version from latest-4.20 to latest-4.21 across all sample variable files and deployment documentation.