### PR TITLE
feat: Add post_install_node_labels to consolidate node labeling post-…

### DIFF
--- a/ansible/roles/mno-post-cluster-install/defaults/main/main.yml
+++ b/ansible/roles/mno-post-cluster-install/defaults/main/main.yml
@@ -59,3 +59,8 @@ minio_pv_storageclass: localstorage2-sc
 # Performance-addon-operator vars_files
 install_performance_addon_operator: false
 ocp_channel: "{{ openshift_version }}"
+
+# Additional labels to apply to worker nodes post-install (list of key=value or key= strings)
+post_install_node_labels:
+  - jetlag=true
+  # - cluster.ocs.openshift.io/openshift-storage=

--- a/ansible/roles/mno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/mno-post-cluster-install/tasks/main.yml
@@ -36,9 +36,10 @@
     KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc delete ns assisted-installer
   when: remove_assisted_installer_namespace
 
-- name: Apply a label to the worker node(s)
+- name: Apply post-install labels to worker node(s)
   shell: |
-    KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc label no --overwrite -l node-role.kubernetes.io/worker jetlag=true
+    KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc label no --overwrite -l node-role.kubernetes.io/worker {{ item }}
+  loop: "{{ post_install_node_labels }}"
 
 - name: Install Performance-Addon-Operator - find channel
   shell: |

--- a/ansible/roles/sno-post-cluster-install/defaults/main/main.yml
+++ b/ansible/roles/sno-post-cluster-install/defaults/main/main.yml
@@ -42,3 +42,7 @@ install_performance_addon_operator: false
 hugepages_count: 16
 node: 0
 isolated_cpus: 2-47,50-95
+
+# Additional labels to apply to all nodes post-install (list of key=value or key= strings)
+post_install_node_labels:
+  - jetlag=true

--- a/ansible/roles/sno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/sno-post-cluster-install/tasks/main.yml
@@ -38,9 +38,10 @@
     KUBECONFIG={{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/kubeconfig oc delete ns assisted-installer
   when: remove_assisted_installer_namespace
 
-- name: Apply a label to the SNO node
+- name: Apply post-install labels to SNO node
   shell: |
-    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/kubeconfig oc label no --all --overwrite jetlag=true
+    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/kubeconfig oc label no --all --overwrite {{ item }}
+  loop: "{{ post_install_node_labels }}"
 
 - name: Place templated configuration items
   template:


### PR DESCRIPTION
…install

Replaces the hardcoded jetlag=true label tasks in mno-post-cluster-install and sno-post-cluster-install with a generic post_install_node_labels list variable. jetlag=true remains the default, and additional labels (e.g. cluster.ocs.openshift.io/openshift-storage=) can be appended in all.yml.