### PR TITLE
feat: Add mno-post-install ODF support with configurable StorageCluster

### DIFF
--- a/ansible/roles/mno-post-cluster-install/defaults/main/odf.yml
+++ b/ansible/roles/mno-post-cluster-install/defaults/main/odf.yml
@@ -1,0 +1,25 @@
+---
+# OpenShift Data Foundation (ODF) vars
+
+# Master toggle to install ODF
+setup_odf: false
+
+# ODF operator subscription channel
+odf_channel: stable-4.21
+
+# StorageCluster configuration
+
+# Number of storageDeviceSets; increment by 1 for each set of 3 block PVs
+odf_storagecluster_device_count: 1
+
+odf_storagecluster_replica_count: 3
+
+# Storage size per PVC in each device set (minimum 100Gi, maximum 4Ti)
+odf_storagecluster_storage_size: 100Gi
+
+# StorageClass backing the device set PVCs - should match localvolume-disk-sc from LSO
+odf_storagecluster_storage_class: localstorage-disk-sc
+
+# Wait for the StorageCluster to reach Ready status before proceeding
+wait_for_odf_storagecluster_ready: false
+wait_for_odf_storagecluster_ready_timeout: 20m

--- a/ansible/roles/mno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/mno-post-cluster-install/tasks/main.yml
@@ -11,6 +11,7 @@
     - "{{ bastion_cluster_config_dir }}/gitops"
     - "{{ bastion_cluster_config_dir }}/localstorage"
     - "{{ bastion_cluster_config_dir }}/minio"
+    - "{{ bastion_cluster_config_dir }}/odf"
     - "{{ bastion_cluster_config_dir }}/openshift-monitoring"
     - "{{ bastion_cluster_config_dir }}/performance-addon-operator"
 
@@ -69,6 +70,10 @@
       dest: "{{ bastion_cluster_config_dir }}/localstorage/localvolume-disk.yml"
     - src: minio.yml.j2
       dest: "{{ bastion_cluster_config_dir }}/minio/minio.yml"
+    - src: odf.yml.j2
+      dest: "{{ bastion_cluster_config_dir }}/odf/odf.yml"
+    - src: odf-storagecluster.yml.j2
+      dest: "{{ bastion_cluster_config_dir }}/odf/odf-storagecluster.yml"
     - src: cluster-monitoring-config.yml.j2
       dest: "{{ bastion_cluster_config_dir }}/openshift-monitoring/cluster-monitoring-config.yml"
     - src: performance-addon-operator.yml.j2
@@ -159,7 +164,7 @@
       KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc label no --overwrite {{ item }} localstorage=true
     loop: "{{ groups['worker'] }}"
 
-  # The localvolume resource will not be instantly available, thus retry for around 15 minutes
+  # The localvolume resource will not be instantly available, thus retry for around 2 minutes
   - name: Create localvolume-lvm resource
     when: (controlplane_localstorage_lvm_devices | length > 0) or (worker_localstorage_lvm_devices | length > 0)
     shell:
@@ -177,6 +182,27 @@
     until: not lv_result.failed
     retries: 60
     delay: 2
+
+- name: Setup OpenShift Data Foundation (ODF)
+  when: setup_odf | bool
+  block:
+  - name: Install ODF operator (namespace, operatorgroup, subscription)
+    shell:
+      KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc apply -f {{ bastion_cluster_config_dir }}/odf/odf.yml
+
+  # The StorageCluster CRD is not available until the ODF operator finishes installing; retry for ~15 minutes
+  - name: Create ODF StorageCluster
+    shell:
+      KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc apply -f {{ bastion_cluster_config_dir }}/odf/odf-storagecluster.yml
+    register: sc_result
+    until: not sc_result.failed
+    retries: 60
+    delay: 15
+
+  - name: Wait for ODF StorageCluster to be Ready
+    shell: |
+      KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc wait storagecluster/ocs-storagecluster -n openshift-storage --for=jsonpath='{.status.phase}'=Ready --timeout={{ wait_for_odf_storagecluster_ready_timeout }}
+    when: wait_for_odf_storagecluster_ready | bool
 
 - name: Setup Minio
   when: setup_minio | bool

--- a/ansible/roles/mno-post-cluster-install/templates/odf-storagecluster.yml.j2
+++ b/ansible/roles/mno-post-cluster-install/templates/odf-storagecluster.yml.j2
@@ -1,0 +1,42 @@
+---
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: ocs-storagecluster
+  namespace: openshift-storage
+spec:
+  managedResources:
+    cephCluster:
+      cleanupPolicy:
+        wipeDevicesFromOtherClusters: true
+  resources:
+    mds:
+      limits:
+        cpu: "3"
+        memory: "8Gi"
+      requests:
+        cpu: "3"
+        memory: "8Gi"
+  monDataDirHostPath: /var/lib/rook
+  storageDeviceSets:
+  - count: {{ odf_storagecluster_device_count }}
+    dataPVCTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: "{{ odf_storagecluster_storage_size }}"
+        storageClassName: "{{ odf_storagecluster_storage_class }}"
+        volumeMode: Block
+    name: ocs-deviceset
+    placement: {}
+    portable: false
+    replica: {{ odf_storagecluster_replica_count }}
+    resources:
+      limits:
+        cpu: "2"
+        memory: "5Gi"
+      requests:
+        cpu: "2"
+        memory: "5Gi"

--- a/ansible/roles/mno-post-cluster-install/templates/odf.yml.j2
+++ b/ansible/roles/mno-post-cluster-install/templates/odf.yml.j2
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-storage
+  labels:
+    openshift.io/cluster-monitoring: "true"
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-storage-operatorgroup
+  namespace: openshift-storage
+spec:
+  targetNamespaces:
+    - openshift-storage
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: odf-operator
+  namespace: openshift-storage
+spec:
+  channel: "{{ odf_channel }}"
+  name: odf-operator
+{% if use_bastion_registry | default(false) %}
+  source: {{ generated_operator_index_name_tag }}
+{% else %}
+  source: redhat-operators
+{% endif %}
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic


### PR DESCRIPTION
Installs the OpenShift Data Foundation operator and creates a StorageCluster after LSO (so block PVs are available) and before openshift-monitoring configuration (so ODF can back Prometheus storage). Controlled by setup_odf (default false) with variables for channel, device set count, replica count, PVC size, and storage class.

🤖 Generated with Claude Code