### PR TITLE
feat: Add custom CatalogSource support and per-operator catalog overr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ xxxxx-xxxxx-xxxxx-xxxxx
 | -------- | ----------- |
 | [Bastion MinIO](docs/bastion-minio.md) | Deploying S3-compatible object storage on the bastion |
 | [CI](docs/ci.md) | Continuous integration details |
+| [Custom CatalogSources](docs/custom-catalogsources.md) | Custom operator catalogs and per-operator CatalogSource overrides |
 | [Disconnected API/Console Access](docs/disconnected-ipv6-cluster-access.md) | Accessing disconnected IPv6 clusters |
 | [Hypervisors](docs/hypervisors.md) | Managing hypervisor nodes and VMs |
 | [Local Storage](docs/local-storage.md) | Configuring the Local Storage Operator (LSO) for control-plane and worker nodes |

--- a/ansible/roles/mno-post-cluster-install/defaults/main/main.yml
+++ b/ansible/roles/mno-post-cluster-install/defaults/main/main.yml
@@ -27,6 +27,7 @@ setup_performance_dashboards: false
 # Deploy ansible-automation-platform operator
 setup_ansible_automation_platform: false
 aap_channel: stable-2.6-cluster-scoped
+aap_catalogsource: redhat-operators
 aap_enable_overrides: false
 # MAX_CONCURRENT_RECONCILES_ANSIBLEJOB_TOWER_ANSIBLE_COM
 aap_override_max_concurrent_ajt: 10
@@ -36,6 +37,10 @@ aap_override_max_concurrent_awt: 10
 # Deploy openshift-gitops-operator
 setup_openshift_gitops: false
 gitops_channel: stable
+gitops_catalogsource: redhat-operators
+
+# Local Storage Operator (LSO) catalog source
+lso_catalogsource: redhat-operators
 
 # Migrate the ingresscontrollers and/or monitoring components to the master nodes
 # Used during nodedensity testing to ensure these things are more available
@@ -59,6 +64,16 @@ minio_pv_storageclass: localstorage2-sc
 # Performance-addon-operator vars_files
 install_performance_addon_operator: false
 ocp_channel: "{{ openshift_version }}"
+pao_catalogsource: redhat-operators
+
+# Custom CatalogSources to apply post-install
+# Each entry creates a CatalogSource resource in openshift-marketplace
+# custom_catalogsources:
+# - name: my-custom-catalog
+#   image: quay.io/my-org/my-operator-index:v4.21
+#   displayName: My Custom Catalog
+#   publisher: My Org
+custom_catalogsources: []
 
 # Additional labels to apply to worker nodes post-install (list of key=value or key= strings)
 post_install_node_labels:

--- a/ansible/roles/mno-post-cluster-install/defaults/main/odf.yml
+++ b/ansible/roles/mno-post-cluster-install/defaults/main/odf.yml
@@ -6,6 +6,7 @@ setup_odf: false
 
 # ODF operator subscription channel
 odf_channel: stable-4.21
+odf_catalogsource: redhat-operators
 
 # StorageCluster configuration
 

--- a/ansible/roles/mno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/mno-post-cluster-install/tasks/main.yml
@@ -8,6 +8,7 @@
   loop:
     - "{{ bastion_cluster_config_dir }}"
     - "{{ bastion_cluster_config_dir }}/aap"
+    - "{{ bastion_cluster_config_dir }}/catalogsources"
     - "{{ bastion_cluster_config_dir }}/gitops"
     - "{{ bastion_cluster_config_dir }}/localstorage"
     - "{{ bastion_cluster_config_dir }}/minio"
@@ -78,6 +79,8 @@
       dest: "{{ bastion_cluster_config_dir }}/openshift-monitoring/cluster-monitoring-config.yml"
     - src: performance-addon-operator.yml.j2
       dest: "{{ bastion_cluster_config_dir }}/performance-addon-operator/performance-addon-operator.yml"
+    - src: catalogsource.yml.j2
+      dest: "{{ bastion_cluster_config_dir }}/catalogsources/catalogsource.yml"
 
 - name: Clone performance-dashboards
   git:
@@ -134,6 +137,11 @@
   shell: |
     KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc apply -f {{ sync_path }}/operators/{{ operator_index_name }}/working-dir/cluster-resources/{{ generated_operator_index_name_tag }}.yaml
   when: use_bastion_registry | default(false)
+
+- name: Apply custom CatalogSources
+  shell: |
+    KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc apply -f {{ bastion_cluster_config_dir }}/catalogsources/catalogsource.yml
+  when: custom_catalogsources | length > 0
 
 - name: Install Ansible-Automation-Platform-operator
   shell: |

--- a/ansible/roles/mno-post-cluster-install/templates/ansible-automation-platform-operator.yml.j2
+++ b/ansible/roles/mno-post-cluster-install/templates/ansible-automation-platform-operator.yml.j2
@@ -21,10 +21,10 @@ spec:
   installPlanApproval: Automatic
   name: ansible-automation-platform-operator
   channel: {{ aap_channel }}
-{% if use_bastion_registry | default(false) %}
+{% if use_bastion_registry | default(false) and aap_catalogsource == 'redhat-operators' %}
   source: {{ generated_operator_index_name_tag }}
 {% else %}
-  source: redhat-operators
+  source: {{ aap_catalogsource }}
 {% endif %}
   sourceNamespace: openshift-marketplace
 {% if aap_enable_overrides %}

--- a/ansible/roles/mno-post-cluster-install/templates/catalogsource.yml.j2
+++ b/ansible/roles/mno-post-cluster-install/templates/catalogsource.yml.j2
@@ -1,0 +1,13 @@
+{% for cs in custom_catalogsources %}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: {{ cs.name }}
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: {{ cs.image }}
+  displayName: {{ cs.displayName | default(cs.name) }}
+  publisher: {{ cs.publisher | default('Custom') }}
+{% endfor %}

--- a/ansible/roles/mno-post-cluster-install/templates/localstorage.yml.j2
+++ b/ansible/roles/mno-post-cluster-install/templates/localstorage.yml.j2
@@ -24,9 +24,9 @@ spec:
   installPlanApproval: Automatic
   name: local-storage-operator
   channel: stable
-{% if use_bastion_registry | default(false) %}
+{% if use_bastion_registry | default(false) and lso_catalogsource == 'redhat-operators' %}
   source: {{ generated_operator_index_name_tag }}
 {% else %}
-  source: redhat-operators
+  source: {{ lso_catalogsource }}
 {% endif %}
   sourceNamespace: openshift-marketplace

--- a/ansible/roles/mno-post-cluster-install/templates/odf.yml.j2
+++ b/ansible/roles/mno-post-cluster-install/templates/odf.yml.j2
@@ -23,10 +23,10 @@ metadata:
 spec:
   channel: "{{ odf_channel }}"
   name: odf-operator
-{% if use_bastion_registry | default(false) %}
+{% if use_bastion_registry | default(false) and odf_catalogsource == 'redhat-operators' %}
   source: {{ generated_operator_index_name_tag }}
 {% else %}
-  source: redhat-operators
+  source: {{ odf_catalogsource }}
 {% endif %}
   sourceNamespace: openshift-marketplace
   installPlanApproval: Automatic

--- a/ansible/roles/mno-post-cluster-install/templates/openshift-gitops-operator.yml.j2
+++ b/ansible/roles/mno-post-cluster-install/templates/openshift-gitops-operator.yml.j2
@@ -26,8 +26,8 @@ spec:
   sourceNamespace: openshift-marketplace
   channel: {{ gitops_channel }}
   installPlanApproval: Automatic
-{% if use_bastion_registry | default(false) %}
+{% if use_bastion_registry | default(false) and gitops_catalogsource == 'redhat-operators' %}
   source: {{ generated_operator_index_name_tag }}
 {% else %}
-  source: redhat-operators
+  source: {{ gitops_catalogsource }}
 {% endif %}

--- a/ansible/roles/mno-post-cluster-install/templates/performance-addon-operator.yml.j2
+++ b/ansible/roles/mno-post-cluster-install/templates/performance-addon-operator.yml.j2
@@ -20,5 +20,9 @@ metadata:
 spec:
   channel: "{{ ocp_channel }}"
   name: performance-addon-operator
-  source: redhat-operators
+{% if use_bastion_registry | default(false) and pao_catalogsource == 'redhat-operators' %}
+  source: {{ generated_operator_index_name_tag }}
+{% else %}
+  source: {{ pao_catalogsource }}
+{% endif %}
   sourceNamespace: openshift-marketplace

--- a/ansible/roles/sno-post-cluster-install/defaults/main/main.yml
+++ b/ansible/roles/sno-post-cluster-install/defaults/main/main.yml
@@ -16,6 +16,10 @@ remove_assisted_installer_namespace: false
 # Deploy openshift-gitops-operator
 setup_openshift_gitops: false
 gitops_channel: stable
+gitops_catalogsource: redhat-operators
+
+# Local Storage Operator (LSO) catalog source
+lso_catalogsource: redhat-operators
 
 # Minio deployment is an object storage pod for use with ACM
 setup_minio: false
@@ -39,9 +43,19 @@ du_profile: false
 
 # Performance-addon-operator and du profile vars
 install_performance_addon_operator: false
+pao_catalogsource: redhat-operators
 hugepages_count: 16
 node: 0
 isolated_cpus: 2-47,50-95
+
+# Custom CatalogSources to apply post-install
+# Each entry creates a CatalogSource resource in openshift-marketplace
+# custom_catalogsources:
+# - name: my-custom-catalog
+#   image: quay.io/my-org/my-operator-index:v4.21
+#   displayName: My Custom Catalog
+#   publisher: My Org
+custom_catalogsources: []
 
 # Additional labels to apply to all nodes post-install (list of key=value or key= strings)
 post_install_node_labels:

--- a/ansible/roles/sno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/sno-post-cluster-install/tasks/main.yml
@@ -8,6 +8,7 @@
   loop:
   - "{{ bastion_cluster_config_dir }}"
   - "{{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}"
+  - "{{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/catalogsources"
   - "{{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/gitops"
   - "{{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/localstorage"
   - "{{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/metal3"
@@ -64,6 +65,8 @@
     dest: "{{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/metal3/metal3.yml"
   - src: openshift-marketplace-ns.yaml
     dest: "{{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/openshift-marketplace-ns.yaml"
+  - src: catalogsource.yml.j2
+    dest: "{{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/catalogsources/catalogsource.yml"
 
 - name: Add kube-burner sa
   shell: |
@@ -112,6 +115,11 @@
   shell: |
     KUBECONFIG={{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/kubeconfig oc apply -f {{ sync_path }}/operators/{{ operator_index_name }}/working-dir/cluster-resources/{{ generated_operator_index_name_tag }}.yaml
   when: use_bastion_registry | default(false)
+
+- name: Apply custom CatalogSources
+  shell: |
+    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/kubeconfig oc apply -f {{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/catalogsources/catalogsource.yml
+  when: custom_catalogsources | length > 0
 
 # Part of DU Profile (Not completely in du_profile_tasks.yml)
 - name: Annotate catalogSource.yaml to pin opm to reserved cores for DUs

--- a/ansible/roles/sno-post-cluster-install/templates/catalogsource.yml.j2
+++ b/ansible/roles/sno-post-cluster-install/templates/catalogsource.yml.j2
@@ -1,0 +1,13 @@
+{% for cs in custom_catalogsources %}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: {{ cs.name }}
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: {{ cs.image }}
+  displayName: {{ cs.displayName | default(cs.name) }}
+  publisher: {{ cs.publisher | default('Custom') }}
+{% endfor %}

--- a/ansible/roles/sno-post-cluster-install/templates/localstorage.yml.j2
+++ b/ansible/roles/sno-post-cluster-install/templates/localstorage.yml.j2
@@ -24,9 +24,9 @@ spec:
   installPlanApproval: Automatic
   name: local-storage-operator
   channel: stable
-{% if use_bastion_registry | default(false) %}
+{% if use_bastion_registry | default(false) and lso_catalogsource == 'redhat-operators' %}
   source: {{ generated_operator_index_name_tag }}
 {% else %}
-  source: redhat-operators
+  source: {{ lso_catalogsource }}
 {% endif %}
   sourceNamespace: openshift-marketplace

--- a/ansible/roles/sno-post-cluster-install/templates/openshift-gitops-operator.yml.j2
+++ b/ansible/roles/sno-post-cluster-install/templates/openshift-gitops-operator.yml.j2
@@ -26,8 +26,8 @@ spec:
   sourceNamespace: openshift-marketplace
   channel: {{ gitops_channel }}
   installPlanApproval: Automatic
-{% if use_bastion_registry | default(false) %}
+{% if use_bastion_registry | default(false) and gitops_catalogsource == 'redhat-operators' %}
   source: {{ generated_operator_index_name_tag }}
 {% else %}
-  source: redhat-operators
+  source: {{ gitops_catalogsource }}
 {% endif %}

--- a/ansible/roles/sno-post-cluster-install/templates/performance-addon-operator.yml.j2
+++ b/ansible/roles/sno-post-cluster-install/templates/performance-addon-operator.yml.j2
@@ -20,9 +20,9 @@ metadata:
 spec:
   channel: "{{ ocp_channel }}"
   name: performance-addon-operator
-{% if use_bastion_registry | default(false) %}
-  source: {{ operator_index_name }}
+{% if use_bastion_registry | default(false) and pao_catalogsource == 'redhat-operators' %}
+  source: {{ generated_operator_index_name_tag }}
 {% else %}
-  source: redhat-operators
+  source: {{ pao_catalogsource }}
 {% endif %}
   sourceNamespace: openshift-marketplace

--- a/docs/custom-catalogsources.md
+++ b/docs/custom-catalogsources.md
@@ -1,0 +1,147 @@
+# Custom CatalogSources and Per-Operator Overrides
+
+Jetlag supports applying custom [CatalogSource](https://docs.openshift.com/container-platform/latest/operators/understanding/olm-understanding-operatorhub.html) resources to the cluster post-install and overriding the catalog source used by each operator's Subscription. This allows operators to be installed from custom or third-party operator indexes instead of the default `redhat-operators` catalog.
+
+_**Table of Contents**_
+
+<!-- TOC -->
+- [Custom CatalogSources and Per-Operator Overrides](#custom-catalogsources-and-per-operator-overrides)
+  - [Use cases](#use-cases)
+  - [Custom CatalogSources](#custom-catalogsources)
+    - [Variables](#variables)
+    - [Configuration example](#configuration-example)
+  - [Per-operator CatalogSource overrides](#per-operator-catalogsource-overrides)
+    - [Override variables](#override-variables)
+    - [Precedence](#precedence)
+  - [Full example: ODF from a custom catalog](#full-example-odf-from-a-custom-catalog)
+  - [Multiple custom catalogs](#multiple-custom-catalogs)
+<!-- /TOC -->
+
+## Use cases
+
+- Install pre-release or development builds of operators from a custom index image
+- Use a third-party operator catalog alongside the default Red Hat catalog
+- Test specific operator versions that are not yet available in the default catalog
+- Install different operators from different custom catalogs
+
+## Custom CatalogSources
+
+The `custom_catalogsources` variable defines CatalogSource resources that are applied to the `openshift-marketplace` namespace during post-install. Each entry creates a separate CatalogSource that operators can subscribe to.
+
+### Variables
+
+Add these to the `Extra vars` section of `ansible/vars/all.yml` (or `ansible/vars/ibmcloud.yml`).
+
+| Variable | Type | Description |
+| -------- | ---- | ----------- |
+| `custom_catalogsources` | list | List of CatalogSource definitions to apply (default: `[]`) |
+| `custom_catalogsources[].name` | string | Name of the CatalogSource resource |
+| `custom_catalogsources[].image` | string | Index image reference (e.g., `quay.io/org/index:tag`) |
+| `custom_catalogsources[].displayName` | string | Display name shown in OperatorHub (default: value of `name`) |
+| `custom_catalogsources[].publisher` | string | Publisher name (default: `Custom`) |
+
+### Configuration example
+
+```yaml
+################################################################################
+# Extra vars
+################################################################################
+
+custom_catalogsources:
+- name: my-custom-catalog
+  image: quay.io/my-org/my-operator-index:v4.21
+  displayName: My Custom Catalog
+  publisher: My Org
+```
+
+This creates the following CatalogSource in the cluster:
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: my-custom-catalog
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: quay.io/my-org/my-operator-index:v4.21
+  displayName: My Custom Catalog
+  publisher: My Org
+```
+
+## Per-operator CatalogSource overrides
+
+Each post-install operator can be pointed to a specific CatalogSource by setting a per-operator override variable. When set, the override takes precedence over all other catalog source selection logic.
+
+### Override variables
+
+| Variable | Default | Operator | Applies to |
+| -------- | ------- | -------- | ---------- |
+| `odf_catalogsource` | `redhat-operators` | OpenShift Data Foundation | MNO |
+| `lso_catalogsource` | `redhat-operators` | Local Storage Operator | MNO, SNO |
+| `gitops_catalogsource` | `redhat-operators` | OpenShift GitOps | MNO, SNO |
+| `aap_catalogsource` | `redhat-operators` | Ansible Automation Platform | MNO |
+| `pao_catalogsource` | `redhat-operators` | Performance Addon Operator | MNO, SNO |
+
+All variables default to `redhat-operators`. When left at the default, the existing behavior is preserved (bastion registry catalog if `use_bastion_registry: true`, otherwise `redhat-operators`). Setting a variable to any other value overrides both the bastion registry catalog and the default.
+
+### Precedence
+
+The catalog source for each operator Subscription is determined in this order:
+
+1. **Per-operator override** (e.g., `odf_catalogsource`) - highest priority
+2. **Bastion registry catalog** (`generated_operator_index_name_tag`) - when `use_bastion_registry: true`
+3. **Default** (`redhat-operators`) - fallback
+
+## Full example: ODF from a custom catalog
+
+This example installs ODF from a custom operator index while leaving LSO on the default `redhat-operators` catalog.
+
+```yaml
+################################################################################
+# Extra vars
+################################################################################
+
+# Define the custom CatalogSource
+custom_catalogsources:
+- name: odf-testing-catalog
+  image: quay.io/my-org/odf-operator-index:v4.21-rc1
+  displayName: ODF Testing Catalog
+  publisher: My Org
+
+# Point only ODF at the custom catalog
+odf_catalogsource: odf-testing-catalog
+odf_channel: stable-4.21
+
+# LSO uses the default redhat-operators (no override set)
+controlplane_localstorage_configuration: true
+controlplane_localstorage_disk_devices:
+- /dev/disk/by-path/pci-0000:4a:00.0-scsi-0:0:2:0
+
+# Enable ODF
+setup_odf: true
+
+post_install_node_labels:
+- cluster.ocs.openshift.io/openshift-storage=
+```
+
+## Multiple custom catalogs
+
+You can define multiple CatalogSources and point different operators to different catalogs:
+
+```yaml
+custom_catalogsources:
+- name: odf-staging
+  image: quay.io/my-org/odf-index:v4.21-staging
+  displayName: ODF Staging
+  publisher: My Org
+- name: gitops-nightly
+  image: quay.io/my-org/gitops-index:nightly
+  displayName: GitOps Nightly
+  publisher: My Org
+
+# Each operator uses a different catalog
+odf_catalogsource: odf-staging
+gitops_catalogsource: gitops-nightly
+# LSO and AAP remain on the default redhat-operators catalog
+```


### PR DESCRIPTION
…ides

Allow custom CatalogSource resources to be applied post-install and enable each operator to use a different catalog source via override variables. This supports installing operators from custom or third-party operator indexes alongside or instead of the default redhat-operators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for applying custom Operator CatalogSources during post-install
  * Per-operator catalog source overrides (ODF, GitOps, Local Storage, AAP, PAO)

* **Behavior**
  * Catalog selection precedence: per-operator override → bastion-registry-generated catalog → default

* **Documentation**
  * New guide with examples for defining, mapping, and applying custom CatalogSources during post-install

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redhat-performance/jetlag/pull/824)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->