### PR TITLE
test: Add variable assertion to bastion-http role

### DIFF
--- a/ansible/roles/bastion-http/tasks/main.yml
+++ b/ansible/roles/bastion-http/tasks/main.yml
@@ -1,6 +1,13 @@
 ---
 # bastion-http tasks
 
+- name: Ensure http store path is defined
+  ansible.builtin.assert:
+    that:
+      - http_store_path is defined
+      - http_store_path | length > 0
+    fail_msg: "http_store_path must be defined and non-empty"
+
 - name: Create directories for bastion http server
   file:
     path: "{{ item }}"


### PR DESCRIPTION
## Summary
- Test PR to verify CodeRabbit reviews trigger correctly on draft-to-ready transitions
- Adds an `assert` task to validate `http_store_path` is defined before use

## Test plan
- [ ] Verify CodeRabbit skips review while PR is in draft
- [ ] Convert to ready-for-review and verify CodeRabbit triggers a full review
- [ ] Close PR after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)