### PR TITLE
Add ability to provide custom idms for the pre-ga content

### DIFF
--- a/ansible/roles/mno-post-cluster-install/defaults/main/main.yml
+++ b/ansible/roles/mno-post-cluster-install/defaults/main/main.yml
@@ -73,6 +73,9 @@ minio_pv_storageclass: localstorage2-sc
 #   publisher: My Org
 custom_catalogsources: []
 
+# IDMS Configurations for Pre-GA sources
+idms_prega_configuration: "{{ bastion_cluster_config_dir }}/catalogsources/prega-idms.yaml"
+
 # Additional labels to apply to worker nodes post-install (list of key=value or key= strings)
 post_install_node_labels:
   - jetlag=true

--- a/ansible/roles/mno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/mno-post-cluster-install/tasks/main.yml
@@ -94,15 +94,38 @@
     KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc adm policy add-cluster-role-to-user -z kubeburner cluster-admin
   when: setup_kube_burner_sa | default(true) | bool
 
+- name: Pre-GA block
+  when:
+    - use_prega_content | default(false) | bool
+    - prega_idms_link is defined
+    - prega_idms_link | length > 0
+  block:
+    - name: Delete previous IDMS configuration
+      ansible.builtin.file:
+        path: "{{ idms_prega_configuration }}"
+        state: absent
+
+    - name: Download IDMS configuration
+      ansible.builtin.uri:
+        url: "{{ prega_idms_link }}"
+        dest: "{{ idms_prega_configuration }}"
+        mode: '0644'
+      register: idms_download_result
+      until: idms_download_result is not failed
+      retries: 3
+      delay: 5
+
 - name: Disable default OperatorHub sources on bastion registry clusters
   shell: |
     KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc patch OperatorHub cluster --type json -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
-  when: use_bastion_registry | default(false)
+  when: (use_bastion_registry | default(false)) or (use_prega_content | default(false))
 
 - name: Apply oc mirror ImageDigestMirrorSet on bastion registry clusters
+  vars:
+    idms_configuration: "{{ use_prega_content | default(false) | ternary(idms_prega_configuration, idms_bastion_configuration) }}"
   shell: |
-    KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc apply -f {{ sync_path }}/operators/{{ operator_index_name }}/working-dir/cluster-resources/idms-oc-mirror.yaml
-  when: use_bastion_registry | default(false)
+    KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc apply -f {{ idms_configuration }}
+  when: (use_bastion_registry | default(false) | bool) or (use_prega_content | default(false) | bool)
 
 - name: Apply ImageTagMirrorSet on bastion registry clusters
   shell: |
@@ -119,6 +142,7 @@
     EOF
   loop: "{{ image_tag_mirrors | default([]) }}"
   when: use_bastion_registry | default(false)
+
 - name: Apply oc mirror catalogSource on bastion registry clusters
   shell: |
     KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc apply -f {{ sync_path }}/operators/{{ operator_index_name }}/working-dir/cluster-resources/{{ generated_operator_index_name_tag }}.yaml

--- a/ansible/roles/sno-post-cluster-install/defaults/main/main.yml
+++ b/ansible/roles/sno-post-cluster-install/defaults/main/main.yml
@@ -58,6 +58,9 @@ isolated_cpus: 2-47,50-95
 #   publisher: My Org
 custom_catalogsources: []
 
+# IDMS Configurations for Pre-GA sources
+idms_prega_configuration: "{{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/catalogsources/prega-idms.yaml"
+
 # Additional labels to apply to all nodes post-install (list of key=value or key= strings)
 post_install_node_labels:
   - jetlag=true

--- a/ansible/roles/sno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/sno-post-cluster-install/tasks/main.yml
@@ -78,10 +78,31 @@
     KUBECONFIG={{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/kubeconfig oc adm policy add-cluster-role-to-user -z kubeburner cluster-admin
   when: setup_kube_burner_sa | default(true) | bool
 
+- name: Pre-GA block
+  when:
+    - use_prega_content | default(false) | bool
+    - prega_idms_link is defined
+    - prega_idms_link | length > 0
+  block:
+    - name: Delete previous IDMS configuration
+      ansible.builtin.file:
+        path: "{{ idms_prega_configuration }}"
+        state: absent
+
+    - name: Download IDMS configuration
+      ansible.builtin.uri:
+        url: "{{ prega_idms_link }}"
+        dest: "{{ idms_prega_configuration }}"
+        mode: '0644'
+      register: idms_download_result
+      until: idms_download_result is not failed
+      retries: 3
+      delay: 5
+
 - name: Disable default OperatorHub sources on bastion registry clusters
   shell: |
     KUBECONFIG={{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/kubeconfig oc patch OperatorHub cluster --type json -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
-  when: use_bastion_registry | default(false)
+  when: (use_bastion_registry | default(false)) or (use_prega_content | default(false))
 
 - name: Create openshift-marketplace namespace for ocp 4.15 and higher releases DUs
   shell: |
@@ -91,9 +112,11 @@
   - openshift_version is version('4.15', ">=")
 
 - name: Apply oc mirror ImageDigestMirrorSet on bastion registry clusters
+  vars:
+    idms_configuration: "{{ use_prega_content | default(false) | ternary(idms_prega_configuration, idms_bastion_configuration) }}"
   shell: |
-    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/kubeconfig oc apply -f {{ sync_path }}/operators/{{ operator_index_name }}/working-dir/cluster-resources/idms-oc-mirror.yaml
-  when: use_bastion_registry | default(false)
+    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/kubeconfig oc apply -f {{ idms_configuration }}
+  when: (use_bastion_registry | default(false) | bool) or (use_prega_content | default(false) | bool)
 
 - name: Apply ImageTagMirrorSet on bastion registry clusters
   shell: |

--- a/ansible/roles/sync-operator-index/defaults/main.yml
+++ b/ansible/roles/sync-operator-index/defaults/main.yml
@@ -19,6 +19,9 @@ operator_index_tag: v4.19
 # for now we will continue to use the catalogsource although clustercatalog is a newer API
 generated_operator_index_name_tag: "cs-{{ operator_index_name }}-{{ operator_index_tag | replace('.', '-') }}"
 
+# IDMS Configuration for bastion registry
+idms_bastion_configuration: "{{ sync_path }}/operators/{{ operator_index_name }}/working-dir/cluster-resources/idms-oc-mirror.yaml"
+
 catalogs_to_sync:
 - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19
   packages:

--- a/ansible/vars/all.sample.yml
+++ b/ansible/vars/all.sample.yml
@@ -187,3 +187,7 @@ bond_vlan_id: 10
 # Extra vars
 ################################################################################
 # Append override vars below
+
+# Pre-GA content section
+use_prega_content: false
+# prega_idms_link: ""

--- a/docs/custom-catalogsources.md
+++ b/docs/custom-catalogsources.md
@@ -15,6 +15,7 @@ _**Table of Contents**_
     - [Precedence](#precedence)
   - [Full example: ODF from a custom catalog](#full-example-odf-from-a-custom-catalog)
   - [Multiple custom catalogs](#multiple-custom-catalogs)
+  - [Pre-GA content](#pre-ga-catalog-source)
 <!-- /TOC -->
 
 ## Use cases
@@ -23,6 +24,7 @@ _**Table of Contents**_
 - Use a third-party operator catalog alongside the default Red Hat catalog
 - Test specific operator versions that are not yet available in the default catalog
 - Install different operators from different custom catalogs
+- Use Pre-GA content
 
 ## Custom CatalogSources
 
@@ -144,3 +146,27 @@ odf_catalogsource: odf-staging
 gitops_catalogsource: gitops-nightly
 # LSO and AAP remain on the default redhat-operators catalog
 ```
+## Pre-GA catalog source
+Pre-GA content relies on the custom catalog with a few caveats and requirements
+
+### Requirements
+
+> !!! Important !!!
+>
+> Make sure your `pull-secret` has access to the pre-GA namespace.
+
+|variable|value|
+|-|-|
+|`use_prega_content`|`true`|
+|`prega_idms_link`|Should contain a valid IDMS for the respective catalog source|
+
+Custom catalog source should be named `redhat-operators` like following example:
+
+```yaml
+custom_catalogsources:
+- name: redhat-operators
+  image: quay.io/prega/prega-operator-index:v4.22
+  displayName: OpenShift Pre-GA Operators
+  publisher: Red Hat
+```
+Using `use_prega_content` will disable default catalog source


### PR DESCRIPTION
Building on top of the capabilities of the https://github.com/redhat-performance/jetlag/pull/824 this adds ability to download and apply the custom idms for the pre-ga content and additionally trigger some existing tasks on pre-ga content. The Pre-GA catalog source itself is setup through the https://github.com/redhat-performance/jetlag/pull/824 functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pre-GA catalog source support for post-install flows, including an option to fetch Pre-GA IDMS content from a provided link.
  * OperatorHub/catalog-source actions now run when either the bastion registry or Pre-GA content option is enabled; IDMS manifests are chosen accordingly.

* **Documentation**
  * Added Pre-GA content guidance, configuration flags, usage requirements, examples, and notes about default catalog-source behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redhat-performance/jetlag/pull/829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->