### PR TITLE
feat: Add dynamic VM bandwidth limiting playbook and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,3 +224,4 @@ xxxxx-xxxxx-xxxxx-xxxxx
 | [OpenShift Data Foundation (ODF)](docs/odf.md) | Installing ODF for Ceph-backed block, file, and object storage |
 | [Tips and Vars](docs/tips-and-vars.md) | Advanced configuration, network overrides, and extra variables |
 | [Troubleshooting](docs/troubleshooting.md) | Common deployment issues and solutions |
+| [VM Bandwidth](docs/vm-bandwidth.md) | Creation-time and dynamic bandwidth limiting for VMs |

--- a/ansible/hv-vm-bandwidth.yml
+++ b/ansible/hv-vm-bandwidth.yml
@@ -1,0 +1,54 @@
+---
+# Apply or remove bandwidth limits on VMs (running or powered off)
+#
+# Example Usage:
+#
+# Apply 1000 Mbit/s bandwidth limit to all VMs
+# ansible-playbook -i ansible/inventory/cloud42.local ansible/hv-vm-bandwidth.yml -e vm_bandwidth=1000
+#
+# Remove bandwidth limits from all VMs
+# ansible-playbook -i ansible/inventory/cloud42.local ansible/hv-vm-bandwidth.yml -e vm_bandwidth=0
+#
+# vm_bandwidth | Throughput             | bw_avg | bw_peak | bw_burst
+# -------------|------------------------|--------|---------|--------
+#            1 | 1 Mbit/s  (~125 KB/s)  |    115 |     125 |     117
+#           10 | 10 Mbit/s (~1.2 MB/s)  |   1150 |    1250 |    1175
+#           20 | 20 Mbit/s (~2.5 MB/s)  |   2300 |    2500 |    2350
+#          100 | 100 Mbit/s (~12.5 MB/s)|  11500 |   12500 |   11750
+#         1000 | 1 Gbit/s  (~125 MB/s)  | 115000 |  125000 |  117500
+#            0 | No limit (remove)      |      - |       - |       -
+#
+
+- name: Apply/remove bandwidth limits on VMs
+  hosts: hv_vm
+  gather_facts: false
+  vars:
+    vm_bandwidth: 0
+  tasks:
+  - name: Get VM state
+    ansible.builtin.command: virsh domstate {{ inventory_hostname }}
+    register: domstate_result
+    changed_when: false
+
+  - name: Set domiftune flags based on VM state
+    ansible.builtin.set_fact:
+      domiftune_flags: "{{ '--live --config' if domstate_result.stdout | trim == 'running' else '--config' }}"
+
+  - name: Remove bandwidth limit
+    ansible.builtin.command: >-
+      virsh domiftune {{ inventory_hostname }} {{ hostvars[inventory_hostname]['mac_address'] }}
+      --inbound 0 --outbound 0 {{ domiftune_flags }}
+    when: vm_bandwidth | int == 0
+
+  - name: Apply bandwidth limit
+    ansible.builtin.command: >-
+      virsh domiftune {{ inventory_hostname }} {{ hostvars[inventory_hostname]['mac_address'] }}
+      --inbound {{ vm_bandwidth_avg }},{{ vm_bandwidth_peak }},{{ vm_bandwidth_burst }}
+      --outbound {{ vm_bandwidth_avg }},{{ vm_bandwidth_peak }},{{ vm_bandwidth_burst }}
+      {{ domiftune_flags }}
+    vars:
+      vm_bandwidth_kbps: "{{ (vm_bandwidth | int) * 125 }}"
+      vm_bandwidth_peak: "{{ vm_bandwidth_kbps }}"
+      vm_bandwidth_avg: "{{ ((vm_bandwidth_kbps | int) * 0.92) | int }}"
+      vm_bandwidth_burst: "{{ ((vm_bandwidth_kbps | int) * 0.94) | int }}"
+    when: vm_bandwidth | int > 0

--- a/ansible/roles/create-inventory/defaults/main/main.yml
+++ b/ansible/roles/create-inventory/defaults/main/main.yml
@@ -30,7 +30,7 @@ hv_vm_cpu_count: 8
 hv_vm_memory_size: 18
 hv_vm_disk_size: 120
 
-# Bandwith limits for VMs (in KB/s)
+# Bandwidth limits for VMs (in KB/s) When enabled, the defaults below match 100Mbps network speed.
 hv_vm_bandwidth_limit: false
 hv_vm_bandwidth_average: 11500
 hv_vm_bandwidth_peak: 12500

--- a/docs/vm-bandwidth.md
+++ b/docs/vm-bandwidth.md
@@ -1,0 +1,123 @@
+# VM Bandwidth Limiting
+
+Jetlag provides two mechanisms for controlling VM network bandwidth: static limits applied at VM creation time via the libvirt domain XML, and dynamic limits applied to existing VMs via `virsh domiftune`.
+
+> **Note:** Bandwidth limits are applied per VM network interface. This is primarily intended for SNO deployments where each VM represents a single-node OpenShift cluster, allowing you to simulate low-bandwidth edge environments. Applying per-VM bandwidth limits to VMs that form a multi-node cluster (VMNO) will constrain each node individually, which may not accurately represent a shared network bottleneck.
+
+_**Table of Contents**_
+
+<!-- TOC -->
+- [VM Bandwidth Limiting](#vm-bandwidth-limiting)
+  - [Creation-time bandwidth limits](#creation-time-bandwidth-limits)
+    - [Variables](#variables)
+    - [Enabling creation-time limits](#enabling-creation-time-limits)
+    - [Changing creation-time limits after inventory generation](#changing-creation-time-limits-after-inventory-generation)
+  - [Dynamic bandwidth limits](#dynamic-bandwidth-limits)
+    - [Overview](#overview)
+    - [Apply a bandwidth limit](#apply-a-bandwidth-limit)
+    - [Remove a bandwidth limit](#remove-a-bandwidth-limit)
+  - [Bandwidth reference](#bandwidth-reference)
+  - [Interaction between creation-time and dynamic limits](#interaction-between-creation-time-and-dynamic-limits)
+    - [VMs created without bandwidth limits](#vms-created-without-bandwidth-limits)
+    - [VMs created with bandwidth limits](#vms-created-with-bandwidth-limits)
+<!-- /TOC -->
+
+## Creation-time bandwidth limits
+
+Bandwidth limits can be baked into the libvirt domain XML at VM creation time. When enabled, the limits are applied as part of `hv-vm-create.yml` (or `hv-vm-replace.yml`) and persist as long as the VM definition exists.
+
+### Variables
+
+The following variables control creation-time bandwidth limits and are defined in `ansible/roles/create-inventory/defaults/main/main.yml`. Override them in the `Extra vars` section of `ansible/vars/all.yml`.
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `hv_vm_bandwidth_limit` | `false` | Enable bandwidth limiting on VM network interfaces |
+| `hv_vm_bandwidth_average` | `11500` | Average bandwidth in KB/s (~92 Mbit/s) |
+| `hv_vm_bandwidth_peak` | `12500` | Peak bandwidth in KB/s (~100 Mbit/s) |
+| `hv_vm_bandwidth_burst` | `11750` | Burst bandwidth in KB/s (~94 Mbit/s) |
+
+### Enabling creation-time limits
+
+Set the following in the `Extra vars` section of `ansible/vars/all.yml` before running `create-inventory.yml`:
+
+```yaml
+################################################################################
+# Extra vars
+################################################################################
+hv_vm_bandwidth_limit: true
+
+# Optional: override the default bandwidth values (in KB/s)
+# hv_vm_bandwidth_average: 11500
+# hv_vm_bandwidth_peak: 12500
+# hv_vm_bandwidth_burst: 11750
+```
+
+Then regenerate the inventory and create VMs:
+
+```console
+[root@<bastion> jetlag]# ansible-playbook ansible/create-inventory.yml
+[root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/hv-vm-create.yml
+```
+
+The bandwidth limits are written into each VM's inventory entry and applied to the libvirt domain XML `<bandwidth>` element during VM creation.
+
+### Changing creation-time limits after inventory generation
+
+The bandwidth values (`bw_avg`, `bw_peak`, `bw_burst`) are baked into the generated inventory file when `create-inventory.yml` runs. To change the limits for future VMs, update the variables in `ansible/vars/all.yml` and rerun `create-inventory.yml` to regenerate the inventory.
+
+You can also edit the generated inventory file directly (e.g., `ansible/inventory/cloud99.local`) to apply different bandwidth limits to individual VMs. Each VM entry in the `[hv_vm]` section has `bw_avg`, `bw_peak`, and `bw_burst` values that can be adjusted independently. This is useful when you want to simulate a mix of bandwidth conditions across VMs, for example testing a fleet of SNOs with varying link speeds.
+
+## Dynamic bandwidth limits
+
+### Overview
+
+The `hv-vm-bandwidth.yml` playbook uses `virsh domiftune` to dynamically apply or remove bandwidth limits on VMs managed by Jetlag. It works on both running and powered-off VMs:
+
+- **Running VMs**: The limit is applied immediately and persisted to the VM definition so it survives reboots.
+- **Powered-off VMs**: The limit is persisted to the VM definition and takes effect on the next start.
+
+The playbook accepts a single extra variable `vm_bandwidth` specified in **Mbit/s**. The value maps to the peak bandwidth, with average (92%) and burst (94%) computed automatically to match the ratios used by the creation-time defaults.
+
+### Apply a bandwidth limit
+
+Pass `vm_bandwidth` with the desired limit in Mbit/s:
+
+```console
+[root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/hv-vm-bandwidth.yml -e vm_bandwidth=100
+```
+
+### Remove a bandwidth limit
+
+Pass `vm_bandwidth=0` to remove any existing limit:
+
+```console
+[root@<bastion> jetlag]# ansible-playbook -i ansible/inventory/cloud99.local ansible/hv-vm-bandwidth.yml -e vm_bandwidth=0
+```
+
+If `vm_bandwidth` is omitted, it defaults to `0` (remove limits).
+
+## Bandwidth reference
+
+The following table shows the dynamic `vm_bandwidth` value (Mbit/s) and the corresponding creation-time inventory variables (`bw_avg`, `bw_peak`, `bw_burst` in KB/s) for common bandwidth targets.
+
+| `vm_bandwidth` | Throughput | `bw_avg` | `bw_peak` | `bw_burst` |
+| --------------:| ---------- | -------: | --------: | ---------: |
+| 1 | 1 Mbit/s (~125 KB/s) | 115 | 125 | 117 |
+| 10 | 10 Mbit/s (~1.2 MB/s) | 1150 | 1250 | 1175 |
+| 20 | 20 Mbit/s (~2.5 MB/s) | 2300 | 2500 | 2350 |
+| 100 | 100 Mbit/s (~12.5 MB/s) | 11500 | 12500 | 11750 |
+| 1000 | 1 Gbit/s (~125 MB/s) | 115000 | 125000 | 117500 |
+| 0 | No limit (remove) | - | - | - |
+
+## Interaction between creation-time and dynamic limits
+
+The `hv-vm-bandwidth.yml` playbook works regardless of whether creation-time limits were used.
+
+### VMs created without bandwidth limits
+
+When `hv_vm_bandwidth_limit` is `false` (the default), VMs are created with no bandwidth restrictions. Running `hv-vm-bandwidth.yml` with a `vm_bandwidth` value adds a limit where none existed before. This is useful for testing bandwidth-constrained scenarios on VMs that were originally deployed without limits.
+
+### VMs created with bandwidth limits
+
+When `hv_vm_bandwidth_limit` is `true`, VMs are created with bandwidth limits defined in the libvirt domain XML. Running `hv-vm-bandwidth.yml` **overrides** those creation-time limits with the new value. Setting `vm_bandwidth=0` removes the limit entirely, even if the VM was originally created with one. Note that `hv-vm-replace.yml` will recreate VMs with whatever limits are defined in the inventory, so creation-time settings are restored on VM replacement.


### PR DESCRIPTION
Allow applying or removing bandwidth limits on running or powered-off VMs via virsh domiftune without redefining the VM. The playbook accepts a single vm_bandwidth variable in Mbit/s for quick adjustments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VM network bandwidth limiting with two methods: static limits at creation and dynamic limits applicable to running or stopped VMs.

* **Documentation**
  * Added comprehensive VM bandwidth limiting guide and linked it from the README.
  * Clarified default bandwidth commentary in inventory defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redhat-performance/jetlag/pull/831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->