### PR TITLE
Replace smcipmitool download link with new location

### DIFF
--- a/docs/deploy-mno-performancelab.md
+++ b/docs/deploy-mno-performancelab.md
@@ -208,7 +208,7 @@ Note: user has to add registry.ci.openshift.org token in pull-secret.txt for `ci
 
 ### Bastion node vars
 
-Set `smcipmitool_url` to the location of the Supermicro SMCIPMITool binary. Since you must accept a EULA in order to download, it is suggested to download the file and place it onto a local http server, that is accessible to your laptop or deployment machine. You can then always reference that URL. Alternatively, you can download it to the `ansible/` directory of your Jetlag repo clone and rename the file to `smcipmitool.tar.gz`. You can find the file [here](https://www.supermicro.com/SwDownload/SwSelect_Free.aspx?cat=IPMI).
+Set `smcipmitool_url` to the location of the Supermicro SMCIPMITool binary. Since you must accept a EULA in order to download, it is suggested to download the file and place it onto a local http server, that is accessible to your laptop or deployment machine. You can then always reference that URL. Alternatively, you can download it to the `ansible/` directory of your Jetlag repo clone and rename the file to `smcipmitool.tar.gz`. You can find the file [here](https://www.supermicro.com/en/support/resources/downloadcenter/smsdownload).
 
 **Network Interface Configuration:**
 

--- a/docs/deploy-sno-performancelab.md
+++ b/docs/deploy-sno-performancelab.md
@@ -212,7 +212,7 @@ For the ssh keys we have a chicken before the egg problem in that our bastion ma
 
 By default, Jetlag will choose the first node in an allocation as the bastion node.
 
-Set `smcipmitool_url` to the location of the Supermicro SMCIPMITool binary. Since you must accept a EULA in order to download, it is suggested to download the file and place it onto a local http server, that is accessible to your laptop or deployment machine. You can then always reference that URL. Alternatively, you can download it to the `ansible/` directory of your Jetlag repo clone and rename the file to `smcipmitool.tar.gz`. You can find the file [here](https://www.supermicro.com/SwDownload/SwSelect_Free.aspx?cat=IPMI).
+Set `smcipmitool_url` to the location of the Supermicro SMCIPMITool binary. Since you must accept a EULA in order to download, it is suggested to download the file and place it onto a local http server, that is accessible to your laptop or deployment machine. You can then always reference that URL. Alternatively, you can download it to the `ansible/` directory of your Jetlag repo clone and rename the file to `smcipmitool.tar.gz`. You can find the file [here](https://www.supermicro.com/en/support/resources/downloadcenter/smsdownload).
 
 **Network Interface Configuration:**
 


### PR DESCRIPTION
Fixes https://github.com/redhat-performance/jetlag/issues/832. I found the same issue in the multi-node variant of the docs so I changed it there as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Supermicro SMCIPMITool download resource links in deployment documentation guides. Documentation now points to the current Supermicro download center location instead of deprecated paths, affecting both single-node and multi-node performance lab deployment instructions to ensure users can readily access the latest tool resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redhat-performance/jetlag/pull/833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->