### PR TITLE
feat: validate bastion_lab_interface exists on bastion during setup-bastion

### DIFF
--- a/ansible/roles/validate-vars/tasks/main.yml
+++ b/ansible/roles/validate-vars/tasks/main.yml
@@ -207,3 +207,14 @@
       fail:
         msg: "For dual stack, controlplane_network[1] must be IPv6, got {{ controlplane_network[1] }}"
       when: not (controlplane_network[1] | ansible.utils.ipv6)
+
+- name: Validate bastion_lab_interface exists on the bastion host
+  fail:
+    msg: >-
+      bastion_lab_interface '{{ bastion_lab_interface }}' was not found on the bastion host.
+      Available interfaces: {{ ansible_interfaces | sort | join(', ') }}.
+      Check bastion_lab_interface in your all.yml or the lab/machine_type NIC mapping in lab.yml.
+  when:
+  - ansible_interfaces is defined
+  - bastion_lab_interface is defined
+  - bastion_lab_interface not in ansible_interfaces


### PR DESCRIPTION
Fails early in the `validate-vars` role when `bastion_lab_interface` is set to an interface that doesn't exist on the bastion, instead of failing later in `bastion-network` with a cryptic error.

fixes https://github.com/redhat-performance/jetlag/issues/666