### PR TITLE
Preserve operator sync IDMS and CatalogSource per index tag

### DIFF
--- a/ansible/roles/mno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/mno-post-cluster-install/tasks/main.yml
@@ -145,7 +145,7 @@
 
 - name: Apply oc mirror catalogSource on bastion registry clusters
   shell: |
-    KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc apply -f {{ sync_path }}/operators/{{ operator_index_name }}/working-dir/cluster-resources/{{ generated_operator_index_name_tag }}.yaml
+    KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc apply -f {{ catalogsource_bastion_configuration }}
   when: use_bastion_registry | default(false)
 
 - name: Apply custom CatalogSources

--- a/ansible/roles/sno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/sno-post-cluster-install/tasks/main.yml
@@ -136,7 +136,7 @@
 
 - name: Apply oc mirror catalogSource on bastion registry clusters
   shell: |
-    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/kubeconfig oc apply -f {{ sync_path }}/operators/{{ operator_index_name }}/working-dir/cluster-resources/{{ generated_operator_index_name_tag }}.yaml
+    KUBECONFIG={{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/kubeconfig oc apply -f {{ catalogsource_bastion_configuration }}
   when: use_bastion_registry | default(false)
 
 - name: Apply custom CatalogSources

--- a/ansible/roles/sync-operator-index/defaults/main.yml
+++ b/ansible/roles/sync-operator-index/defaults/main.yml
@@ -18,9 +18,13 @@ operator_index_tag: v4.19
 # oc mirror will create manifests for catalogsource and clustercatalog when it syncs the operator index,
 # for now we will continue to use the catalogsource although clustercatalog is a newer API
 generated_operator_index_name_tag: "cs-{{ operator_index_name }}-{{ operator_index_tag | replace('.', '-') }}"
+generated_catalogsource_name_tag: "{{ generated_operator_index_name_tag }}"
+generated_clustercatalog_name_tag: "cc-{{ operator_index_name }}-{{ operator_index_tag | replace('.', '-') }}"
 
-# IDMS Configuration for bastion registry
-idms_bastion_configuration: "{{ sync_path }}/operators/{{ operator_index_name }}/working-dir/cluster-resources/idms-oc-mirror.yaml"
+# Preserved cluster resource configurations (stored outside cluster-resources/ to survive subsequent oc mirror runs)
+idms_bastion_configuration: "{{ sync_path }}/operators/{{ operator_index_name }}/idms-oc-mirror-{{ operator_index_tag }}.yaml"
+catalogsource_bastion_configuration: "{{ sync_path }}/operators/{{ operator_index_name }}/{{ generated_catalogsource_name_tag }}.yaml"
+clustercatalog_bastion_configuration: "{{ sync_path }}/operators/{{ operator_index_name }}/{{ generated_clustercatalog_name_tag }}.yaml"
 
 catalogs_to_sync:
 - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19

--- a/ansible/roles/sync-operator-index/tasks/main.yml
+++ b/ansible/roles/sync-operator-index/tasks/main.yml
@@ -19,6 +19,27 @@
   shell: |
     oc mirror --authfile {{ registry_path }}/pull-secret-bastion.txt -c {{ sync_path }}/operators/{{ operator_index_name }}/imagesetconf.yml --workspace file://{{ sync_path }}/operators/{{ operator_index_name }} docker://{{ registry_host }}:{{ registry_port }} --v2
 
+- name: Preserve IDMS for this operator index tag
+  ansible.builtin.copy:
+    src: "{{ sync_path }}/operators/{{ operator_index_name }}/working-dir/cluster-resources/idms-oc-mirror.yaml"
+    dest: "{{ idms_bastion_configuration }}"
+    remote_src: true
+
+- name: Preserve CatalogSource for this operator index tag
+  ansible.builtin.copy:
+    src: "{{ sync_path }}/operators/{{ operator_index_name }}/working-dir/cluster-resources/{{ generated_catalogsource_name_tag }}.yaml"
+    dest: "{{ catalogsource_bastion_configuration }}"
+    remote_src: true
+
+  # Older oc mirror versions may not generate the cc-* ClusterCatalog file (OLM v1),
+  # and nothing currently applies it to the cluster, so a missing file is not fatal.
+- name: Preserve ClusterCatalog for this operator index tag
+  ansible.builtin.copy:
+    src: "{{ sync_path }}/operators/{{ operator_index_name }}/working-dir/cluster-resources/{{ generated_clustercatalog_name_tag }}.yaml"
+    dest: "{{ clustercatalog_bastion_configuration }}"
+    remote_src: true
+  ignore_errors: true
+
 - name: Mirror extra images with renaming support
   shell: |
     oc image mirror -a {{ registry_path }}/pull-secret-bastion.txt {{ item.src }} {{ registry_host }}:{{ registry_port }}/{{ item.dest }} --keep-manifest-list --continue-on-error=true

--- a/docs/bastion-registry.md
+++ b/docs/bastion-registry.md
@@ -6,6 +6,7 @@ _**Table of Contents**_
 <!-- TOC -->
 - [Bastion Mirror Registry](#bastion-mirror-registry)
   - [Enabling the registry](#enabling-the-registry)
+  - [Syncing an operator index](#syncing-an-operator-index)
   - [Add/delete contents to the bastion registry](#adddelete-contents-to-the-bastion-registry)
   - [Bandwidth limiting](#bandwidth-limiting)
 <!-- /TOC -->
@@ -23,6 +24,60 @@ use_bastion_registry: true
 ```
 
 The registry is deployed during `setup-bastion.yml` as a Podman pod named `registry` with a container named `bastion-registry`, listening on port 5000. It stores data under `/opt/registry/` on the bastion host.
+
+## Syncing an operator index
+
+The `sync-operator-index` playbook mirrors operator catalog images into the bastion registry using `oc mirror`. It generates the IDMS (ImageDigestMirrorSet), CatalogSource, and ClusterCatalog resources that clusters need to consume operators from the mirror.
+
+### Setup
+
+Copy and edit the sample vars file:
+
+```console
+(.ansible) [root@<bastion> jetlag]# cp ansible/vars/sync-operator-index.sample.yml ansible/vars/sync-operator-index.yml
+(.ansible) [root@<bastion> jetlag]# vi ansible/vars/sync-operator-index.yml
+```
+
+Key variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `operator_index_name` | `redhat-operator-index` | Destination index name in the registry |
+| `operator_index_tag` | `v4.19` | OCP version tag for the catalog |
+| `catalogs_to_sync` | *(see sample)* | List of catalog images and operator packages to mirror |
+| `additional_images` | `[]` | Extra images to mirror directly (no renaming) |
+| `extra_images` | `[]` | Extra images to mirror with renaming support |
+
+### Running the sync
+
+```console
+(.ansible) [root@<bastion> jetlag]# ansible-playbook ansible/sync-operator-index.yml
+```
+
+To override the tag at runtime (e.g. to sync a different OCP version):
+
+```console
+(.ansible) [root@<bastion> jetlag]# ansible-playbook ansible/sync-operator-index.yml -e operator_index_tag=v4.20
+```
+
+### Multiple OCP versions
+
+The `oc mirror` command clears the `cluster-resources/` directory on each run, which would destroy the IDMS and CatalogSource files from a previous sync. To support environments where multiple OCP versions share the same bastion registry (e.g. a 4.21 hub cluster alongside 4.20 SNO clusters), the playbook automatically preserves these artifacts per `operator_index_tag` after each sync:
+
+| Artifact | Preserved path |
+| --- | --- |
+| IDMS | `<sync_path>/operators/<operator_index_name>/idms-oc-mirror-<tag>.yaml` |
+| CatalogSource | `<sync_path>/operators/<operator_index_name>/cs-<operator_index_name>-<tag>.yaml` |
+| ClusterCatalog | `<sync_path>/operators/<operator_index_name>/cc-<operator_index_name>-<tag>.yaml` |
+
+This means you can sync 4.21 operators, then sync 4.20 operators, and redeploying the 4.21 hub cluster will still apply the correct 4.21 IDMS and CatalogSource — as long as `operator_index_tag` is set to `v4.21` in your vars at deployment time.
+
+> [!NOTE]
+> Images mirrored into the registry are additive — syncing a new version does not remove images from a previous sync. Only the `cluster-resources/` manifests are regenerated.
+
+### Post-install application
+
+During cluster deployment (`mno-deploy.yml` or `sno-deploy.yml`), the post-cluster-install role automatically applies the preserved IDMS and CatalogSource to the cluster when `use_bastion_registry: true` is set in `ansible/vars/all.yml`. Ensure `operator_index_tag` matches the OCP version of the cluster being deployed.
 
 ## Add/delete contents to the bastion registry
 


### PR DESCRIPTION
oc mirror --v2 clears the cluster-resources directory on each run, so syncing a different operator_index_tag overwrites the IDMS and CatalogSource from a previous sync. This causes problems when multiple OCP versions share the same bastion registry (e.g. a 4.21 hub cluster and 4.20 SNO clusters) — redeploying the hub would apply the wrong IDMS/CatalogSource.

After each sync, copy both artifacts to tag-versioned filenames outside the cluster-resources directory so subsequent syncs cannot clobber them. Update post-cluster-install roles to reference the preserved copies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for syncing operator catalog content into the bastion mirror registry using the sync-operator-index playbook
  * Operator index artifacts (IDMS, CatalogSource, and ClusterCatalog configurations) are now preserved per OCP tag, enabling multiple OCP versions to be supported in the same registry

* **Documentation**
  * Added comprehensive guide for syncing operator indexes to the bastion registry, including setup, configuration, and runtime usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->