### PR TITLE
fix: report registry container working set memory instead of raw cgro…

### DIFF
--- a/ansible/roles/hv-metrics-server/files/dashboards/bastion-dashboard.json
+++ b/ansible/roles/hv-metrics-server/files/dashboards/bastion-dashboard.json
@@ -658,8 +658,12 @@
       },
       "targets": [
         {
+          "expr": "registry_container_memory_working_set_bytes{job='bastion-system'}",
+          "legendFormat": "working set"
+        },
+        {
           "expr": "registry_container_memory_usage_bytes{job='bastion-system'}",
-          "legendFormat": "used"
+          "legendFormat": "total (incl. page cache)"
         }
       ],
       "fieldConfig": {

--- a/ansible/roles/hv-metrics-server/templates/registry-traffic-collector.sh.j2
+++ b/ansible/roles/hv-metrics-server/templates/registry-traffic-collector.sh.j2
@@ -53,6 +53,7 @@ tx_packets=$(( ${tx4_packets:-0} + ${tx6_packets:-0} ))
 
 cpu_seconds="0"
 mem_bytes="0"
+mem_working_set_bytes="0"
 mem_limit="0"
 
 REGISTRY_PID=$(podman inspect --format '{% raw %}{{.State.Pid}}{% endraw %}' "$REGISTRY_CONTAINER" 2>/dev/null)
@@ -65,6 +66,12 @@ if [[ -n "$REGISTRY_PID" && "$REGISTRY_PID" != "0" ]]; then
     cpu_usec=$(awk '/^usage_usec/ {print $2}' "${CGROUP_DIR}/cpu.stat" 2>/dev/null)
     cpu_seconds=$(echo "${cpu_usec:-0}" | awk '{printf "%.6f", $1/1000000}')
     mem_bytes=$(cat "${CGROUP_DIR}/memory.current" 2>/dev/null || echo "0")
+
+    inactive_file=$(awk '/^inactive_file / {print $2; exit}' "${CGROUP_DIR}/memory.stat" 2>/dev/null)
+    inactive_file=${inactive_file:-0}
+    if [[ "$mem_bytes" -gt "$inactive_file" ]]; then
+      mem_working_set_bytes=$(( mem_bytes - inactive_file ))
+    fi
 
     raw_limit=$(cat "${CGROUP_DIR}/memory.max" 2>/dev/null)
     if [[ "$raw_limit" != "max" ]]; then
@@ -98,9 +105,12 @@ registry_network_transmit_packets_total{port="${REGISTRY_PORT}",service="mirror_
 # HELP registry_container_cpu_usage_seconds_total Cumulative CPU time consumed by the registry container.
 # TYPE registry_container_cpu_usage_seconds_total counter
 registry_container_cpu_usage_seconds_total{container="${REGISTRY_CONTAINER}"} ${cpu_seconds}
-# HELP registry_container_memory_usage_bytes Current memory usage of the registry container.
+# HELP registry_container_memory_usage_bytes Current memory usage of the registry container (includes page cache).
 # TYPE registry_container_memory_usage_bytes gauge
 registry_container_memory_usage_bytes{container="${REGISTRY_CONTAINER}"} ${mem_bytes}
+# HELP registry_container_memory_working_set_bytes Working set memory of the registry container (excludes reclaimable page cache).
+# TYPE registry_container_memory_working_set_bytes gauge
+registry_container_memory_working_set_bytes{container="${REGISTRY_CONTAINER}"} ${mem_working_set_bytes}
 # HELP registry_container_memory_limit_bytes Memory limit of the registry container (0 if unlimited).
 # TYPE registry_container_memory_limit_bytes gauge
 registry_container_memory_limit_bytes{container="${REGISTRY_CONTAINER}"} ${mem_limit}

--- a/docs/hv-metrics.md
+++ b/docs/hv-metrics.md
@@ -124,7 +124,7 @@ Monitors the bastion machine with panels for:
 - **Disk Space**: Root filesystem used, root usage gauge (%), all mountpoints
 - **Disk I/O**: IOPS, throughput, I/O utilization (%) — selectable via **Disk Device** dropdown
 - **Network**: All physical interface bandwidth, received/transmitted breakdown — selectable via **Network Interface** dropdown
-- **Mirror Registry**: Container CPU usage (cores), container memory usage, active connections, bandwidth, throughput, cumulative bytes transferred, and packets/s (only populated when `setup_bastion_registry` is enabled)
+- **Mirror Registry**: Container CPU usage (cores), container memory (working set and total), active connections, bandwidth, throughput, cumulative bytes transferred, and packets/s (only populated when `setup_bastion_registry` is enabled)
 
 > **Note:** Registry bandwidth (measured via iptables at the IP layer) may appear 5-10% higher than the NIC-level bandwidth shown in the Network section. This is expected — iptables counts TCP/IP headers that are not included in the interface byte counters. The NIC graph reflects true wire bandwidth.
 
@@ -146,9 +146,19 @@ The following metrics are exposed:
 | `registry_network_receive_packets_total` | counter | Packets received by the registry |
 | `registry_network_transmit_packets_total` | counter | Packets transmitted by the registry |
 | `registry_container_cpu_usage_seconds_total` | counter | Cumulative CPU time consumed by the registry container |
-| `registry_container_memory_usage_bytes` | gauge | Current memory usage of the registry container |
+| `registry_container_memory_usage_bytes` | gauge | Total memory charged to the registry container cgroup (includes reclaimable page cache) |
+| `registry_container_memory_working_set_bytes` | gauge | Working set memory of the registry container (`memory.current - inactive_file`) |
 | `registry_container_memory_limit_bytes` | gauge | Memory limit of the registry container (0 if unlimited) |
 | `registry_network_connections` | gauge | Current number of established connections to the registry |
+
+### Registry Memory Metrics
+
+The dashboard shows two memory series for the registry container:
+
+- **working set** — `memory.current - inactive_file` from the container's cgroup. This is the same calculation that `podman stats` and `docker stats` use ([containers/common#2454](https://github.com/containers/common/issues/2454)). It excludes inactive file-backed page cache that the kernel can reclaim under memory pressure.
+- **total (incl. page cache)** — the raw `memory.current` value from the cgroup. This includes all memory charged to the container, including reclaimable page cache from serving container images. This value can appear significantly higher than actual memory consumption (e.g. 75 GiB vs 1 GiB) on systems with large registries.
+
+Both values will differ from `top` RES for the registry process. `top` shows per-process resident pages (anonymous + file-mapped memory), while the cgroup metrics include kernel memory charged to the container (slab, socket buffers, etc.) that doesn't appear in any single process's RSS.
 
 ## Resetting Registry Traffic Counters
 


### PR DESCRIPTION
…up usage

The registry container memory panel was showing cgroup memory.current which includes reclaimable page cache, inflating reported usage (~75 GiB) far beyond actual working set memory (~25 GiB). Add a working_set metric computed as memory.current minus inactive_file (matching kubectl top / cadvisor approach) and display it as the primary series on the dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registry container memory dashboard now displays working set and total memory metrics separately.
  * Added working set memory metric collection for registry containers.

* **Documentation**
  * Updated documentation explaining registry memory metrics (working set vs. total) and calculation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->