### PR TITLE
Add ability to use hv with sno deployments

### DIFF
--- a/ansible/roles/create-inventory/tasks/main.yml
+++ b/ansible/roles/create-inventory/tasks/main.yml
@@ -336,83 +336,83 @@
 - name: Single Node OpenShift cluster type tasks
   when: cluster_type == "sno"
   block:
+    - name: SNO - Set ocpinventory hv nodes
+      when: hv_inventory | bool
+      ansible.builtin.set_fact:
+        ocpinventory_hv_nodes: "{{ ocpinventory.json.nodes[2:] }}"
 
-  - name: SNO - Set ocpinventory sno nodes
-    set_fact:
-      ocpinventory_sno_nodes: "{{ ocpinventory.json.nodes[1:] }}"
+    - name: SNO - Set ocpinventory sno nodes
+      ansible.builtin.set_fact:
+        ocpinventory_sno_nodes: "{{ ocpinventory.json.nodes[1:2] if hv_inventory | bool else ocpinventory.json.nodes[1:] }}"
 
-  - name: SNO - Set max number of nodes
-    set_fact:
-      max_nodes: "{{ ocpinventory.json.nodes|length }}"
-    when: worker_node_count is not defined or worker_node_count == None
+    - name: SNO - Set max number of nodes
+      ansible.builtin.set_fact:
+        max_nodes: "{{ ocpinventory.json.nodes|length }}"
+      when: worker_node_count is not defined or worker_node_count == None
 
-  - name: SNO - Set max number of nodes (worker_node_count set)
-    set_fact:
-      max_nodes: "{{ worker_node_count|int + 2 }}"
-    when: worker_node_count is defined and worker_node_count != None
+    - name: SNO - Set max number of nodes (worker_node_count set)
+      ansible.builtin.set_fact:
+        max_nodes: "{{ worker_node_count|int + 2 }}"
+      when: worker_node_count is defined and worker_node_count != None
 
-  - name: SNO - Set ocpinventory worker nodes (for scale-out scenarios)
-    set_fact:
-      ocpinventory_worker_nodes: "{{ ocpinventory.json.nodes[2:max_nodes|int] }}"
+    - name: SNO - Set ocpinventory worker nodes (for scale-out scenarios)
+      when:
+        - not (hv_inventory | bool)
+        - worker_node_count is defined
+        - worker_node_count != None
+      ansible.builtin.set_fact:
+        ocpinventory_worker_nodes: "{{ ocpinventory.json.nodes[2:max_nodes|int] }}"
 
-  - name: SNO - Get lab data for each sno
-    uri:
-      url: "https://{{ labs[lab]['foreman'] }}/api/hosts/{{ item.pm_addr | replace('mgmt-','') }}"
-      force_basic_auth: yes
-      user: "{{ lab_cloud }}"
-      password: "{{ bmc_password }}"
-      validate_certs: false
-    register: sno_foreman_data
-    loop: "{{ ocpinventory_sno_nodes }}"
+    - name: SNO - Get lab data for each sno
+      ansible.builtin.uri:
+        url: "https://{{ labs[lab]['foreman'] }}/api/hosts/{{ item.pm_addr | replace('mgmt-','') }}"
+        force_basic_auth: true
+        user: "{{ lab_cloud }}"
+        password: "{{ bmc_password }}"
+        validate_certs: false
+      register: sno_foreman_data
+      loop: "{{ ocpinventory_sno_nodes }}"
 
-  - name: SNO - Get lab mac address for worker nodes
-    uri:
-      url: "https://{{ labs[lab]['foreman'] }}/api/hosts/{{ item.pm_addr | replace('mgmt-','') }}"
-      force_basic_auth: yes
-      user: "{{ lab_cloud }}"
-      password: "{{ bmc_password }}"
-      validate_certs: false
-    loop: "{{ ocpinventory_worker_nodes }}"
-    when: cluster_type == "sno" and ocpinventory_worker_nodes|length > 0
-    register: sno_worker_foreman_data
-    
-  - name: SNO - Auto-configure bond interface names from hardware mapping (when bonding is enabled)
-    set_fact:
-      bond0_interface1: "{{ hw_nic_name[lab][machine_type][bond0_port1|int] }}"
-      bond0_interface2: "{{ hw_nic_name[lab][machine_type][bond0_port2|int] }}"
-    when:
-      - enable_bond | default(false) and not (public_vlan | default(false))
-      - lab in hw_nic_name
-      - machine_type in hw_nic_name[lab]
-      - hw_nic_name[lab][machine_type] | length > (bond0_port2|int)
+    - name: SNO - Get lab mac address for worker nodes
+      ansible.builtin.uri:
+        url: "https://{{ labs[lab]['foreman'] }}/api/hosts/{{ item.pm_addr | replace('mgmt-','') }}"
+        force_basic_auth: true
+        user: "{{ lab_cloud }}"
+        password: "{{ bmc_password }}"
+        validate_certs: false
+      loop: "{{ ocpinventory_worker_nodes }}"
+      when: cluster_type == "sno" and ocpinventory_worker_nodes|length > 0
+      register: sno_worker_foreman_data
 
+    - name: SNO - Auto-configure bond interface names from hardware mapping (when bonding is enabled)
+      ansible.builtin.set_fact:
+        bond0_interface1: "{{ hw_nic_name[lab][machine_type][bond0_port1|int] }}"
+        bond0_interface2: "{{ hw_nic_name[lab][machine_type][bond0_port2|int] }}"
+      when:
+        - enable_bond | default(false) and not (public_vlan | default(false))
+        - lab in hw_nic_name
+        - machine_type in hw_nic_name[lab]
+        - hw_nic_name[lab][machine_type] | length > (bond0_port2|int)
 
+    - name: SNO - Add bond MAC addresses to hv nodes (when bonding is enabled)
+      when: enable_bond | default(false) and not (public_vlan | default(false))
+      ansible.builtin.set_fact:
+        ocpinventory_sno_nodes: >-
+          {{
+            ocpinventory_sno_nodes[:idx] +
+            [ocpinventory_sno_nodes[idx] | combine({
+              'bond0_macs': (item.mac[bond0_port1|int - 1 ] + ',' + item.mac[bond0_port2|int - 1])
+            })] +
+            ocpinventory_sno_nodes[idx + 1:]
+          }}
+      loop: "{{ ocpinventory_sno_nodes }}"
+      loop_control:
+        loop_var: item
+        index_var: idx
 
-  - name: SNO - Add bond MAC addresses to SNO nodes (when bonding is enabled)
-    when: enable_bond | default(false) and not (public_vlan | default(false))
-    set_fact:
-      ocpinventory_sno_nodes: >-
-        {{
-          ocpinventory_sno_nodes[:idx] +
-          [ocpinventory_sno_nodes[idx] | combine({
-            'bond0_macs': (item.mac[bond0_port1|int - 1 ] + ',' + item.mac[bond0_port2|int - 1])
-          })] +
-          ocpinventory_sno_nodes[idx + 1:]
-        }}
-    loop: "{{ ocpinventory_sno_nodes }}"
-    loop_control:
-      loop_var: item
-      index_var: idx
-
-  - name: set json query fact
-    set_fact:
-      mac_query: "json.interfaces[?type=='interface'].mac"
-
-  # Start at 2 because 1st is bastion, 2nd is SNO, rest are hypervisors
-  # Commented out until implementation is a requirement
-  # - name: SNO - Set ocpinventory hv nodes
-  #   set_fact:
-  #     ocpinventory_hv_nodes: "{{ ocpinventory.json.nodes[2:] }}"
+- name: set json query fact
+  set_fact:
+    mac_query: "json.interfaces[?type=='interface'].mac"
 
 - name: Loop over all OCP nodes to find Supermicro hardware
   include_tasks: find_supermicro.yml

--- a/ansible/roles/create-inventory/templates/inventory-sno.j2
+++ b/ansible/roles/create-inventory/templates/inventory-sno.j2
@@ -171,14 +171,55 @@ dns1_ipv6={{ controlplane_network[1] | ansible.utils.nthhost(1) }}
 {%   endif %}
 {% endif %}
 
+{% if hv_inventory | default(false) | bool %}
 [hv]
-# Unused
+{% for hv in ocpinventory_hv_nodes %}
+{{ hv.pm_addr | replace('mgmt-','') }} bmc_address={{ hv.pm_addr }} vendor={{ hw_vendor[(hv.pm_addr.split('.')[0]).split('-')[-1]] }} ip={{ controlplane_network[0] | ansible.utils.nthhost(loop.index + ocpinventory_worker_nodes|length + sno_controlplane_ip_offset + hv_ip_offset) }} nic={{ hw_nic_name[lab][(hv.pm_addr.split('.')[0]).split('-')[-1]][hypervisor_nic_interface_idx] }} disk2_enable={{ hv.disk2_enable }} disk2_device={{ hv.disk2_device }}
+{% endfor %}
 
 [hv:vars]
-# Unused
+ansible_user=root
+ansible_ssh_pass={{ hv_ssh_pass }}
+bmc_user={{ bmc_user }}
+bmc_password={{ bmc_password }}
+network_prefix={{ controlplane_network_prefix[0] }}
 
 [hv_vm]
-# Unused
+{% set ctr = namespace(vm=1) %}
+{% for hv in ocpinventory_hv_nodes %}
+{%   set hv_loop = loop %}
+{%   for vm in range(hw_vm_counts[lab][(hv.pm_addr.split('.')[0]).split('-')[-1]]['default']) %}
+{{ hv_vm_prefix }}{{ '%05d' % ctr.vm }} ansible_host={{ hv.pm_addr | replace('mgmt-','') }} hv_ip={{ controlplane_network[0] | ansible.utils.nthhost(hv_loop.index + ocpinventory_worker_nodes|length + sno_controlplane_ip_offset + hv_ip_offset) }} ip={{ controlplane_network[0] | ansible.utils.nthhost(hv_vm_ip_offset + ctr.vm - 1) }} cpus={{ hv_vm_cpu_count }} memory={{ hv_vm_memory_size }} disk_size={{ hv_vm_disk_size }} vnc_port={{ 5900 + loop.index }} mac_address={{ (90520730730496 + ctr.vm) | ansible.utils.hwaddr('linux') }} domain_uuid={{ ctr.vm | to_uuid }} disk_location=/var/lib/libvirt/images bw_avg={{ hv_vm_bandwidth_average }} bw_peak={{ hv_vm_bandwidth_peak }} bw_burst={{ hv_vm_bandwidth_burst }}
+{%     set ctr.vm = ctr.vm + 1 %}
+{%   endfor %}
+{%   if hv.disk2_enable %}
+{%     for vm in range(hw_vm_counts[lab][(hv.pm_addr.split('.')[0]).split('-')[-1]][hv.disk2_device]) %}
+{{ hv_vm_prefix }}{{ '%05d' % ctr.vm }} ansible_host={{ hv.pm_addr | replace('mgmt-','') }} hv_ip={{ controlplane_network[0] | ansible.utils.nthhost(hv_loop.index + ocpinventory_worker_nodes|length + sno_controlplane_ip_offset + hv_ip_offset) }} ip={{ controlplane_network[0] | ansible.utils.nthhost(hv_vm_ip_offset + ctr.vm - 1) }} cpus={{ hv_vm_cpu_count }} memory={{ hv_vm_memory_size }} disk_size={{ hv_vm_disk_size }} vnc_port={{ 5900 + loop.index + hw_vm_counts[lab][(hv.pm_addr.split('.')[0]).split('-')[-1]]['default'] }} mac_address={{ (90520730730496 + ctr.vm) | ansible.utils.hwaddr('linux') }} domain_uuid={{ ctr.vm | to_uuid }} disk_location={{ disk2_mount_path }}/libvirt/images bw_avg={{ hv_vm_bandwidth_average }} bw_peak={{ hv_vm_bandwidth_peak }} bw_burst={{ hv_vm_bandwidth_burst }}
+{%       set ctr.vm = ctr.vm + 1 %}
+{%     endfor %}
+{%   endif %}
+
+{% endfor %}
 
 [hv_vm:vars]
-# Unused
+ansible_user=root
+ansible_ssh_pass={{ hv_ssh_pass }}
+base_domain={{ base_dns_name }}
+machine_network={{ controlplane_network[0] }}
+network_prefix={{ controlplane_network_prefix[0] }}
+gateway={{ controlplane_network_gateway }}
+bw_limit={{ hv_vm_bandwidth_limit }}
+
+{% else %}
+[hv]
+# Set `hv_inventory: true` to populate
+
+[hv:vars]
+# Set `hv_inventory: true` to populate
+
+[hv_vm]
+# Set `hv_inventory: true` to populate
+
+[hv_vm:vars]
+# Set `hv_inventory: true` to populate
+{% endif %}


### PR DESCRIPTION
Add ability to use hypervisors with sno deployments for the SNO HUB + Virtual Spoke deployment use case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SNO hub deployments with virtual spoke cluster configurations.
  * Enhanced inventory generation for hypervisors and virtual machines, including networking, hardware, storage, sizing, and additional disks.
  * Added configurable hypervisor inventory output, with clear placeholders when the feature is disabled.

* **Bug Fixes**
  * Added validation to ensure adequate node allocation and defined worker counts for hub and spoke deployments.
  * Improved authentication and inventory configuration handling for more reliable setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->