### PR TITLE
Bump assisted installer to v2.53.2 and add image service health check

### DIFF
--- a/ansible/roles/bastion-assisted-installer/defaults/main/main.yml
+++ b/ansible/roles/bastion-assisted-installer/defaults/main/main.yml
@@ -1,8 +1,8 @@
 ---
 # bastion-assisted-installer default vars
 
-assisted_installer_tag: v2.45.2
-assisted_installer_ui_tag: v2.45.0
+assisted_installer_tag: v2.53.2
+assisted_installer_ui_tag: v2.52.2
 
 assisted_image_service_image: quay.io/edge-infrastructure/assisted-image-service:{{ assisted_installer_tag }}
 assisted_installer_image: quay.io/edge-infrastructure/assisted-installer:{{ assisted_installer_tag }}

--- a/ansible/roles/bastion-assisted-installer/tasks/main.yml
+++ b/ansible/roles/bastion-assisted-installer/tasks/main.yml
@@ -132,3 +132,13 @@
     volume:
     - /etc/pki/ca-trust/extracted/pem:/etc/pki/ca-trust/extracted/pem:Z
     state: started
+
+- name: Wait for assisted image service to be ready
+  uri:
+    url: "http://{{ assisted_installer_host }}:{{ assisted_image_service_port }}/health"
+    method: GET
+    status_code: [200]
+  register: image_service_health
+  until: image_service_health is success
+  retries: 30
+  delay: 10


### PR DESCRIPTION
## Summary
- Bump assisted installer components from v2.45.2 to v2.53.2 and UI from v2.45.0 to v2.52.2
- Add health check for the assisted image service after container start

## Problem
The assisted-image-service v2.45.2 crashes on OCP 5.0 (RHCOS 10.x / RHEL 10) because it expects `root.squashfs` during nmstatectl extraction, but RHEL 10-based RHCOS images use `root.erofs` instead. This causes a fatal error in the image service, killing port 8888 and resulting in `Connection refused` when downloading the discovery ISO.

Fixed upstream in https://github.com/openshift/assisted-image-service/pull/610 (first included in v2.49.0).

Additionally, there was no readiness check after starting the image-service container, leading to sporadic race conditions even when the service starts successfully.

## Changes
- `assisted_installer_tag`: v2.45.2 → v2.53.2
- `assisted_installer_ui_tag`: v2.45.0 → v2.52.2
- Added `Wait for assisted image service to be ready` task that polls `/health` on port 8888 (up to 5 minutes)

## Test plan
- [ ] Deploy SNO cluster with OCP 5.0 CI nightly (`5.0.0-0.nightly-2026-06-14-221055`)
- [ ] Verify image service starts without crashing (`podman logs image-service`)
- [ ] Verify discovery ISO downloads successfully
- [ ] Deploy MNO cluster with OCP 4.x GA release to confirm backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated health checks to verify the assisted image service is ready and operational before proceeding

* **Chores**
  * Updated assisted installer components to v2.53.2 and installer UI to v2.52.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->