### PR TITLE
Reduce memory validation from 32GiB to 16GiB for SNOs

### DIFF
--- a/ansible/roles/bastion-assisted-installer/templates/onprem-environment.j2
+++ b/ansible/roles/bastion-assisted-installer/templates/onprem-environment.j2
@@ -31,7 +31,7 @@ PUBLIC_CONTAINER_REGISTRIES=quay.io
 NTP_DEFAULT_SERVER=
 IPV6_SUPPORT=true
 AUTH_TYPE=none
-HW_VALIDATOR_REQUIREMENTS=[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":100,"packet_loss_percentage":0},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":1000,"packet_loss_percentage":10},"sno":{"cpu_cores":8,"ram_mib":32768,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10}}]
+HW_VALIDATOR_REQUIREMENTS=[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":100,"packet_loss_percentage":0},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":1000,"packet_loss_percentage":10},"sno":{"cpu_cores":8,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10}}]
 
 SKIP_CERT_VERIFICATION=true
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated hardware requirements for single-node deployments, reducing minimum RAM requirement from 32GB to 16GB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->