### PR TITLE
Update assisted_installer to include MGMT-24243 fix

### DIFF
--- a/ansible/roles/bastion-assisted-installer/defaults/main/main.yml
+++ b/ansible/roles/bastion-assisted-installer/defaults/main/main.yml
@@ -1,7 +1,7 @@
 ---
 # bastion-assisted-installer default vars
 
-assisted_installer_tag: v2.53.2
+assisted_installer_tag: stable.17.06.2026-02.05
 assisted_installer_ui_tag: v2.52.2
 
 assisted_image_service_image: quay.io/edge-infrastructure/assisted-image-service:{{ assisted_installer_tag }}


### PR DESCRIPTION
RHCOS10 introduced a race condition for static nework configuration on certain setups that [MGMT-24243](https://redhat.atlassian.net/browse/MGMT-24243) fixed.  Update assisted-service image tag to `stable.17.06.2026-02.05` which includes the fix.  I'll update the tag back to `v2.5x` version once a new tag including the fix is created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Assisted Installer services to a new stable container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->