### PR TITLE
Support RHEL 10 bastions in release selection

### DIFF
--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -249,7 +249,7 @@
     dest: "{{ bastion_cluster_config_dir }}/opm-linux.tar.gz"
   - url: "{{ release_urls['ga'] }}/latest/oc-mirror.rhel9.tar.gz"
     dest: "{{ bastion_cluster_config_dir }}/oc-mirror.tar.gz"
-  when: ansible_facts['distribution_major_version'] is version('9', '==')
+  when: ansible_facts['distribution_major_version'] is version('9', '>=')
 
 - name: Untar coredns, opm, kube-burner, kube-burner-ocp and grpcurl client
   unarchive:
@@ -279,7 +279,7 @@
     dest: /usr/local/bin/opm
     state: link
     force: yes
-  when: ansible_facts['distribution_major_version'] is version('9', '==')
+  when: ansible_facts['distribution_major_version'] is version('9', '>=')
 
 - name: Untar yq tool
   unarchive:

--- a/ansible/roles/bastion-ocp-version/tasks/main.yml
+++ b/ansible/roles/bastion-ocp-version/tasks/main.yml
@@ -25,10 +25,10 @@
     state: directory
 
 # Set bastion rhel version for ocp 4.15 and newer
-- name: RHEL version rhel9 check
+- name: RHEL version rhel9+ check
   set_fact:
     bastion_rhel_version: "rhel9"
-  when: ansible_facts['distribution_major_version'] is version('9', '==')
+  when: ansible_facts['distribution_major_version'] is version('9', '>=')
 
 - name: RHEL version rhel8 check
   set_fact:

--- a/ansible/roles/ocp-release/tasks/payload_url.yml
+++ b/ansible/roles/ocp-release/tasks/payload_url.yml
@@ -11,10 +11,10 @@
     dest: "/root/.docker/config.json"
 
 # Set bastion rhel version for ocp 4.15 and newer
-- name: RHEL version rhel9 check
+- name: RHEL version rhel9+ check
   set_fact:
     bastion_rhel_version: "rhel9"
-  when: ansible_facts['distribution_major_version'] is version('9', '==')
+  when: ansible_facts['distribution_major_version'] is version('9', '>=')
 
 - name: RHEL version rhel8 check
   set_fact:


### PR DESCRIPTION
## Summary
- treat RHEL 10+ bastions as `rhel9` when selecting bastion OpenShift client artifacts
- update `bastion-install` to keep using the RHEL 9 `opm` and `oc-mirror` downloads on newer bastions
- align `bastion-ocp-version` and `ocp-release` so the same client selection works in setup-bastion and release sync flows

## Test plan
- [x] `ansible-playbook --syntax-check ansible/setup-bastion.yml`
- [x] `ansible-playbook --syntax-check ansible/sync-ocp-release.yml`
- [ ] validate end-to-end on a RHEL 10 bastion

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Extended RHEL version compatibility to support version 9 and later (previously limited to version 9 only). This includes updates to tool downloads, symlink creation, bastion version detection, and OpenShift payload handling across deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->