### PR TITLE
Add option to set host password for debug

### DIFF
--- a/ansible/roles/generate-discovery-iso/tasks/main.yml
+++ b/ansible/roles/generate-discovery-iso/tasks/main.yml
@@ -20,6 +20,37 @@
   until: iso_download is success
   delay: 20
 
+- name: Set discovery ISO password
+  block:
+    - name: Backup original discovery ISO
+      copy:
+        src: "{{ http_store_path }}/data/{{ iso_name }}.iso"
+        dest: "{{ http_store_path }}/data/{{ iso_name }}-backup.iso"
+        remote_src: true
+        mode: 0644
+
+    - name: Checkout assisted-service repo
+      git:
+        repo: https://github.com/openshift/assisted-service.git
+        dest: /root/assisted-service
+        version: master
+
+
+    - name: Create new discovery ISO with password
+      shell: /root/assisted-service/docs/change-iso-password.sh {{ http_store_path }}/data/{{ iso_name }}.iso
+      args:
+        stdin: "{{ discovery_iso_password }}"
+      no_log: true
+
+    - name: Copy discovery_with_password ISO to discovery ISO
+      copy:
+        src: "{{ http_store_path }}/data/{{ iso_name }}_with_password.iso"
+        dest: "{{ http_store_path }}/data/{{ iso_name }}.iso"
+        remote_src: true
+        mode: 0644
+
+  when: discovery_iso_password is defined
+
 - name: Symlink discovery ISO into "iso" subdirectory
   ansible.builtin.file:
     src: ../{{ iso_name }}.iso

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,6 +12,7 @@ _**Table of Contents**_
   - [Failed on Wait for cluster to be ready](#failed-on-wait-for-cluster-to-be-ready)
   - [Failed on Adjust by-path selected install disk](#failed-on-adjust-by-path-selected-install-disk)
   - [Failed on Insert Virtual Media](#failed-on-insert-virtual-media)
+  - [Discovery ISO password for debugging](#discovery-iso-password-for-debugging)
 - [Bastion](#bastion)
   - [Accessing services](#accessing-services)
   - [Clean all container services / podman pods](#clean-all-container-services--podman-pods)
@@ -273,6 +274,16 @@ Object value modified successfully
 racadm>>set iDRAC.VirtualMedia.Attached Attached
 [Key=iDRAC.Embedded.1#VirtualMedia.1]
 Object value modified successfully
+```
+
+## Discovery ISO password for debugging
+
+If you need to debug a host, you can setup a default password for `core` 
+by setting `discovery_iso_password` in `vars/all.yml`. The ISO will be modified
+via the [documented assisted-service method](https://github.com/openshift/assisted-service/blob/master/docs/set-discovery-password.md):
+
+```yaml
+discovery_iso_password: <PASS>
 ```
 
 # Bastion


### PR DESCRIPTION
Use the provided script from assisted-service
to change the discovery ISO password for debugging.

https://github.com/openshift/assisted-service/blob/master/docs/set-discovery-password.md 
https://github.com/openshift/assisted-service/blob/master/docs/change-iso-password.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discovery ISOs can now be created with a password for easier debugging.
  * Added guidance on how to enable a default `core` password when generating the ISO.

* **Documentation**
  * Updated troubleshooting docs with a new section and example configuration for the password-protected discovery ISO.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->