### PR TITLE
fix: add force_basic_auth to Dell iDRAC wait tasks

### DIFF
--- a/ansible/roles/boot-iso/tasks/dell-wait-clear-jobs.yml
+++ b/ansible/roles/boot-iso/tasks/dell-wait-clear-jobs.yml
@@ -6,6 +6,7 @@
 - name: "Dell - Wait for ComputerSystem ready after clear-jobs for {{ item }}"
   ansible.builtin.uri:
     url: "https://{{ hostvars[item]['bmc_address'] }}/redfish/v1/Systems"
+    force_basic_auth: yes
     user: "{{ hostvars[item]['bmc_user'] }}"
     password: "{{ hostvars[item]['bmc_password'] }}"
     method: GET

--- a/ansible/roles/boot-iso/tasks/dell-wait-idrac.yml
+++ b/ansible/roles/boot-iso/tasks/dell-wait-idrac.yml
@@ -5,6 +5,7 @@
 - name: "Dell - Wait for iDRAC Redfish ready after racreset for {{ item }}"
   ansible.builtin.uri:
     url: "https://{{ hostvars[item]['bmc_address'] }}/redfish/v1"
+    force_basic_auth: yes
     user: "{{ hostvars[item]['bmc_user'] }}"
     password: "{{ hostvars[item]['bmc_password'] }}"
     method: GET


### PR DESCRIPTION
## Summary
- Add `force_basic_auth: yes` to the Dell iDRAC wait tasks (`dell-wait-clear-jobs.yml` and `dell-wait-idrac.yml`) that were missed in PR #816
- Without preemptive Basic Auth, iDRACs return 401 Unauthorized, causing each host to exhaust all 40 retries (~10 min per host), wasting ~50 min in the deploy-mno CI job and exceeding the 2h Prow step timeout

Fixes #847

## Test Plan
- [ ] `deploy-sno` — covers boot-iso role (Dell iDRAC wait tasks)
- [ ] `deploy-mno` — the issue was observed in MNO deployment

## Changes
- `ansible/roles/boot-iso/tasks/dell-wait-clear-jobs.yml`: add `force_basic_auth: yes`
- `ansible/roles/boot-iso/tasks/dell-wait-idrac.yml`: add `force_basic_auth: yes`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hardware readiness checks during boot by ensuring authentication is sent consistently when polling Dell systems.
  * This helps the setup process complete more reliably when waiting for iDRAC and ComputerSystem availability after clearing jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->