### PR TITLE
Update assisted installer tag to v2.54.0

### DIFF
--- a/ansible/roles/bastion-assisted-installer/defaults/main/main.yml
+++ b/ansible/roles/bastion-assisted-installer/defaults/main/main.yml
@@ -1,7 +1,7 @@
 ---
 # bastion-assisted-installer default vars
 
-assisted_installer_tag: stable.17.06.2026-02.05
+assisted_installer_tag: v2.54.0
 assisted_installer_ui_tag: v2.52.2
 
 assisted_image_service_image: quay.io/edge-infrastructure/assisted-image-service:{{ assisted_installer_tag }}


### PR DESCRIPTION
https://github.com/redhat-performance/jetlag/pull/843 temporarily set `assisted_installer_tag: stable.17.06.2026-02.05` until `v2.54` tag was created. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default assisted installer image version tag to `v2.54.0`, so deployments now use newer container image releases by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->