### PR TITLE
Batch VM delete per-hypervisor to eliminate SSH MaxSessions bottleneck

### DIFF
--- a/ansible/hv-vm-delete.yml
+++ b/ansible/hv-vm-delete.yml
@@ -7,17 +7,13 @@
 #
 
 - name: Delete VMs on hypervisors
-  hosts: hv_vm
+  hosts: hv
   gather_facts: false
   vars_files:
   - vars/hv.yml
   roles:
   - hv-vm-delete
-
-- name: Cleanup hypervisors after clearing off VMs
-  hosts: hv
-  gather_facts: false
-  tasks:
+  post_tasks:
   - name: Restart sushy-emulator
     systemd:
       state: restarted

--- a/ansible/hv-vm-replace.yml
+++ b/ansible/hv-vm-replace.yml
@@ -7,17 +7,13 @@
 #
 
 - name: Delete VMs on hypervisors
-  hosts: hv_vm
+  hosts: hv
   gather_facts: false
   vars_files:
   - vars/hv.yml
   roles:
   - hv-vm-delete
-
-- name: Cleanup hypervisors after clearing off VMs
-  hosts: hv
-  gather_facts: false
-  tasks:
+  post_tasks:
   - name: Restart sushy-emulator
     systemd:
       state: restarted

--- a/ansible/roles/hv-vm-delete/tasks/main.yml
+++ b/ansible/roles/hv-vm-delete/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 # hv-vm-delete tasks
+# Targets 'hv' hosts and batches all VM operations per hypervisor
 
 - name: Remove directories for hv-vm manifests on bastion
   file:
@@ -9,31 +10,36 @@
   run_once: true
   when: hv_vm_remove_all_manifests
 
-- name: Destroy VM
+- name: Build list of VMs on this hypervisor
+  set_fact:
+    _my_vms: >-
+      {% set comma = joiner(",") -%}
+      [{% for vm in groups['hv_vm'] | default([]) -%}
+      {% if hostvars[vm]['ansible_host'] == inventory_hostname -%}
+      {{ comma() }}"{{ vm }}"
+      {%- endif -%}
+      {%- endfor %}]
+
+- name: Batch destroy and undefine VMs
   shell: |
-    virsh destroy {{ inventory_hostname }}
+    {% for vm in _my_vms %}
+    ( virsh destroy {{ vm }} 2>/dev/null; virsh undefine --nvram {{ vm }} 2>/dev/null ) &
+    {% if loop.index is divisibleby 10 %}
+    wait
+    {% endif %}
+    {% endfor %}
+    wait
+  when: _my_vms | length > 0
   ignore_errors: true
 
-- name: Undefine VM
+- name: Batch delete VM disks and definition files
   shell: |
-    virsh undefine --nvram {{ inventory_hostname }}
-  ignore_errors: true
-
-- name: Delete VM disk
-  file:
-    path: "{{ hostvars[inventory_hostname]['disk_location'] }}/{{ inventory_hostname }}.qcow2"
-    state: absent
-  ignore_errors: true
-
-- name: Delete 2nd VM disk
-  file:
-    path: "{{ hostvars[inventory_hostname]['disk2_location'] }}/{{ inventory_hostname }}-sdb.qcow2"
-    state: absent
-  when: "'disk2_location' in hostvars[inventory_hostname]"
-  ignore_errors: true
-
-- name: Remove VM definition file
-  file:
-    path: "{{ hv_kvm_def_path }}/{{ inventory_hostname }}.xml"
-    state: absent
+    {% for vm in _my_vms %}
+    rm -f "{{ hostvars[vm]['disk_location'] }}/{{ vm }}.qcow2"
+    {% if 'disk2_location' in hostvars[vm] %}
+    rm -f "{{ hostvars[vm]['disk2_location'] }}/{{ vm }}-sdb.qcow2"
+    {% endif %}
+    rm -f "{{ hv_kvm_def_path }}/{{ vm }}.xml"
+    {% endfor %}
+  when: _my_vms | length > 0
   ignore_errors: true


### PR DESCRIPTION
Restructure the hv-vm-delete role to target hv hosts instead of
individual hv_vm hosts, batching all virsh and file cleanup operations
into single shell calls per hypervisor. Collapse the separate cleanup
play into post_tasks on the same play in both hv-vm-delete.yml and
hv-vm-replace.yml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM deletion across hypervisors by processing all assigned VMs in batches.
  * Ensured VM disks and definition files are consistently removed during deletion.
  * Consolidated post-deletion cleanup to reliably restart the emulator service and recreate the required images directory.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->