### PR TITLE
fix: upgrade containers.podman collection to support podman 5.x

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,3 +6,4 @@ pip3 install -q 'ansible<12.0.0' netaddr
 pip3 install -q jmespath --force
 pip3 install -q yq
 ansible-galaxy collection install ansible.utils --force
+ansible-galaxy collection install containers.podman --upgrade


### PR DESCRIPTION
## Problem

`containers.podman 1.11.0` is incompatible with podman 5.x and causes the following error when creating or managing pods:

```
TASK [bastion-http : Create http pod] ******************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'list' object has no attribute 'get'
fatal: [10.26.8.107]: FAILED! => {
  "changed": false,
  "module_stderr": "Shared connection to 10.26.8.107 closed.",
  "module_stdout": "Traceback (most recent call last):\n
    File \"podman_pod_lib.py\", line 368, in diffparam_cgroup_parent\n
    AttributeError: 'list' object has no attribute 'get'",
  "msg": "MODULE FAILURE"
}
```

Full traceback points to `podman_pod_lib.py` in `diffparam_cgroup_parent` — it expects a dict but receives a list due to a changed response format in podman 5.x.

## Root Cause

- Installed collection: `containers.podman 1.11.0`
- Bastion podman version: `podman 5.4.0`
- podman 5.x changed the inspect output format for pod cgroup info from a dict to a list, which the older collection version does not handle

```
$ ansible-galaxy collection list | grep containers.podman
containers.podman   1.11.0   ← too old for podman 5.x
```

## Fix

Add `ansible-galaxy collection install containers.podman --upgrade` to `bootstrap.sh` so the latest compatible version is always installed during setup.

## Impact

Affects all installer types (ibmcloud, scalelab, byol, performancelab, vmno) that use the `bastion-http`, `bastion-assisted-installer`, or `bastion-registry` roles — all of which use `podman_pod` under the hood.

Tested with:
- podman 5.4.0
- containers.podman upgraded from 1.11.0 to latest