### PR TITLE
Auto-detect ai_cluster_id in mno-post-cluster-install when unset

### DIFF
--- a/ansible/roles/mno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/mno-post-cluster-install/tasks/main.yml
@@ -15,6 +15,41 @@
     - "{{ bastion_cluster_config_dir }}/odf"
     - "{{ bastion_cluster_config_dir }}/openshift-monitoring"
 
+- name: Auto-detect ai_cluster_id when not provided
+  when: ai_cluster_id is not defined
+  block:
+  - name: Look up Assisted Installer clusters
+    uri:
+      url: "http://{{ assisted_installer_host }}:{{ assisted_installer_port }}/api/assisted-install/v2/clusters"
+      method: GET
+      status_code: [200]
+      return_content: true
+    register: ai_clusters_lookup
+
+  - name: Filter to installed clusters matching cluster_name
+    set_fact:
+      ai_clusters_matched: "{{ ai_clusters_lookup.json | selectattr('name', 'equalto', cluster_name) | selectattr('status', 'equalto', 'installed') | list }}"
+
+  - name: Fail if no installed cluster matches cluster_name
+    fail:
+      msg: >-
+        ai_cluster_id was not provided and no installed Assisted Installer cluster named
+        '{{ cluster_name }}' was found. Pass -e ai_cluster_id=<id> explicitly, or verify
+        the cluster install completed successfully.
+    when: ai_clusters_matched | length == 0
+
+  - name: Fail if multiple installed clusters match cluster_name
+    fail:
+      msg: >-
+        Multiple installed Assisted Installer clusters named '{{ cluster_name }}' were found
+        ({{ ai_clusters_matched | map(attribute='id') | join(', ') }}). Pass -e ai_cluster_id=<id>
+        explicitly to disambiguate.
+    when: ai_clusters_matched | length > 1
+
+  - name: Set ai_cluster_id from lookup
+    set_fact:
+      ai_cluster_id: "{{ ai_clusters_matched[0].id }}"
+
 - name: Get credentials (kubeconfig and kubeadmin password) from installed cluster
   get_url:
     url: "http://{{ assisted_installer_host }}:{{ assisted_installer_port }}/api/assisted-install/v2/clusters/{{ ai_cluster_id }}/downloads/credentials?file_name={{ item.name }}"


### PR DESCRIPTION
`ai_cluster_id` is normally set by the `create-ai-cluster` role earlier in `mno-deploy.yml`. When re-running `mno-post-cluster-install` standalone (e.g. via `--start-at-task`, to resume after a partial failure without re-triggering cluster creation), that fact is never set and the role fails immediately with an undefined variable error.

We hit this after `mno-post-cluster-install` failed on "Create localvolume-lvm resource" because the Local Storage Operator's CRDs weren't ready yet within the existing retry window (LSO finished installing a few minutes later). Re-running just this role to pick up where it left off required `ai_cluster_id` to be supplied manually.

This adds a lookup step that auto-detects `ai_cluster_id` from the Assisted Installer API by `cluster_name` + `status: installed` when not explicitly provided, and fails clearly if zero or more than one match is found (rather than silently picking the wrong cluster).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery of the cluster identifier when it is not provided.
  * Validates that exactly one installed cluster matches the configured cluster name.
  * Continues to support explicitly provided cluster identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->