### PR TITLE
Extend localvolume resource creation retry window to 10 minutes

### DIFF
--- a/ansible/roles/mno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/mno-post-cluster-install/tasks/main.yml
@@ -182,14 +182,15 @@
       KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc label no --overwrite {{ item }} localstorage=true
     loop: "{{ groups['worker'] }}"
 
-  # The localvolume resource will not be instantly available, thus retry for around 2 minutes
+  # The LocalVolume CRD is only available once the LSO operator finishes installing,
+  # which can take longer than the resource itself becoming available, thus retry for around 10 minutes
   - name: Create localvolume-lvm resource
     when: (controlplane_localstorage_lvm_devices | length > 0) or (worker_localstorage_lvm_devices | length > 0)
     shell:
       KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc apply -f {{ bastion_cluster_config_dir }}/localstorage/localvolume-lvm.yml
     register: lv_result
     until: not lv_result.failed
-    retries: 60
+    retries: 300
     delay: 2
 
   - name: Create localvolume-disk resource
@@ -198,7 +199,7 @@
       KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc apply -f {{ bastion_cluster_config_dir }}/localstorage/localvolume-disk.yml
     register: lv_result
     until: not lv_result.failed
-    retries: 60
+    retries: 300
     delay: 2
 
 - name: Setup OpenShift Data Foundation (ODF)


### PR DESCRIPTION
The retry loop for applying `localvolume-lvm`/`localvolume-disk` only waited ~2 minutes (60 retries x 2s delay), assuming the `LocalVolume` CRD would already be present. In practice the CRD is only installed once the Local Storage Operator subscription finishes reconciling, which can take longer than 2 minutes in a disconnected cluster.

We hit this directly: the apply failed with `no matches for kind "LocalVolume" ... ensure CRDs are installed first`, but LSO's CSV reached `Succeeded` and the CRDs were installed only a few minutes later. Bumps retries from 60 to 300 (same 2s delay) to give a 10 minute window.