### PR TITLE
Apply bool filter to wait_until_cluster_stable when condition

### DIFF
--- a/ansible/roles/mno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/mno-post-cluster-install/tasks/main.yml
@@ -30,7 +30,7 @@
 - name: Wait until cluster is stable
   shell: |
     KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc adm wait-for-stable-cluster --minimum-stable-period={{ minimum_stable_period }} --timeout={{ wait_until_cluster_stable_timeout }}
-  when: wait_until_cluster_stable
+  when: wait_until_cluster_stable | bool
 
 - name: Remove assisted-installer namespace
   shell: |

--- a/ansible/roles/sno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/sno-post-cluster-install/tasks/main.yml
@@ -32,7 +32,7 @@
 - name: Wait until cluster is stable
   shell: |
     KUBECONFIG={{ bastion_cluster_config_dir }}/{{ groups['sno'][0] }}/kubeconfig oc adm wait-for-stable-cluster --minimum-stable-period={{ minimum_stable_period }} --timeout={{ wait_until_cluster_stable_timeout }}
-  when: wait_until_cluster_stable
+  when: wait_until_cluster_stable | bool
 
 - name: Remove assisted-installer namespace
   shell: |


### PR DESCRIPTION
`ansible-playbook -e var=false` sets extra-vars passed in `key=value` form as plain strings, not booleans. Since any non-empty string (including `"false"`) is truthy in Jinja2/Python, `when: wait_until_cluster_stable` ran the task even when explicitly overridden with `-e wait_until_cluster_stable=false` on the CLI — the wait then ran to its full timeout instead of being skipped.

The `| bool` filter correctly maps string values like `"false"`/`"no"` to `False`, matching how the variable is meant to be used. Applied to both `mno-post-cluster-install` and `sno-post-cluster-install`, which have the identical pattern.