### PR TITLE
Add mno_capabilities_baseline_set/additional_enabled for MNO/VMNO installs

### DIFF
--- a/ansible/roles/install-cluster/templates/install-config-overrides.yml.j2
+++ b/ansible/roles/install-cluster/templates/install-config-overrides.yml.j2
@@ -22,10 +22,12 @@ capabilities:
 {% else %}
 networking:
   networkType: OVNKubernetes
-{%   if mno_capabilities_baseline_set is defined %}
+{%   if mno_capabilities_baseline_set is defined or mno_capabilities_additional_enabled | default([], true) | length > 0 %}
 capabilities:
+{%     if mno_capabilities_baseline_set is defined %}
   baselineCapabilitySet: {{ mno_capabilities_baseline_set }}
-{%     if mno_capabilities_additional_enabled | default([]) | length > 0 %}
+{%     endif %}
+{%     if mno_capabilities_additional_enabled | default([], true) | length > 0 %}
   additionalEnabledCapabilities:
 {%       for capability in mno_capabilities_additional_enabled %}
   - {{ capability }}

--- a/ansible/roles/install-cluster/templates/install-config-overrides.yml.j2
+++ b/ansible/roles/install-cluster/templates/install-config-overrides.yml.j2
@@ -22,6 +22,16 @@ capabilities:
 {% else %}
 networking:
   networkType: OVNKubernetes
+{%   if mno_capabilities_baseline_set is defined %}
+capabilities:
+  baselineCapabilitySet: {{ mno_capabilities_baseline_set }}
+{%     if mno_capabilities_additional_enabled | default([]) | length > 0 %}
+  additionalEnabledCapabilities:
+{%       for capability in mno_capabilities_additional_enabled %}
+  - {{ capability }}
+{%       endfor %}
+{%     endif %}
+{%   endif %}
 {% endif %}
 {% if enable_fips | default(false) %}
 fips: true

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -405,7 +405,7 @@ mno_capabilities_additional_enabled:
 - Console
 - CSISnapshot
 - Ingress
-- Insights # remove/omit this line to leave Insights disabled
+# - Insights # uncomment to re-enable Insights
 - marketplace
 - MachineAPI
 - NodeTuning

--- a/docs/tips-and-vars.md
+++ b/docs/tips-and-vars.md
@@ -391,6 +391,32 @@ CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE MAXMHZ    MINMHZ
 41  1    1      1    1:1:1:1       yes    3900.0000 800.0000
 ```
 
+## Cluster Capabilities for MNO/VMNO
+
+By default, MNO and VMNO installs enable the full baseline set of OpenShift cluster capabilities (Insights, marketplace, etc.). Use `mno_capabilities_baseline_set` and `mno_capabilities_additional_enabled` to trim which capabilities get enabled at install time, mirroring the `capabilities` install-config override already used for the SNO DU profile.
+
+Example settings, e.g. to exclude the `Insights` capability entirely (useful for disconnected/air-gapped labs where it can never report and would otherwise show as permanently degraded):
+
+```yaml
+mno_capabilities_baseline_set: None
+mno_capabilities_additional_enabled:
+- baremetal
+- CloudCredential
+- Console
+- CSISnapshot
+- Ingress
+- Insights # remove/omit this line to leave Insights disabled
+- marketplace
+- MachineAPI
+- NodeTuning
+- OperatorLifecycleManager
+- Storage
+```
+
+`baselineCapabilitySet` accepts the same values as install-config.yaml (`None`, `v4.11`..`v4.20`, `vCurrent`). Both vars are unset by default, so leaving them out of `all.yml` keeps the existing default behavior (no `capabilities` override sent to the Assisted Installer).
+
+Note this only applies at cluster install time — a capability already enabled on a running cluster cannot be disabled afterward; see [Red Hat's cluster capabilities documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/installation_overview/cluster-capabilities) for the list of known capabilities per OCP version.
+
 ## Post Deployment Tasks
 
 ### SNO DU Profile


### PR DESCRIPTION
`install-config-overrides.yml.j2` already supports a `capabilities` install-config override, but only for SNO's `du_profile`. MNO/VMNO always got the full default capability set with no way to trim it.

This is useful in disconnected labs — e.g. to exclude `Insights` at install time so it doesn't show as permanently degraded when it can never reach `console.redhat.com` (its only other "off switch" post-install is removing the `cloud.openshift.com` token from the global pull secret, since cluster capabilities can't be disabled once enabled).

Adds `mno_capabilities_baseline_set` / `mno_capabilities_additional_enabled`, mirroring the existing SNO du_profile pattern. Both are unset by default, so behavior is unchanged unless opted in. Documented in `docs/tips-and-vars.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added install-time configuration for OpenShift cluster capabilities.
  - Supports selecting a baseline capability set and enabling additional capabilities, including Insights.
  - Applies to non-SNO MNO/VMNO installations.

- **Documentation**
  - Added configuration guidance, accepted baseline values, defaults, examples, and the requirement that capabilities be configured during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->