### PR TITLE
Pick newest matching cluster instead of failing on ai_cluster_id auto-detect

### DIFF
--- a/ansible/roles/mno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/mno-post-cluster-install/tasks/main.yml
@@ -38,17 +38,22 @@
         the cluster install completed successfully.
     when: ai_clusters_matched | length == 0
 
-  - name: Fail if multiple installed clusters match cluster_name
-    fail:
+  - name: Sort matched clusters by creation time, newest last
+    set_fact:
+      ai_clusters_matched: "{{ ai_clusters_matched | sort(attribute='created_at') }}"
+
+  - name: Warn when multiple installed clusters match cluster_name
+    debug:
       msg: >-
         Multiple installed Assisted Installer clusters named '{{ cluster_name }}' were found
-        ({{ ai_clusters_matched | map(attribute='id') | join(', ') }}). Pass -e ai_cluster_id=<id>
-        explicitly to disambiguate.
+        ({{ ai_clusters_matched | map(attribute='id') | join(', ') }}). Picking the newest one
+        (created at {{ ai_clusters_matched[-1].created_at }}): {{ ai_clusters_matched[-1].id }}.
+        Pass -e ai_cluster_id=<id> explicitly to pick a different one.
     when: ai_clusters_matched | length > 1
 
   - name: Set ai_cluster_id from lookup
     set_fact:
-      ai_cluster_id: "{{ ai_clusters_matched[0].id }}"
+      ai_cluster_id: "{{ ai_clusters_matched[-1].id }}"
 
 - name: Get credentials (kubeconfig and kubeadmin password) from installed cluster
   get_url:


### PR DESCRIPTION
Follow-up to #859.

`mno-post-cluster-install`'s auto-detection of `ai_cluster_id` fails loudly when more than one installed Assisted Installer cluster shares `cluster_name`. As @akrzos pointed out in #859, this is a normal situation in practice: cluster names get reused across test runs (DNS records in dnsmasq/coredns are tied to the name) and old assisted-service records are intentionally kept as history rather than deleted.

This changes the multi-match case from a hard failure to picking the most recently created matching cluster (sorted by the Assisted Installer API's `created_at` field), with a `debug` message noting which one was picked and how to override with `-e ai_cluster_id=<id>` if a different one is needed.

Zero-match still fails as before.

Marked WIP: this hasn't been exercised against a live Assisted Installer API — the bastion/cluster this was drafted against was already decommissioned. Please hold off merging until verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic cluster selection when multiple installed clusters are detected.
  * The newest cluster is now selected, with a warning that lists all matching cluster IDs.
  * Explicitly provided cluster IDs continue to override automatic selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->