### PR TITLE
Set CoreDNS as default DNS solution and add IBMcloud support

### DIFF
--- a/ansible/ibmcloud-setup-bastion.yml
+++ b/ansible/ibmcloud-setup-bastion.yml
@@ -19,7 +19,10 @@
   - ocp-release
   - bastion-install
   - ibmcloud-bastion-network
-  - bastion-dnsmasq
+  - role: bastion-dnsmasq
+    when: not setup_coredns
+  - role: bastion-coredns
+    when: setup_coredns
   - bastion-http
   - bastion-ocp-version
   - bastion-assisted-installer

--- a/ansible/roles/bastion-coredns/tasks/main.yml
+++ b/ansible/roles/bastion-coredns/tasks/main.yml
@@ -26,20 +26,6 @@
   - src: resolv.conf.j2
     dest: /etc/resolv.conf
 
-- name: Create coredns.service file
-  copy:
-    dest: /usr/lib/systemd/system/coredns.service
-    content: |
-      [Unit]
-      Description=CoreDNS DNS server
-      After=network.target
-
-      [Service]
-      ExecStart=/usr/local/bin/coredns -conf=/etc/coredns/Corefile
-
-      [Install]
-      WantedBy=multi-user.target
-
 - name: Restart NetworkManager
   systemd:
     state: restarted

--- a/ansible/roles/bastion-coredns/templates/Corefile.hosts.j2
+++ b/ansible/roles/bastion-coredns/templates/Corefile.hosts.j2
@@ -1,21 +1,34 @@
 # Bastion/API/VM/Compact/Standard resolution
 hosts {
+{% if lab in cloud_labs %}
     # Bastion
-{% for network in controlplane_network %}
+    {{ hostvars[inventory_hostname]['private_address'] }} {{ groups['bastion'][0] }}
+{% else %}
+    # Bastion
+{%   for network in controlplane_network %}
     {{ network | ansible.utils.nthhost(1) }} {{ groups['bastion'][0] }}
-{% endfor %}
+{%   endfor %}
+{% endif %}
 
 {% if cluster_type in ["mno", "vmno"] %}
     # MNO Cluster API
-{%   for network in controlplane_network %}
+{%   if lab in cloud_labs %}
+    {{ controlplane_network_api }} api.{{ cluster_name }}.{{ base_dns_name }}
+{%   else %}
+{%     for network in controlplane_network %}
     {{ network | ansible.utils.nthhost(3) }} api.{{ cluster_name }}.{{ base_dns_name }}
-{%   endfor %}
+{%     endfor %}
+{%   endif %}
 {% else %}
 {%   for sno in groups['sno'] %}
     # SNO Cluster API
+{%     if lab in cloud_labs %}
+    {{ hostvars[sno].private_address }} api.{{ sno }}.{{ base_dns_name }}
+{%     else %}
     {{ hostvars[sno].ip }} api.{{ sno }}.{{ base_dns_name }}
-{%     if hostvars[sno].ipv6 is defined %}
+{%       if hostvars[sno].ipv6 is defined %}
     {{ hostvars[sno].ipv6 }} api.{{ sno }}.{{ base_dns_name }}
+{%       endif %}
 {%     endif %}
 {%   endfor %}
 {% endif %}
@@ -51,26 +64,49 @@ hosts {
 }
 
 # *.apps All Clusters
-{%   if cluster_type in ["mno", "vmno"] %}
+{% if cluster_type in ["mno", "vmno"] %}
 # *.apps for hub cluster
-{%   for network in controlplane_network %}
-{%     if network | ansible.utils.ipv4 %}
+{%   if lab in cloud_labs %}
+{%     if controlplane_network_ingress | ansible.utils.ipv4 %}
 template IN A {{ cluster_name }}.{{ base_dns_name }} {
     match .*.apps.{{ cluster_name }}.{{ base_dns_name }}
-    answer "{%raw%}{{ .Name }} 60 in {{ .Type }}{%endraw%} {{ network | ansible.utils.nthhost(4) }}"
+    answer "{%raw%}{{ .Name }} 60 in {{ .Type }}{%endraw%} {{ controlplane_network_ingress }}"
     fallthrough
 }
 {%     else %}
 template IN AAAA {{ cluster_name }}.{{ base_dns_name }} {
     match .*.apps.{{ cluster_name }}.{{ base_dns_name }}
-    answer "{%raw%}{{ .Name }} 60 in {{ .Type }}{%endraw%} {{ network | ansible.utils.nthhost(4) }}"
+    answer "{%raw%}{{ .Name }} 60 in {{ .Type }}{%endraw%} {{ controlplane_network_ingress }}"
     fallthrough
 }
 {%     endif %}
-{%   endfor %}
 {%   else %}
-{%     for sno in groups['sno'] %}
+{%     for network in controlplane_network %}
+{%       if network | ansible.utils.ipv4 %}
+template IN A {{ cluster_name }}.{{ base_dns_name }} {
+    match .*.apps.{{ cluster_name }}.{{ base_dns_name }}
+    answer "{%raw%}{{ .Name }} 60 in {{ .Type }}{%endraw%} {{ network | ansible.utils.nthhost(4) }}"
+    fallthrough
+}
+{%       else %}
+template IN AAAA {{ cluster_name }}.{{ base_dns_name }} {
+    match .*.apps.{{ cluster_name }}.{{ base_dns_name }}
+    answer "{%raw%}{{ .Name }} 60 in {{ .Type }}{%endraw%} {{ network | ansible.utils.nthhost(4) }}"
+    fallthrough
+}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
+{% else %}
+{%   for sno in groups['sno'] %}
 # *.apps for {{ sno }} SNO
+{%     if lab in cloud_labs %}
+template IN A {{ sno }}.{{ base_dns_name }} {
+    match .*.apps.{{ sno }}.{{ base_dns_name }}
+    answer "{%raw%}{{ .Name }} 60 in {{ .Type }}{%endraw%} {{ hostvars[sno].private_address }}"
+    fallthrough
+}
+{%     else %}
 {%       if hostvars[sno].ip | ansible.utils.ipv4 %}
 template IN A {{ sno }}.{{ base_dns_name }} {
 {%       else %}
@@ -87,29 +123,30 @@ template IN AAAA {{ sno }}.{{ base_dns_name }} {
     fallthrough
 }
 {%       endif %}
-{%     endfor %}
-{%   endif %}
+{%     endif %}
+{%   endfor %}
+{% endif %}
 
 # *.apps for VMs
-{%   for vm in groups['hv_vm'] %}
-{%     if hostvars[vm].ip | ansible.utils.ipv4 %}
+{% for vm in groups['hv_vm'] %}
+{%   if hostvars[vm].ip | ansible.utils.ipv4 %}
 template IN A {{ vm }}.{{ base_dns_name }} {
-{%     else %}
+{%   else %}
 template IN AAAA {{ vm }}.{{ base_dns_name }} {
-{%     endif %}
+{%   endif %}
     match .*.apps.{{ vm }}.{{ base_dns_name }}
     answer "{%raw%}{{ .Name }} 60 in {{ .Type }}{%endraw%} {{ hostvars[vm].ip }}"
     fallthrough
 }
-{%     if hostvars[vm].ipv6 is defined %}
+{%   if hostvars[vm].ipv6 is defined %}
 template IN AAAA {{ vm }}.{{ base_dns_name }} {
     match .*.apps.{{ vm }}.{{ base_dns_name }}
     answer "{%raw%}{{ .Name }} 60 in {{ .Type }}{%endraw%} {{ hostvars[vm].ipv6 }}"
     fallthrough
 }
-{%     endif %}
-{%   endfor %}
-{%   if groups['hv_vm'] | length > 0 %}
+{%   endif %}
+{% endfor %}
+{% if groups['hv_vm'] | length > 0 %}
 
 # *.apps for jumbocluster00
 template IN AAAA jumbocluster00.{{ base_dns_name }} {
@@ -119,20 +156,20 @@ template IN AAAA jumbocluster00.{{ base_dns_name }} {
 }
 
 # *.apps for standard clusters
-{%     for cluster in range(1, standard_cluster_dns_count + 1, 1)  %}
+{%   for cluster in range(1, standard_cluster_dns_count + 1, 1)  %}
 template IN AAAA standard-{{ '%05d' | format(cluster) }}.{{ base_dns_name }} {
     match .*.apps.standard-{{ '%05d' | format(cluster) }}.{{ base_dns_name }}
     answer "{%raw%}{{ .Name }} 60 in {{ .Type }}{%endraw%} {{ hostvars[groups['hv_vm'][0]]['machine_network'] | ansible.utils.nthhost( (cluster * -2) - 1 ) }}"
     fallthrough
 }
-{%     endfor %}
+{%   endfor %}
 
 # *.apps for compact clusters
-{%     for cluster in range(1, compact_cluster_dns_count + 1, 1)  %}
+{%   for cluster in range(1, compact_cluster_dns_count + 1, 1)  %}
 template IN AAAA compact-{{ '%05d' | format(cluster) }}.{{ base_dns_name }} {
     match .*.apps.compact-{{ '%05d' | format(cluster) }}.{{ base_dns_name }}
     answer "{%raw%}{{ .Name }} 60 in {{ .Type }}{%endraw%} {{ hostvars[groups['hv_vm'][0]]['machine_network'] | ansible.utils.nthhost( ((cluster + standard_cluster_dns_count) * -2) - 1 ) }}"
     fallthrough
 }
-{%     endfor %}
-{%   endif %}
+{%   endfor %}
+{% endif %}

--- a/ansible/roles/bastion-coredns/templates/Corefile.j2
+++ b/ansible/roles/bastion-coredns/templates/Corefile.j2
@@ -3,9 +3,15 @@
     errors
     # log
 
-{% for dns in labs[lab]['dns'] %}
+{% if lab in rh_labs or lab == "byol" %}
+{%   for dns in labs[lab]['dns'] %}
     forward . {{ dns }}
-{% endfor %}
+{%   endfor %}
+{% else %}
+{%   for dns in dns_servers %}
+    forward . {{ dns }}
+{%   endfor %}
+{% endif %}
 
     cache 30
     reload

--- a/ansible/roles/bastion-coredns/templates/resolv.conf.j2
+++ b/ansible/roles/bastion-coredns/templates/resolv.conf.j2
@@ -1,19 +1,21 @@
 # Deployed by Jetlag automation
 search {{ base_dns_name }}
-{% if public_vlan | default(false) %}
+{% if lab in cloud_labs %}
+nameserver {{ hostvars[inventory_hostname]['private_address'] }}
+{% elif public_vlan | default(false) %}
 nameserver {{ ansible_default_ipv4.address }}
 {% else %}
 nameserver {{ controlplane_network[0] | ansible.utils.nthhost(1) }}
 {% endif %}
 {% if lab in rh_labs or lab == "byol" %}
-{% for dns in labs[lab]['dns'] %}
+{%   for dns in labs[lab]['dns'] %}
 nameserver {{ dns }}
-{% endfor %}
+{%   endfor %}
 {% else %}
-{% if dns_servers | length == 1 %}
+{%   if dns_servers | length == 1 %}
 nameserver {{ dns_servers[0] }}
-{% elif dns_servers | length >= 2 %}
+{%   elif dns_servers | length >= 2 %}
 nameserver {{ dns_servers[0] }}
 nameserver {{ dns_servers[1] }}
-{% endif %}
+{%   endif %}
 {% endif %}

--- a/ansible/roles/bastion-dnsmasq/tasks/main.yml
+++ b/ansible/roles/bastion-dnsmasq/tasks/main.yml
@@ -1,6 +1,12 @@
 ---
 # bastion-dnsmasq tasks
 
+- name: Stop and disable coredns
+  systemd:
+    state: stopped
+    enabled: false
+    name: coredns
+
 - name: Configure Dnsmasq / NetworkManager
   template:
     src: "{{ item.src }}"

--- a/ansible/roles/bastion-install/tasks/main.yml
+++ b/ansible/roles/bastion-install/tasks/main.yml
@@ -265,6 +265,22 @@
   - "{{ bastion_cluster_config_dir }}/kube-burner-ocp-linux.tar.gz"
   - "{{ bastion_cluster_config_dir }}/grpcurl-linux.tar.gz"
 
+- name: Create coredns.service file
+  copy:
+    dest: /usr/lib/systemd/system/coredns.service
+    content: |
+      [Unit]
+      Description=CoreDNS DNS server
+      After=network.target
+
+      [Service]
+      ExecStart=/usr/local/bin/coredns -conf=/etc/coredns/Corefile
+      Restart=on-failure
+      RestartSec=5s
+
+      [Install]
+      WantedBy=multi-user.target
+
 - name: Symlink RHEL8 opm
   ansible.builtin.file:
     src: /usr/local/bin/opm-rhel8

--- a/ansible/roles/create-inventory/defaults/main/dns.yml
+++ b/ansible/roles/create-inventory/defaults/main/dns.yml
@@ -3,8 +3,8 @@
 cluster_name: mno
 base_dns_name: example.com
 
-# Setup and use coredns instead of dnsmasq
-setup_coredns: false
+# Coredns is default DNS (False uses dnsmasq, dnsmasq to be removed in future)
+setup_coredns: true
 
 # Appends each entry to /etc/hosts of bastion machine during cluster install to
 # allow sshuttle easy resolution when proxying into cluster

--- a/ansible/roles/hv-coredns/tasks/main.yml
+++ b/ansible/roles/hv-coredns/tasks/main.yml
@@ -30,22 +30,6 @@
   - src: resolv.conf.j2
     dest: /etc/resolv.conf
 
-- name: Create coredns.service file
-  copy:
-    dest: /usr/lib/systemd/system/coredns.service
-    content: |
-      [Unit]
-      Description=CoreDNS DNS server
-      After=network.target
-
-      [Service]
-      ExecStart=/usr/local/bin/coredns -conf=/etc/coredns/Corefile
-      Restart=on-failure
-      RestartSec=5s
-
-      [Install]
-      WantedBy=multi-user.target
-
 - name: Restart NetworkManager
   systemd:
     state: restarted

--- a/ansible/roles/hv-dnsmasq/tasks/main.yml
+++ b/ansible/roles/hv-dnsmasq/tasks/main.yml
@@ -1,6 +1,12 @@
 ---
 # hv-dnsmasq tasks
 
+- name: Stop and disable coredns
+  systemd:
+    state: stopped
+    enabled: false
+    name: coredns
+
 - name: Configure Dnsmasq / NetworkManager
   template:
     src: "{{ item.src }}"

--- a/ansible/roles/hv-install/tasks/main.yml
+++ b/ansible/roles/hv-install/tasks/main.yml
@@ -85,6 +85,22 @@
     remote_src: yes
     mode: 0700
 
+- name: Create coredns.service file
+  copy:
+    dest: /usr/lib/systemd/system/coredns.service
+    content: |
+      [Unit]
+      Description=CoreDNS DNS server
+      After=network.target
+
+      [Service]
+      ExecStart=/usr/local/bin/coredns -conf=/etc/coredns/Corefile
+      Restart=on-failure
+      RestartSec=5s
+
+      [Install]
+      WantedBy=multi-user.target
+
 - name: Setup chronyd
   template:
     src: chrony.conf.j2

--- a/ansible/vars/hv.sample.yml
+++ b/ansible/vars/hv.sample.yml
@@ -8,8 +8,8 @@ ssh_public_key_file: ~/.ssh/id_rsa.pub
 
 install_tc: true
 
-# Setup and use coredns instead of dnsmasq
-setup_coredns: false
+# Coredns is default DNS (False uses dnsmasq, dnsmasq to be removed in future)
+setup_coredns: true
 
 # Enables using DHCP instead of relying on static network configuration for VMs
 setup_hv_vm_dhcp: false

--- a/docs/deploy-vmno.md
+++ b/docs/deploy-vmno.md
@@ -371,8 +371,8 @@ ssh_public_key_file: ~/.ssh/id_rsa.pub
 
 install_tc: true
 
-# Setup and use coredns instead of dnsmasq
-setup_coredns: false
+# Coredns is default DNS (False uses dnsmasq, dnsmasq to be removed in future)
+setup_coredns: true
 
 # Enables using DHCP instead of relying on static network configuration for VMs
 setup_hv_vm_dhcp: false


### PR DESCRIPTION
Add cloud_labs support to CoreDNS templates (Corefile.hosts.j2, Corefile.j2, resolv.conf.j2) so IBMcloud deployments can use CoreDNS. Add setup_coredns conditional to ibmcloud-setup-bastion.yml. Flip setup_coredns default to true so all deployment types (MNO, SNO, VMNO, IBMcloud) use CoreDNS by default. Users can set setup_coredns: false to fall back to dnsmasq during the transition period.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CoreDNS is now enabled by default for new deployments.
  - DNS configuration automatically selects CoreDNS or dnsmasq based on deployment settings.
  - Cloud deployments receive environment-specific DNS and ingress mappings, including IPv4 and IPv6 support.
  - DNS forwarding and resolver selection adapt to deployment and lab configuration.

- **Documentation**
  - Updated deployment examples and sample settings to reflect CoreDNS as the default and document the dnsmasq fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->