### PR TITLE
argcomplete latest release not working with python3.9, taging to old …

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,7 +2,7 @@
 python3 -m venv .ansible
 source .ansible/bin/activate
 pip3 install -q --upgrade pip
-pip3 install -q 'ansible<12.0.0' netaddr
+pip3 install -q 'ansible<12.0.0' 'argcomplete<3.7.0' netaddr
 pip3 install -q jmespath --force
 pip3 install -q yq
 ansible-galaxy collection install ansible.utils --force


### PR DESCRIPTION
…release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bootstrap setup to install a compatible version of `argcomplete` alongside the existing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->