### PR TITLE
fix: pin argcomplete to 3.7.0 to resolve Python 3.9 TypeError in ansible galaxy while bootstraping

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,6 +2,8 @@
 python3 -m venv .ansible
 source .ansible/bin/activate
 pip3 install -q --upgrade pip
+# pin argcomplete to 3.7.0 in bootstrap script due to TypeError
+pip3 install -q argcomplete==3.7.0
 pip3 install -q 'ansible<12.0.0' netaddr
 pip3 install -q jmespath --force
 pip3 install -q yq


### PR DESCRIPTION
Issue: 

```
[root@y37-XXXX-xd jetlag-XXXXXXXXXXXXXX-XXXXXXX-1785842016]# source bootstrap.sh 
Traceback (most recent call last):
  File "/tmp/jetlag-XXXXXXXXXXXXXX-XXXXXXX-1785842016/.ansible/bin/ansible-galaxy", line 3, in <module>
    from ansible.cli.galaxy import main
  File "/tmp/jetlag-XXXXXXXXXXXXXX-XXXXXXX-1785842016/.ansible/lib64/python3.9/site-packages/ansible/cli/__init__.py", line 114, in <module>
    import argcomplete
  File "/tmp/jetlag-XXXXXXXXXXXXXX-XXXXXXX-1785842016/.ansible/lib64/python3.9/site-packages/argcomplete/__init__.py", line 4, in <module>
    from . import completers
  File "/tmp/jetlag-XXXXXXXXXXXXXX-XXXXXXX-1785842016/.ansible/lib64/python3.9/site-packages/argcomplete/completers.py", line 34, in <module>
    class ChoicesCompleter(BaseCompleter):
  File "/tmp/jetlag-XXXXXXXXXXXXXX-XXXXXXX-1785842016/.ansible/lib64/python3.9/site-packages/argcomplete/completers.py", line 35, in ChoicesCompleter
    choices: Final[Mapping[str, str | bytes]]
TypeError: unsupported operand type(s) for |: 'type' and 'type'
(.ansible) [root@y37-XXXXX-xd jetlag-XXXXXXXXXXXXXX-XXXXXXX-1785842016]# pip show argcomplete
Name: argcomplete
Version: 3.7.1
Summary: Bash tab completion for argparse
Home-page: https://github.com/kislyuk/argcomplete
Author: Andrey Kislyuk
Author-email: kislyuk@gmail.com
License: Apache Software License
Location: /tmp/jetlag-XXXXXXXXXXXXXX-XXXXXXX-1785842016/.ansible/lib/python3.9/site-packages
Requires: 
Required-by: yq
```

Resolution logs:
```
[root@y37-XXXX-xd` jetlag-XXXXXXXXXXXXXX-XXXXXXX-1785842016]# source bootstrap.sh
Starting galaxy collection install process
[WARNING]: Collection ansible.utils does not support Ansible version 2.15.13
Process install dependency map
Starting collection install process
Downloading https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/artifacts/ansible-utils-6.0.3.tar.gz to /root/.ansible/tmp/ansible-local-3399231b1mjktjy/tmpcgya3ys1/ansible-utils-6.0.3-2libenk4
Installing 'ansible.utils:6.0.3' to '/root/.ansible/collections/ansible_collections/ansible/utils'
ansible.utils:6.0.3 was installed successfully

(.ansible) [root@y37-hXXXXXX-xd jetlag-XXXXXXXXXXXXXX-XXXXXXX-1785842016]# pip show argcomplete
Name: argcomplete
Version: 3.7.0
Summary: Bash tab completion for argparse
Home-page: https://github.com/kislyuk/argcomplete
Author: Andrey Kislyuk
Author-email: kislyuk@gmail.com
License: Apache Software License
Location: /tmp/jetlag-XXXXXXXXXXXXXX-XXXXXXX-1785842016/.ansible/lib/python3.9/site-packages
Requires: 
Required-by: yq
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added installation of `argcomplete` version 3.7.0 during environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->