### PR TITLE
Default `hv_vm_generate_manifests` to false since majority of manifes…

### DIFF
--- a/ansible/roles/hv-vm-delete/defaults/main.yml
+++ b/ansible/roles/hv-vm-delete/defaults/main.yml
@@ -3,6 +3,6 @@
 
 hv_vm_manifests_directory: /root/hv-vm
 
-hv_vm_remove_all_manifests: true
+hv_vm_remove_all_manifests: false
 
 hv_kvm_def_path: /opt/hv

--- a/ansible/vars/hv.sample.yml
+++ b/ansible/vars/hv.sample.yml
@@ -14,7 +14,7 @@ setup_coredns: true
 # Enables using DHCP instead of relying on static network configuration for VMs
 setup_hv_vm_dhcp: false
 
-hv_vm_generate_manifests: true
+hv_vm_generate_manifests: false
 
 # Types: sno, compact, standard, mixed, jumbo
 # sno = 1 node per cluster

--- a/docs/deploy-vmno.md
+++ b/docs/deploy-vmno.md
@@ -137,11 +137,6 @@ In some VM scenarios, hugepages may be required. To configure VMs with hugepages
 
 Change `lab` to match your environment (same value as in `all.yml`).
 
-Change `hv_vm_generate_manifests` to `hv_vm_generate_manifests: false`
-
-VM manifests are only used in conjunction with ACM/MCE testing.
-
-
 For the metrics collection to work, set following variable:
 ```yaml
 setup_hv_metrics: true


### PR DESCRIPTION
…t generation has shifted to acm-deploy-load for ACM/MCE cluster-deployment manifests.