### PR TITLE
Optimized role inclusion

### DIFF
--- a/ansible/mno-deploy.yml
+++ b/ansible/mno-deploy.yml
@@ -32,4 +32,18 @@
   - wait-hosts-discovered
   - configure-local-storage
   - install-cluster
-  - mno-post-cluster-install
+
+  tasks:
+  - name: Check if sync-operator-index file exists
+    ansible.builtin.stat:
+      path: "vars/sync-operator-index.yml"
+    register: var_file_status
+
+  - name: Load var file needed by mno-post-cluster-install (override defaults)
+    ansible.builtin.include_vars:
+      file: "vars/sync-operator-index.yml"
+    when: var_file_status.stat.exists
+
+  - name: Execute mno-post-cluster-install role
+    ansible.builtin.import_role:
+      name: mno-post-cluster-install

--- a/ansible/roles/bastion-install/defaults/main.yml
+++ b/ansible/roles/bastion-install/defaults/main.yml
@@ -7,6 +7,10 @@ kubeburner_url: https://github.com/kube-burner/kube-burner/releases/download/v2.
 kubeburner_ocp_url: https://github.com/kube-burner/kube-burner-ocp/releases/download/v1.9.1/kube-burner-ocp-V1.9.1-linux-x86_64.tar.gz
 minio_client_url: https://dl.min.io/client/mc/release/linux-amd64/mc
 yq_url: https://github.com/mikefarah/yq/releases/download/v4.40.3/yq_linux_amd64.tar.gz
+release_urls:
+  ga: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp"
+  dev: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview"
+  ci: "https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com"
 
 # Crucible specific vars
 install_rh_crucible: false

--- a/ansible/roles/bastion-install/defaults/main.yml
+++ b/ansible/roles/bastion-install/defaults/main.yml
@@ -11,6 +11,7 @@ release_urls:
   ga: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp"
   dev: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview"
   ci: "https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com"
+payload_url: ""
 
 # Crucible specific vars
 install_rh_crucible: false

--- a/ansible/roles/bastion-ocp-version/defaults/main/main.yml
+++ b/ansible/roles/bastion-ocp-version/defaults/main/main.yml
@@ -10,3 +10,4 @@ http_store_host: "{{ groups['bastion'][0] }}"
 http_store_port: 8081
 
 ocp_version_path: /opt/ocp-version
+payload_url: ""

--- a/ansible/roles/bastion-ocp-version/defaults/main/main.yml
+++ b/ansible/roles/bastion-ocp-version/defaults/main/main.yml
@@ -1,5 +1,10 @@
 ---
 # bastion-ocp-version default vars
+release_urls:
+  ga: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp"
+  dev: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview"
+  ci: "https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com"
+payload_url: ""
 
 # This will be your bastion machine (if you run setup-bastion playbook)
 registry_host: "{{ groups['bastion'][0] }}"
@@ -10,4 +15,3 @@ http_store_host: "{{ groups['bastion'][0] }}"
 http_store_port: 8081
 
 ocp_version_path: /opt/ocp-version
-payload_url: ""

--- a/ansible/roles/mno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/mno-post-cluster-install/tasks/main.yml
@@ -82,7 +82,6 @@
       metadata:
         name: assisted-installer
   when: remove_assisted_installer_namespace
-  when: remove_assisted_installer_namespace
 
 - name: Apply post-install labels to worker node(s)
   shell: |

--- a/ansible/roles/mno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/mno-post-cluster-install/tasks/main.yml
@@ -73,8 +73,15 @@
   when: wait_until_cluster_stable | bool
 
 - name: Remove assisted-installer namespace
-  shell: |
-    KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc delete ns assisted-installer
+  kubernetes.core.k8s:
+    kubeconfig: "{{ bastion_cluster_config_dir }}/kubeconfig"
+    state: absent
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: assisted-installer
+  when: remove_assisted_installer_namespace
   when: remove_assisted_installer_namespace
 
 - name: Apply post-install labels to worker node(s)
@@ -125,8 +132,15 @@
   when: setup_performance_dashboards | bool
 
 - name: Add kube-burner sa
-  shell: |
-    KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc create sa kubeburner
+  kubernetes.core.k8s:
+    kubeconfig: "{{ bastion_cluster_config_dir }}/kubeconfig"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: kubeburner
+        namespace: default
   when: setup_kube_burner_sa | default(true) | bool
 
 - name: Add cluster-admin role to kube-burner sa

--- a/ansible/setup-bastion.yml
+++ b/ansible/setup-bastion.yml
@@ -13,90 +13,90 @@
   - vars/all.yml
 
   tasks:
-    - name: Execute validate-vars role
+  - name: Execute validate-vars role
+    ansible.builtin.include_role:
+      name: validate-vars
+
+  - name: Execute ocp-release role
+    ansible.builtin.include_role:
+      name: ocp-release
+
+  - name: Execute bastion-install role
+    ansible.builtin.include_role:
+      name: bastion-install
+
+  - name: Execute bastion-network role
+    ansible.builtin.include_role:
+      name: bastion-network
+
+  - name: Execute bastion-dnsmasq role
+    ansible.builtin.include_role:
+      name: bastion-dnsmasq
+    when: not setup_coredns
+
+  - name: Execute bastion-coredns role
+    ansible.builtin.include_role:
+      name: bastion-coredns
+    when: setup_coredns
+
+  - name: Execute bastion-http role
+    ansible.builtin.include_role:
+      name: bastion-http
+
+  - name: Execute bastion-ocp-version role
+    ansible.builtin.include_role:
+      name: bastion-ocp-version
+
+  - name: Execute bastion-registry role
+    ansible.builtin.include_role:
+      name: bastion-registry
+    when: setup_bastion_registry
+
+  - name: Handle Sync Operator Index configurations and execution
+    when:
+      - setup_bastion_registry
+      - sync_operator_index | default(false)
+    block:
+    - name: Load specific sync-operator-index variables
+      ansible.builtin.include_vars:
+        file: vars/sync-operator-index.yml
+
+    - name: Execute sync-operator-index role
       ansible.builtin.include_role:
-        name: validate-vars
+        name: sync-operator-index
 
-    - name: Execute ocp-release role
-      ansible.builtin.include_role:
-        name: ocp-release
+  - name: Execute sync-ocp-release role
+    ansible.builtin.include_role:
+      name: sync-ocp-release
+    when:
+      - setup_bastion_registry
+      - sync_ocp_release | default(false)
 
-    - name: Execute bastion-install role
-      ansible.builtin.include_role:
-        name: bastion-install
+  - name: Execute bastion-proxy role
+    ansible.builtin.include_role:
+      name: bastion-proxy
+    when: setup_bastion_proxy | default(false)
 
-    - name: Execute bastion-network role
-      ansible.builtin.include_role:
-        name: bastion-network
+  - name: Execute bastion-assisted-installer role
+    ansible.builtin.include_role:
+      name: bastion-assisted-installer
 
-    - name: Execute bastion-dnsmasq role
-      ansible.builtin.include_role:
-        name: bastion-dnsmasq
-      when: not setup_coredns
+  - name: Execute bastion-gogs role
+    ansible.builtin.include_role:
+      name: bastion-gogs
+    when: setup_bastion_gogs
 
-    - name: Execute bastion-coredns role
-      ansible.builtin.include_role:
-        name: bastion-coredns
-      when: setup_coredns
+  - name: Execute bastion-disconnected-haproxy role
+    ansible.builtin.include_role:
+      name: bastion-disconnected-haproxy
+    when: use_bastion_registry or setup_bastion_proxy | default(false)
 
-    - name: Execute bastion-http role
-      ansible.builtin.include_role:
-        name: bastion-http
+  - name: Execute hv-metrics-server role
+    ansible.builtin.include_role:
+      name: hv-metrics-server
+    when: setup_hv_metrics | default(false) | bool
 
-    - name: Execute bastion-ocp-version role
-      ansible.builtin.include_role:
-        name: bastion-ocp-version
-
-    - name: Execute bastion-registry role
-      ansible.builtin.include_role:
-        name: bastion-registry
-      when: setup_bastion_registry
-
-    - name: Handle Sync Operator Index configurations and execution
-      when:
-        - setup_bastion_registry
-        - sync_operator_index | default(false)
-      block:
-        - name: Load specific sync-operator-index variables
-          ansible.builtin.include_vars:
-            file: vars/sync-operator-index.yml
-
-        - name: Execute sync-operator-index role
-          ansible.builtin.include_role:
-            name: sync-operator-index
-
-    - name: Execute sync-ocp-release role
-      ansible.builtin.include_role:
-        name: sync-ocp-release
-      when:
-        - setup_bastion_registry
-        - sync_ocp_release | default(false)
-
-    - name: Execute bastion-proxy role
-      ansible.builtin.include_role:
-        name: bastion-proxy
-      when: setup_bastion_proxy | default(false)
-
-    - name: Execute bastion-assisted-installer role
-      ansible.builtin.include_role:
-        name: bastion-assisted-installer
-
-    - name: Execute bastion-gogs role
-      ansible.builtin.include_role:
-        name: bastion-gogs
-      when: setup_bastion_gogs
-
-    - name: Execute bastion-disconnected-haproxy role
-      ansible.builtin.include_role:
-        name: bastion-disconnected-haproxy
-      when: use_bastion_registry or setup_bastion_proxy | default(false)
-
-    - name: Execute hv-metrics-server role
-      ansible.builtin.include_role:
-        name: hv-metrics-server
-      when: setup_hv_metrics | default(false) | bool
-
-    - name: Execute bastion-minio role
-      ansible.builtin.include_role:
-        name: bastion-minio
-      when: setup_bastion_minio | default(false)
+  - name: Execute bastion-minio role
+    ansible.builtin.include_role:
+      name: bastion-minio
+    when: setup_bastion_minio | default(false)

--- a/ansible/setup-bastion.yml
+++ b/ansible/setup-bastion.yml
@@ -11,35 +11,92 @@
   vars_files:
   - vars/lab.yml
   - vars/all.yml
-  roles:
-  - validate-vars
-  - ocp-release
-  - bastion-install
-  - bastion-network
-  - role: bastion-dnsmasq
-    when: not setup_coredns
-  - role: bastion-coredns
-    when: setup_coredns
-  - bastion-http
-  - bastion-ocp-version
-  - role: bastion-registry
-    when: setup_bastion_registry
-  - role: sync-operator-index
-    when:
-    - setup_bastion_registry
-    - sync_operator_index | default(false)
-  - role: sync-ocp-release
-    when:
-    - setup_bastion_registry
-    - sync_ocp_release | default(false)
-  - role: bastion-proxy
-    when: setup_bastion_proxy | default(false)
-  - bastion-assisted-installer
-  - role: bastion-gogs
-    when: setup_bastion_gogs
-  - role: bastion-disconnected-haproxy
-    when: use_bastion_registry or setup_bastion_proxy | default(false)
-  - role: hv-metrics-server
-    when: setup_hv_metrics | default(false) | bool
-  - role: bastion-minio
-    when: setup_bastion_minio | default(false)
+
+  tasks:
+    - name: Execute validate-vars role
+      ansible.builtin.include_role:
+        name: validate-vars
+
+    - name: Execute ocp-release role
+      ansible.builtin.include_role:
+        name: ocp-release
+
+    - name: Execute bastion-install role
+      ansible.builtin.include_role:
+        name: bastion-install
+
+    - name: Execute bastion-network role
+      ansible.builtin.include_role:
+        name: bastion-network
+
+    - name: Execute bastion-dnsmasq role
+      ansible.builtin.include_role:
+        name: bastion-dnsmasq
+      when: not setup_coredns
+
+    - name: Execute bastion-coredns role
+      ansible.builtin.include_role:
+        name: bastion-coredns
+      when: setup_coredns
+
+    - name: Execute bastion-http role
+      ansible.builtin.include_role:
+        name: bastion-http
+
+    - name: Execute bastion-ocp-version role
+      ansible.builtin.include_role:
+        name: bastion-ocp-version
+
+    - name: Execute bastion-registry role
+      ansible.builtin.include_role:
+        name: bastion-registry
+      when: setup_bastion_registry
+
+    - name: Handle Sync Operator Index configurations and execution
+      when:
+        - setup_bastion_registry
+        - sync_operator_index | default(false)
+      block:
+        - name: Load specific sync-operator-index variables
+          ansible.builtin.include_vars:
+            file: vars/sync-operator-index.yml
+
+        - name: Execute sync-operator-index role
+          ansible.builtin.include_role:
+            name: sync-operator-index
+
+    - name: Execute sync-ocp-release role
+      ansible.builtin.include_role:
+        name: sync-ocp-release
+      when:
+        - setup_bastion_registry
+        - sync_ocp_release | default(false)
+
+    - name: Execute bastion-proxy role
+      ansible.builtin.include_role:
+        name: bastion-proxy
+      when: setup_bastion_proxy | default(false)
+
+    - name: Execute bastion-assisted-installer role
+      ansible.builtin.include_role:
+        name: bastion-assisted-installer
+
+    - name: Execute bastion-gogs role
+      ansible.builtin.include_role:
+        name: bastion-gogs
+      when: setup_bastion_gogs
+
+    - name: Execute bastion-disconnected-haproxy role
+      ansible.builtin.include_role:
+        name: bastion-disconnected-haproxy
+      when: use_bastion_registry or setup_bastion_proxy | default(false)
+
+    - name: Execute hv-metrics-server role
+      ansible.builtin.include_role:
+        name: hv-metrics-server
+      when: setup_hv_metrics | default(false) | bool
+
+    - name: Execute bastion-minio role
+      ansible.builtin.include_role:
+        name: bastion-minio
+      when: setup_bastion_minio | default(false)

--- a/ansible/setup-bastion.yml
+++ b/ansible/setup-bastion.yml
@@ -54,8 +54,8 @@
 
   - name: Handle Sync Operator Index configurations and execution
     when:
-      - setup_bastion_registry
-      - sync_operator_index | default(false)
+    - setup_bastion_registry
+    - sync_operator_index | default(false)
     block:
     - name: Load specific sync-operator-index variables
       ansible.builtin.include_vars:
@@ -69,8 +69,8 @@
     ansible.builtin.include_role:
       name: sync-ocp-release
     when:
-      - setup_bastion_registry
-      - sync_ocp_release | default(false)
+    - setup_bastion_registry
+    - sync_ocp_release | default(false)
 
   - name: Execute bastion-proxy role
     ansible.builtin.include_role:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,5 +5,6 @@ pip3 install -q --upgrade pip
 pip3 install -q 'ansible<12.0.0' 'argcomplete<3.7.0' netaddr
 pip3 install -q jmespath --force
 pip3 install -q yq
+pip3 install kubernetes
 ansible-galaxy collection install ansible.utils --force
 ansible-galaxy collection install containers.podman --upgrade


### PR DESCRIPTION
This change suggests using `include_role` instead of the `roles` list keyword to include dependency roles in the `setup-bastion.yml` playbook.

This has the following advantages:
1. It'll avoid statically pre-processing the role to stamp every task in the target (dependency) role with a conditional `when` statement. This, otherwise, would obviously mean added processing overhead and memory footprint on the Ansible controller.
2. It helps isolate role vars, i.e., there's less global vars inter-dependency between roles, keeping the roles clean boundaries cleanly defined with explicit vars. This aids in forward maintainability and lowers the chance of breakage in a dependent role that relies on a global var. i.e., lower the overall fragility index of the playbook.
3. It skips loading a role (and potentially its sample/copied vars file) if a conditional is false, leading to a cleaner, faster execution of the playbook.

The downside to this is a little more repetitive vars defaults in the roles. These defaults don't need to be updated with every run / execution though. Overriding them in a `all.yml` is still possible and ultimately this PR shouldn't change how people are utilizing Jetlag today or in the future.

The need for this refactor beside the above points stems from copying the sample `sync-operator-index.yml` var file which was skipped because it's not in the list of vars files in the `all.yml`. This change would make it such that including vars doesn't necessitate overrides if someone wants to simply use the pinned defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bastion setup now supports OpenShift release sources for GA, development-preview, and CI payloads.
  * Custom OpenShift payload URLs can be provided when needed.
  * Bastion deployment workflows now support optional operator index synchronization with the required configuration loaded automatically.

* **Improvements**
  * Cluster post-install setup now manages required namespaces and service accounts more consistently.
  * Bastion bootstrapping now includes the Kubernetes tooling required for deployment automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->