### PR TITLE
Make remove assisted-install ns and adding kubeuser sa idempotent

### DIFF
--- a/ansible/roles/mno-post-cluster-install/tasks/main.yml
+++ b/ansible/roles/mno-post-cluster-install/tasks/main.yml
@@ -73,8 +73,10 @@
   when: wait_until_cluster_stable | bool
 
 - name: Remove assisted-installer namespace
-  shell: |
-    KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc delete ns assisted-installer
+  environment:
+    KUBECONFIG: "{{ bastion_cluster_config_dir }}/kubeconfig"
+  ansible.builtin.shell: |
+    oc delete namespace assisted-installer --ignore-not-found=true
   when: remove_assisted_installer_namespace
 
 - name: Apply post-install labels to worker node(s)
@@ -125,8 +127,10 @@
   when: setup_performance_dashboards | bool
 
 - name: Add kube-burner sa
-  shell: |
-    KUBECONFIG={{ bastion_cluster_config_dir }}/kubeconfig oc create sa kubeburner
+  environment:
+    KUBECONFIG: "{{ bastion_cluster_config_dir }}/kubeconfig"
+  ansible.builtin.shell: |
+    oc create sa kubeburner --dry-run=client -o yaml | oc apply -f -
   when: setup_kube_burner_sa | default(true) | bool
 
 - name: Add cluster-admin role to kube-burner sa


### PR DESCRIPTION
This change switches two `mno-post-cluster-install` tasks to use `kubernetes.core.k8s` module instead of executing the tasks with shell commands. The shell commands cause the `mno-post-cluster-install` role to break upon reruns. I've encountered this issue when rerunning parts of the `mno-deploy` when attempting to resume from where it stopped/broke. 

This change has been tested and appears to work with idempotent behavior now.

I did face one small issue, though, where I had to help ansible use the Python interpreter that had the `kubernetes` module installed which was the venv interpreter I had sourced, ansible was not picking it up and instead was pointing at /usr/bin/python3:

```
TASK [roles/mno-post-cluster-install : Add kube-burner sa] **********************************************************************************************************************************
Friday 04 September 2026  15:24:32 +0000 (0:00:00.028)       0:00:29.102 ******                                                                                                              
fatal: [d24-h03-000-r650.rdu2.scalelab.redhat.com]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (kubernetes) on d24-h03-000-r650.rdu2.scalelab.redhat.
com's Python /usr/bin/python3. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python i
nterpreter, please consult the documentation on ansible_python_interpreter"}                                                                                                                 
```

I was a little surprised to see the [local ansible.cfg set to auto](https://github.com/redhat-performance/jetlag/blob/main/ansible.cfg#L2) and a venv sources but ansible still used the system-wide Python! This may be an issue with my own setup, so I'd if the reviewer could verify this part please.t

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated post-installation cluster configuration for assisted-installer namespace cleanup and kube-burner service account setup.
  * These operations continue to use the configured cluster credentials and preserve their existing conditions and outcomes.
  * No user-visible behavior changes are expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->